### PR TITLE
Transitional Inputs Cleanup — label corrections (Issue #31)

### DIFF
--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -1027,25 +1027,25 @@ This indicator updates automatically based on your layer selections.</string>
 
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_IHSlope_transitional">
-          <property name="text">
-           <string>Slope (%):</string>
-          </property>
-         </widget>
-        </item>
+    <item row="6" column="0">
+     <widget class="QLabel" name="label_IHSlope_transitional">
+      <property name="text">
+       <string>IH Slope (%):</string>
+      </property>
+     </widget>
+    </item>
         <item row="6" column="1">
          <widget class="QLineEdit" name="spin_IHSlope_transitional">
 
          </widget>
         </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_Tslope_transitional">
-          <property name="text">
-           <string>Transitional Slope (%):</string>
-          </property>
-         </widget>
-        </item>
+    <item row="7" column="0">
+     <widget class="QLabel" name="label_Tslope_transitional">
+      <property name="text">
+       <string>Slope (%):</string>
+      </property>
+     </widget>
+    </item>
         <item row="7" column="1">
          <widget class="QLineEdit" name="spin_Tslope_transitional">
 


### PR DESCRIPTION
## Summary

This PR updates the Transitional tab per the client’s request in Issue #31:

- Keep “IH Slope (%)” with its original label.
- Simplify “Transitional Slope (%)” to “Slope (%)” (applies to the selected surface).
- No functional logic changes; this is a labels/UX correction.

Outcome: labeling consistent with the client specification, clearer UI, and no superfluous information.

## Key Changes

- `qols/qols_panel_base.ui`
  - `label_IHSlope_transitional`: now shows “IH Slope (%)”.
  - `label_Tslope_transitional`: now shows “Slope (%)”.
- No changes in `qols/qols_dockwidget.py` or calculation scripts.

## Rationale

- Client requested that “IH Slope (%)” must remain and the transitional slope label should read just “Slope (%)”.
- Transitional UI should only show relevant information and avoid redundant naming.

## Technical Note — Is IH Slope used in this calculation?

- In the current script `scripts/TransitionalSurface_UTM.py`, the Transitional surface geometry is driven by `Tslope` (the field now labeled “Slope (%)”).