### PR TITLE
Take-Off Surface: use UI parameters + 1200/1800 final-width selector for Code 3/4 (Closes #33)

### DIFF
--- a/qols/icao_defaults.py
+++ b/qols/icao_defaults.py
@@ -1,0 +1,70 @@
+"""
+ICAO Annex 14 Vol 1 — Table 4-1 helper defaults.
+
+This module centralizes the mapping from Runway Classification + Aerodrome Code
+Number to default dimensions for specific surfaces where the standard provides
+clear values. It allows the UI/backend to stay thin and provides a pure-Python
+module that can be unit-tested without QGIS.
+
+Notes
+- Conical: Slope is always 5%. The "height" varies by classification/code.
+- Inner Horizontal: Height is 45 m across classifications; radius varies.
+- Values derived from Table 4-1 (as commonly reproduced). When in doubt or when
+  a specific jurisdiction deviates, the UI still allows manual override.
+"""
+from typing import Dict, Tuple
+
+RWY_NON_INSTRUMENT = "Non-instrument"
+RWY_NON_PRECISION = "Non-precision approach"
+RWY_CAT_I = "Precision Approach CAT I"
+RWY_CAT_II_III = "Precision Approach CAT II or III"
+
+
+def get_conical_defaults(rwy_classification: str, code: int) -> Dict[str, float]:
+    """Return default conical surface dimensions.
+
+    Returns a dict with:
+    - height_m: Conical height in meters
+    - radius_m: Conical radius (L) in meters
+    """
+    # Conical height per classification/code. Slope is always 5% (not returned).
+    height_map = {
+        RWY_NON_INSTRUMENT: {1: 35.0, 2: 55.0, 3: 75.0, 4: 100.0},
+        RWY_NON_PRECISION: {1: 60.0, 2: 60.0, 3: 75.0, 4: 100.0},
+        RWY_CAT_I: {1: 60.0, 2: 60.0, 3: 100.0, 4: 100.0},
+        RWY_CAT_II_III: {1: 60.0, 2: 60.0, 3: 100.0, 4: 100.0},
+    }
+    classification_map = height_map.get(rwy_classification, height_map[RWY_CAT_I])
+    height = classification_map.get(int(code), 100.0)
+    return {"height_m": height, "radius_m": 6000.0}
+
+
+def get_inner_horizontal_defaults(rwy_classification: str, code: int) -> Dict[str, float]:
+    """Return default inner horizontal surface dimensions.
+
+    Returns a dict with:
+    - height_m: Inner horizontal height in meters (45 m per table)
+    - radius_m: Inner horizontal radius (L) in meters
+    """
+    # Height is 45 m for all classifications in Table 4-1
+    height = 45.0
+    # Radius varies with classification and code
+    radius_map = {
+        RWY_NON_INSTRUMENT: {1: 2000.0, 2: 2500.0, 3: 4000.0, 4: 4000.0},
+        RWY_NON_PRECISION: {1: 3000.0, 2: 3000.0, 3: 4000.0, 4: 4000.0},
+        RWY_CAT_I: {1: 3500.0, 2: 3500.0, 3: 4000.0, 4: 4000.0},
+        RWY_CAT_II_III: {1: 3500.0, 2: 3500.0, 3: 4000.0, 4: 4000.0},
+    }
+    classification_map = radius_map.get(rwy_classification, radius_map[RWY_CAT_I])
+    radius = classification_map.get(int(code), 4000.0)
+    return {"height_m": height, "radius_m": radius}
+
+
+__all__ = [
+    "get_conical_defaults",
+    "get_inner_horizontal_defaults",
+    "RWY_NON_INSTRUMENT",
+    "RWY_NON_PRECISION",
+    "RWY_CAT_I",
+    "RWY_CAT_II_III",
+]

--- a/qols/qols_dockwidget.py
+++ b/qols/qols_dockwidget.py
@@ -132,7 +132,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 'spin_widthDep_takeoff', 'spin_maxWidthDep_takeoff',
                 'spin_CWYLength_takeoff', 'spin_Z0_takeoff',
                 'spin_widthApp_transitional', 'spin_Z0_transitional', 'spin_ZE_transitional',
-                'spin_ARPH_transitional', 'spin_IHSlope_transitional', 'spin_Tslope_transitional'
+                'spin_ARPH_transitional', 'spin_Tslope_transitional'
             ]
             
             default_values = {
@@ -220,7 +220,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 'spin_Z0_transitional': '2548.00',
                 'spin_ZE_transitional': '2546.50',
                 'spin_ARPH_transitional': '2548.00',
-                'spin_IHSlope_transitional': '33.30',
                 'spin_Tslope_transitional': '14.30'
             }
             for widget_name, default_value in transitional_defaults.items():
@@ -1734,7 +1733,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'Z0': float(self.spin_Z0_transitional.text() or "0"),              # QLineEdit
                     'ZE': float(self.spin_ZE_transitional.text() or "0"),              # QLineEdit
                     'ARPH': float(self.spin_ARPH_transitional.text() or "0"),          # QLineEdit
-                    'IHSlope': float(self.spin_IHSlope_transitional.text() or "0") / 100.0,  # QLineEdit, convert % to decimal
                     'Tslope': float(self.spin_Tslope_transitional.text() or "0") / 100.0,   # QLineEdit, convert % to decimal
                     's': s_value  # Special parameter for transitional runway direction
                 }

--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -412,26 +412,91 @@ This indicator updates automatically based on your layer selections.</string>
       </widget>
       
       <!-- CONICAL TAB -->
-      <widget class="QWidget" name="tab_conical">
+            <widget class="QWidget" name="tab_conical">
        <attribute name="title">
         <string>Conical</string>
        </attribute>
        <layout class="QFormLayout" name="formLayout_conical">
-        <item row="0" column="0">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_rwyClassification_conical">
+                    <property name="text">
+                     <string>RWY Classification:</string>
+                    </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QComboBox" name="combo_rwyClassification_conical">
+                    <property name="currentIndex">
+                     <number>2</number>
+                    </property>
+                    <item>
+                     <property name="text">
+                        <string>Non-instrument</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>Non-precision approach</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>Precision Approach CAT I</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>Precision Approach CAT II or III</string>
+                     </property>
+                    </item>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="label_code_conical">
+                    <property name="text">
+                     <string>Code:</string>
+                    </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QComboBox" name="spin_code_conical">
+                    <item>
+                     <property name="text">
+                        <string>1</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>2</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>3</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>4</string>
+                     </property>
+                    </item>
+                 </widget>
+                </item>
+                <item row="2" column="0">
          <widget class="QLabel" name="label_L_conical">
           <property name="text">
            <string>Distance L (m):</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+                <item row="2" column="1">
          <widget class="QLineEdit" name="spin_L_conical">
           <property name="text">
            <string>6000.00</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+                <item row="3" column="0">
          <widget class="QLabel" name="label_height_conical">
           <property name="text">
            <string>Height (m):</string>
@@ -439,7 +504,7 @@ This indicator updates automatically based on your layer selections.</string>
           
          </widget>
         </item>
-        <item row="1" column="1">
+                <item row="3" column="1">
          <widget class="QLineEdit" name="spin_height_conical">
           <property name="text">
            <string>60.00</string>
@@ -452,26 +517,91 @@ This indicator updates automatically based on your layer selections.</string>
       </widget>
       
       <!-- INNER HORIZONTAL TAB -->
-      <widget class="QWidget" name="tab_inner_horizontal">
+            <widget class="QWidget" name="tab_inner_horizontal">
        <attribute name="title">
         <string>Inner Horizontal</string>
        </attribute>
        <layout class="QFormLayout" name="formLayout_inner_horizontal">
-        <item row="0" column="0">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_rwyClassification_inner">
+                    <property name="text">
+                     <string>RWY Classification:</string>
+                    </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QComboBox" name="combo_rwyClassification_inner">
+                    <property name="currentIndex">
+                     <number>2</number>
+                    </property>
+                    <item>
+                     <property name="text">
+                        <string>Non-instrument</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>Non-precision approach</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>Precision Approach CAT I</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>Precision Approach CAT II or III</string>
+                     </property>
+                    </item>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="label_code_inner">
+                    <property name="text">
+                     <string>Code:</string>
+                    </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QComboBox" name="spin_code_inner">
+                    <item>
+                     <property name="text">
+                        <string>1</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>2</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>3</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                        <string>4</string>
+                     </property>
+                    </item>
+                 </widget>
+                </item>
+                <item row="2" column="0">
          <widget class="QLabel" name="label_L_inner">
           <property name="text">
            <string>Distance L (m):</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+                <item row="2" column="1">
          <widget class="QLineEdit" name="spin_L_inner">
           <property name="text">
            <string>4000.00</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+                <item row="3" column="0">
          <widget class="QLabel" name="label_height_inner">
           <property name="text">
            <string>Height (m):</string>
@@ -479,7 +609,7 @@ This indicator updates automatically based on your layer selections.</string>
           
          </widget>
         </item>
-        <item row="1" column="1">
+                <item row="3" column="1">
          <widget class="QLineEdit" name="spin_height_inner">
           <property name="text">
            <string>45.00</string>
@@ -488,7 +618,7 @@ This indicator updates automatically based on your layer selections.</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0" colspan="2">
+                <item row="4" column="0" colspan="2">
          <widget class="QLabel" name="label_info_inner">
           <property name="text">
            <string>📍 Inner Horizontal Surface: Racetrack-shaped 3D polygon

--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -1047,30 +1047,18 @@ This indicator updates automatically based on your layer selections.</string>
          </widget>
         </item>
     <item row="6" column="0">
-     <widget class="QLabel" name="label_IHSlope_transitional">
-      <property name="text">
-       <string>IH Slope (%):</string>
-      </property>
-     </widget>
-    </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="spin_IHSlope_transitional">
-
-         </widget>
-        </item>
-    <item row="7" column="0">
      <widget class="QLabel" name="label_Tslope_transitional">
       <property name="text">
        <string>Slope (%):</string>
       </property>
      </widget>
     </item>
-        <item row="7" column="1">
+        <item row="6" column="1">
          <widget class="QLineEdit" name="spin_Tslope_transitional">
 
          </widget>
         </item>
-        <item row="8" column="0" colspan="2">
+        <item row="7" column="0" colspan="2">
          <widget class="QPushButton" name="button_rotate_transitional">
           <property name="text">
            <string>🔄 Runway Direction: Normal</string>

--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -798,63 +798,63 @@ This indicator updates automatically based on your layer selections.</string>
           </item>
          </widget>
         </item>
-    <item row="1" column="0">
+    <item row="2" column="0">
          <widget class="QLabel" name="label_widthDep_takeoff">
           <property name="text">
            <string>Width Dep (m):</string>
           </property>
          </widget>
         </item>
-    <item row="1" column="1">
+    <item row="2" column="1">
          <widget class="QLineEdit" name="spin_widthDep_takeoff">
           <property name="text">
            <string>180.0</string>
           </property>
          </widget>
         </item>
-    <item row="2" column="0">
+    <item row="3" column="0">
          <widget class="QLabel" name="label_maxWidthDep_takeoff">
           <property name="text">
            <string>Max Width Dep (m):</string>
           </property>
          </widget>
         </item>
-    <item row="2" column="1">
+    <item row="3" column="1">
          <widget class="QLineEdit" name="spin_maxWidthDep_takeoff">
           <property name="text">
            <string>1800.0</string>
           </property>
          </widget>
         </item>
-    <item row="3" column="0">
+    <item row="4" column="0">
          <widget class="QLabel" name="label_CWYLength_takeoff">
           <property name="text">
            <string>CWY Length (m):</string>
           </property>
          </widget>
         </item>
-    <item row="3" column="1">
+    <item row="4" column="1">
          <widget class="QLineEdit" name="spin_CWYLength_takeoff">
           <property name="text">
            <string>0.0</string>
           </property>
          </widget>
         </item>
-    <item row="4" column="0">
+    <item row="5" column="0">
          <widget class="QLabel" name="label_Z0_takeoff">
           <property name="text">
           <string>Start Elevation (m):</string>
           </property>
          </widget>
         </item>
-    <item row="4" column="1">
+    <item row="5" column="1">
          <widget class="QLineEdit" name="spin_Z0_takeoff">
           <property name="text">
            <string>2548.0</string>
           </property>
          </widget>
         </item>
-    <item row="5" column="1">
+    <item row="1" column="1">
      <widget class="QCheckBox" name="check_finalWidth1800_takeoff">
       <property name="text">
        <string>Use 1800 m final width (Code 3/4)</string>

--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -854,6 +854,19 @@ This indicator updates automatically based on your layer selections.</string>
           </property>
          </widget>
         </item>
+    <item row="5" column="1">
+     <widget class="QCheckBox" name="check_finalWidth1800_takeoff">
+      <property name="text">
+       <string>Use 1800 m final width (Code 3/4)</string>
+      </property>
+      <property name="toolTip">
+       <string>For Code 3/4: Checked = 1800 m. Unchecked = 1200 m. You can still override the value manually.</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
     <item row="6" column="0">
      <widget class="QLabel" name="label_divergence_takeoff">
       <property name="text">

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -22,7 +22,6 @@ try:
     Z0 = globals().get('Z0', 2548)
     ZE = globals().get('ZE', 2546.5)
     ARPH = globals().get('ARPH', 2548)
-    IHSlope = globals().get('IHSlope', 33.3/100)
     L1 = globals().get('L1', 3000)
     L2 = globals().get('L2', 3600)
     LH = globals().get('LH', 8400)
@@ -46,7 +45,6 @@ except Exception as e:
     Z0 = 2548
     ZE = 2546.5
     ARPH = 2548
-    IHSlope = 33.3/100
     L1 = 3000
     L2 = 3600
     LH = 8400

--- a/qols/scripts/approach-surface-UTM.py
+++ b/qols/scripts/approach-surface-UTM.py
@@ -1,5 +1,5 @@
 '''
-Inner Approach Surface 4 CAT I
+Inner Approach Surface — supports RWY Classification and Code propagation to attributes
 Procedure to be used in Projected Coordinate System Only
 ENHANCED VERSION - Uses dynamic parameters from UI
 ROBUST VERSION - No fallbacks, explicit layer and feature selection required

--- a/qols/scripts/approach-surface-UTM.py
+++ b/qols/scripts/approach-surface-UTM.py
@@ -13,53 +13,57 @@ from qgis.gui import *
 from qgis.PyQt.QtCore import QVariant
 from math import *
 
-# Parameters - NOW COME FROM UI INSTEAD OF HARDCODED
-# These parameters will be injected by the plugin
+"""Parameter extraction
+Prefers pythonic, UI-aligned names with backward-compatible fallbacks to legacy keys.
+"""
 try:
-    # Try to get parameters from plugin namespace
-    code = globals().get('code', 4)
-    rwyClassification = globals().get('rwyClassification', 'Precision Approach CAT I')
-    widthApp = globals().get('widthApp', 280)
-    Z0 = globals().get('Z0', 21.7)
-    ZE = globals().get('ZE', 21.7)
-    ARPH = globals().get('ARPH', 29.3)
-    L1 = globals().get('L1', 3000)
-    L2 = globals().get('L2', 3600)
-    LH = globals().get('LH', 8400)
-    
-    # Direction parameter
-    s = globals().get('direction', 0)  # 0 for start to end, -1 for end to start
-    
+    # New pythonic names (preferred), with fallbacks to legacy keys
+    runway_code = globals().get('runway_code', globals().get('code', 4))
+    rwy_classification = globals().get('rwy_classification', globals().get('rwyClassification', 'Precision Approach CAT I'))
+    approach_width_m = globals().get('approach_width_m', globals().get('widthApp', 280))
+    start_elevation_m = globals().get('start_elevation_m', globals().get('Z0', 21.7))
+    end_elevation_m = globals().get('end_elevation_m', globals().get('ZE', 21.7))
+    arp_elevation_m = globals().get('arp_elevation_m', globals().get('ARPH', 29.3))
+    first_section_length_m = globals().get('first_section_length_m', globals().get('L1', 3000))
+    second_section_length_m = globals().get('second_section_length_m', globals().get('L2', 3600))
+    horizontal_section_length_m = globals().get('horizontal_section_length_m', globals().get('LH', 8400))
+
+    # Direction parameter: 0 for start→end, -1 for end→start
+    direction = globals().get('direction', globals().get('s', 0))
+
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
     use_selected_feature = globals().get('use_selected_feature', True)
-    
-    print(f"QOLS: Using parameters - code: {code}, rwyClassification: {rwyClassification}, widthApp: {widthApp}, Z0: {Z0}, ZE: {ZE}")
-    print(f"QOLS: Direction parameter s: {s}, Use selected: {use_selected_feature}")
-    
+
+    print(
+        f"QOLS: Using parameters - runway_code: {runway_code}, rwy_classification: {rwy_classification}, "
+        f"approach_width_m: {approach_width_m}, start_elevation_m: {start_elevation_m}, end_elevation_m: {end_elevation_m}"
+    )
+    print(f"QOLS: Direction: {direction}, Use selected features: {use_selected_feature}")
+
 except Exception as e:
     print(f"QOLS: Error getting parameters, using defaults: {e}")
-    # Fallback to defaults if parameters not provided
-    code = 4
-    rwyClassification = 'Precision Approach CAT I'
-    widthApp = 280
-    Z0 = 21.7
-    ZE = 21.7
-    ARPH = 29.3
-    L1 = 3000
-    L2 = 3600
-    LH = 8400
-    s = 0  # This will be overridden by the direction parameter below
+    # Sensible defaults
+    runway_code = 4
+    rwy_classification = 'Precision Approach CAT I'
+    approach_width_m = 280
+    start_elevation_m = 21.7
+    end_elevation_m = 21.7
+    arp_elevation_m = 29.3
+    first_section_length_m = 3000
+    second_section_length_m = 3600
+    horizontal_section_length_m = 8400
+    direction = 0
     runway_layer = None
     threshold_layer = None
     use_selected_feature = True
 
 # Calculate derived parameters
-ZIH = 45 + ARPH
+zih_elevation_m = 45 + arp_elevation_m
 
-print(f"QOLS: Final values - s: {s}, ZIH: {ZIH}")
-print(f"QOLS: Direction interpretation - s={s} means {'End to Start' if s == -1 else 'Start to End'}")
+print(f"QOLS: Final derived - zih_elevation_m: {zih_elevation_m}")
+print(f"QOLS: Direction interpretation - direction={direction} means {'End to Start' if direction == -1 else 'Start to End'}")
 
 map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
@@ -84,10 +88,9 @@ try:
         print(f"QOLS: Processing {len(selection)} runway features")
         rwy_geom = selection[0].geometry()
         rwy_length = rwy_geom.length()
-        rwy_slope = (Z0-ZE)/rwy_length if rwy_length > 0 else 0
-        
+        rwy_slope = (start_elevation_m - end_elevation_m) / rwy_length if rwy_length > 0 else 0
         print(f"QOLS: Runway length: {rwy_length}, slope: {rwy_slope}")
-        
+
     else:
         # No fallback - require explicit runway layer selection
         raise Exception("No runway layer provided. Please select a runway layer from the UI.")
@@ -97,9 +100,9 @@ except Exception as e:
     iface.messageBar().pushMessage("QOLS Error", f"Runway layer error: {str(e)}", level=Qgis.Critical)
     raise
 
-# Calculate ZIHs
-ZIHs = ((Z0-((Z0-ZE)/rwy_length)*1800))
-print(f"QOLS: ZIHs calculated: {ZIHs}")
+# Calculate ZIH at start (legacy name ZIHs)
+zih_at_start_m = (start_elevation_m - ((start_elevation_m - end_elevation_m) / rwy_length) * 1800)
+print(f"QOLS: ZIH at start (m): {zih_at_start_m}")
 
 # Get the azimuth of the line - SIMPLIFIED LOGIC
 for feat in selection:
@@ -110,33 +113,33 @@ for feat in selection:
     # Direction change is handled by azimuth rotation only
     start_point = QgsPoint(geom[0])   # Always first point
     end_point = QgsPoint(geom[-1])    # Always last point
-    angle0 = start_point.azimuth(end_point)
+    base_azimuth_deg = start_point.azimuth(end_point)
     
     print(f"QOLS: Using consistent points regardless of direction")
     print(f"QOLS: start_point = geom[0] (first point)")
     print(f"QOLS: end_point = geom[-1] (last point)")
     print(f"QOLS: Start point: {start_point.x()}, {start_point.y()}")
     print(f"QOLS: End point: {end_point.x()}, {end_point.y()}")
-    print(f"QOLS: Base azimuth (angle0): {angle0}")
+    print(f"QOLS: Base azimuth (deg): {base_azimuth_deg}")
 
 # Initial true azimuth data - FIXED LOGIC FOR PROPER DIRECTION CHANGE
 # Always use the same points but change the azimuth by exactly 180 degrees
-if s == -1:
+if direction == -1:
     # For reverse direction, use the opposite direction (180 degrees from normal)
-    azimuth = angle0 + 180
+    azimuth = base_azimuth_deg + 180
     if azimuth >= 360:
         azimuth -= 360
-    print(f"QOLS: REVERSE direction - using angle0 + 180 = {angle0} + 180 = {azimuth}")
+    print(f"QOLS: REVERSE direction - using base_azimuth + 180 = {base_azimuth_deg} + 180 = {azimuth}")
 else:
     # For normal direction, use the forward azimuth as-is
-    azimuth = angle0
-    print(f"QOLS: NORMAL direction - using angle0 = {azimuth}")
+    azimuth = base_azimuth_deg
+    print(f"QOLS: NORMAL direction - using base_azimuth = {azimuth}")
 
-print(f"QOLS: Using direction s={s}")
-print(f"QOLS: Base azimuth (angle0): {angle0}")
+print(f"QOLS: Using direction={direction}")
+print(f"QOLS: Base azimuth: {base_azimuth_deg}")
 print(f"QOLS: Final azimuth: {azimuth}")
 print(f"QOLS: Expected difference between directions: 180°")
-print(f"QOLS: Direction interpretation - s={s} means {'End to Start' if s == -1 else 'Start to End'}")
+print(f"QOLS: Direction interpretation - direction={direction} means {'End to Start' if direction == -1 else 'Start to End'}")
 
 # ENHANCED THRESHOLD SELECTION - Use threshold layer from UI
 try:
@@ -178,94 +181,94 @@ else:
     raise Exception("No threshold features found")
 
 new_geom = QgsPoint(threshold_geom)
-new_geom.addZValue(Z0)
+new_geom.addZValue(start_elevation_m)
 
 print(f"QOLS: Threshold point: {new_geom.x()}, {new_geom.y()}, {new_geom.z()}")
 print(f"QOLS: Direction change handled by azimuth rotation (180°), not threshold position")
 
-list_pts = []
+construction_points = []
 
 # Origin 
 pt_0 = new_geom
     
 # Distance prior from THR (60 m)
 pt_01 = new_geom.project(60, azimuth)
-pt_01.addZValue(Z0)
-pt_01AL = pt_01.project(widthApp/2, azimuth+90)
-pt_01AR = pt_01.project(widthApp/2, azimuth-90)
+pt_01.addZValue(start_elevation_m)
+pt_01AL = pt_01.project(approach_width_m/2, azimuth+90)
+pt_01AR = pt_01.project(approach_width_m/2, azimuth-90)
 
 # First Section Points 
 pt_05 = pt_01.project(3000, azimuth)
-pt_05.setZ(Z0 + 3000*0.02)
-pt_05L = pt_05.project(widthApp/2 + (3000*.15), azimuth+90)
-pt_05R = pt_05.project(widthApp/2 + (3000*.15), azimuth-90)
+pt_05.setZ(start_elevation_m + 3000*0.02)
+pt_05L = pt_05.project(approach_width_m/2 + (3000*.15), azimuth+90)
+pt_05R = pt_05.project(approach_width_m/2 + (3000*.15), azimuth-90)
 
-list_pts.extend((pt_0, pt_01, pt_01AL, pt_01AR, pt_05, pt_05L, pt_05R))
+construction_points.extend((pt_0, pt_01, pt_01AL, pt_01AR, pt_05, pt_05L, pt_05R))
 
 # Second Section Points 
 pt_06 = pt_01.project(6600, azimuth)
-pt_06.setZ(Z0 + 3000*0.02 + 3600*0.025)
-pt_06L = pt_06.project(widthApp/2 + (6600*.15), azimuth+90)
-pt_06R = pt_06.project(widthApp/2 + (6600*.15), azimuth-90)
+pt_06.setZ(start_elevation_m + 3000*0.02 + 3600*0.025)
+pt_06L = pt_06.project(approach_width_m/2 + (6600*.15), azimuth+90)
+pt_06R = pt_06.project(approach_width_m/2 + (6600*.15), azimuth-90)
 
 # Horizontal Section Points 
 pt_07 = pt_01.project(15000, azimuth)
-pt_07.setZ(Z0 + 3000*0.02 + 3600*0.025)
-pt_07L = pt_07.project(widthApp/2 + (15000*.15), azimuth+90)
-pt_07R = pt_07.project(widthApp/2 + (15000*.15), azimuth-90)
+pt_07.setZ(start_elevation_m + 3000*0.02 + 3600*0.025)
+pt_07L = pt_07.project(approach_width_m/2 + (15000*.15), azimuth+90)
+pt_07R = pt_07.project(approach_width_m/2 + (15000*.15), azimuth-90)
 
-list_pts.extend((pt_06, pt_06L, pt_06R, pt_07, pt_07L, pt_07R))
+construction_points.extend((pt_06, pt_06L, pt_06R, pt_07, pt_07L, pt_07R))
 
-print(f"QOLS: Generated {len(list_pts)} construction points")
+print(f"QOLS: Generated {len(construction_points)} construction points")
 
 # Creation of the Approach Surfaces
 # Create memory layer
-layer_name = f"RWY_ApproachSurface_{rwyClassification}_Code{code}"
-v_layer = QgsVectorLayer("PolygonZ?crs="+map_srid, layer_name, "memory")
-IDField = QgsField('ID', QVariant.String)
-NameField = QgsField('SurfaceName', QVariant.String)
-TypeField = QgsField('SurfaceType', QVariant.String)
-CodeField = QgsField('Code', QVariant.Int)
-v_layer.dataProvider().addAttributes([IDField, NameField, TypeField, CodeField])
-v_layer.updateFields()
+layer_name = f"RWY_ApproachSurface_{rwy_classification}_Code{runway_code}"
+approach_layer = QgsVectorLayer("PolygonZ?crs="+map_srid, layer_name, "memory")
+id_field = QgsField('ID', QVariant.String)
+name_field = QgsField('SurfaceName', QVariant.String)
+type_field = QgsField('SurfaceType', QVariant.String)
+code_field = QgsField('Code', QVariant.Int)
+approach_layer.dataProvider().addAttributes([id_field, name_field, type_field, code_field])
+approach_layer.updateFields()
 
 # Approach - First Section
-SurfaceArea = [pt_05R, pt_05L, pt_01AL, pt_01AR]
-pr = v_layer.dataProvider()
-seg = QgsFeature()
-seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([6, 'Approach First Section', rwyClassification, code])
-pr.addFeatures([seg])
+surface_area = [pt_05R, pt_05L, pt_01AL, pt_01AR]
+provider = approach_layer.dataProvider()
+feature = QgsFeature()
+feature.setGeometry(QgsPolygon(QgsLineString(surface_area), rings=[]))
+feature.setAttributes([6, 'Approach First Section', rwy_classification, runway_code])
+provider.addFeatures([feature])
 
 # Approach - Second Section
-SurfaceArea = [pt_06R, pt_06L, pt_05L, pt_05R]
-pr = v_layer.dataProvider()
-seg = QgsFeature()
-seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([7, 'Approach Second Section', rwyClassification, code])
-pr.addFeatures([seg])
+surface_area = [pt_06R, pt_06L, pt_05L, pt_05R]
+provider = approach_layer.dataProvider()
+feature = QgsFeature()
+feature.setGeometry(QgsPolygon(QgsLineString(surface_area), rings=[]))
+feature.setAttributes([7, 'Approach Second Section', rwy_classification, runway_code])
+provider.addFeatures([feature])
 
 # Approach - Horizontal Section
-SurfaceArea = [pt_07R, pt_07L, pt_06L, pt_06R]
-pr = v_layer.dataProvider()
-seg = QgsFeature()
-seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([8, 'Approach Horizontal Section', rwyClassification, code])
-pr.addFeatures([seg])
+surface_area = [pt_07R, pt_07L, pt_06L, pt_06R]
+provider = approach_layer.dataProvider()
+feature = QgsFeature()
+feature.setGeometry(QgsPolygon(QgsLineString(surface_area), rings=[]))
+feature.setAttributes([8, 'Approach Horizontal Section', rwy_classification, runway_code])
+provider.addFeatures([feature])
 
 # Load PolygonZ Layer to map canvas 
-QgsProject.instance().addMapLayers([v_layer])
+QgsProject.instance().addMapLayers([approach_layer])
 
 # Change style of layer 
-v_layer.renderer().symbol().setColor(QColor("green"))
-v_layer.renderer().symbol().setOpacity(0.4)
-v_layer.triggerRepaint()
+approach_layer.renderer().symbol().setColor(QColor("green"))
+approach_layer.renderer().symbol().setOpacity(0.4)
+approach_layer.triggerRepaint()
 
 # Zoom to layer
-v_layer.selectAll()
+approach_layer.selectAll()
 canvas = iface.mapCanvas()
-canvas.zoomToSelected(v_layer)
-v_layer.removeSelection()
+canvas.zoomToSelected(approach_layer)
+approach_layer.removeSelection()
 
 # Clean up selections only if they weren't originally selected
 # This prevents losing user selections for subsequent calculations
@@ -288,10 +291,10 @@ canvas.zoomScale(sc)
 
 print(f"QOLS: Approach surface calculation completed successfully")
 print(f"QOLS: Created layer: {layer_name}")
-print(f"QOLS: Surface type: {rwyClassification}, Code: {code}, Width: {widthApp}m")
+print(f"QOLS: Surface type: {rwy_classification}, Code: {runway_code}, Width: {approach_width_m}m")
 
 # Success message
-iface.messageBar().pushMessage("QOLS Success", f"Approach Surface ({rwyClassification}, Code {code}) calculated successfully", level=Qgis.Success)
+iface.messageBar().pushMessage("QOLS Success", f"Approach Surface ({rwy_classification}, Code {runway_code}) calculated successfully", level=Qgis.Success)
 
 # Clean up globals
 set(globals().keys()).difference(myglobals)

--- a/qols/scripts/conical.py
+++ b/qols/scripts/conical.py
@@ -21,6 +21,8 @@ try:
     # Conical surface parameters from UI
     L = globals().get('radius', 6000)  # Distance L / Radius from UI
     height = globals().get('height', 60.0)  # Height for 3D polygon (new parameter)
+    runway_code = globals().get('code', 4)
+    rwy_classification = globals().get('rwyClassification', 'Precision Approach CAT I')
     
     # Direction parameter
     s = globals().get('direction', 0)  # 0 for start to end, -1 for end to start
@@ -30,7 +32,7 @@ try:
     threshold_layer = globals().get('threshold_layer', None)
     use_selected_feature = globals().get('use_selected_feature', True)
     
-    print(f"Conical: Using parameters - radius: {L}m, height: {height}m")
+    print(f"Conical: Using parameters - radius: {L}m, height: {height}m, code: {runway_code}, class: {rwy_classification}")
     print(f"Conical: Direction parameter s: {s}, Use selected: {use_selected_feature}")
     
 except Exception as e:
@@ -42,6 +44,8 @@ except Exception as e:
     runway_layer = None
     threshold_layer = None
     use_selected_feature = True
+    runway_code = 4
+    rwy_classification = 'Precision Approach CAT I'
 
 print(f"Conical: Final values - radius: {L}m, height: {height}m, direction: {s}")
 print(f"Conical: Direction interpretation - s={s} means {'End to Start' if s == -1 else 'Start to End'}")
@@ -171,7 +175,8 @@ print(f"Conical: x4={x4}, x5={x5}, x6={x6}")
 print(f"Conical: Using original coordinate calculation methods - trigonometry + transformations")
 
 # Create memory layer for 3D polygon (PolygonZ) instead of separate LineStrings
-v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", "Conical Surface", "memory")
+layer_name = f"Conical_{rwy_classification}_Code{runway_code}"
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", layer_name, "memory")
 v_layer_provider = v_layer.dataProvider()
 
 # Add attributes for the polygon
@@ -183,7 +188,9 @@ v_layer_provider.addAttributes([
     QgsField("runway_start_y", QVariant.Double),
     QgsField("runway_end_x", QVariant.Double),
     QgsField("runway_end_y", QVariant.Double),
-    QgsField("azimuth", QVariant.Double)
+    QgsField("azimuth", QVariant.Double),
+    QgsField("RWYType", QVariant.String),
+    QgsField("Code", QVariant.Int)
 ])
 v_layer.updateFields()
 
@@ -326,7 +333,9 @@ feature.setAttributes([
     start_point.y(),
     end_point.x(),
     end_point.y(),
-    angle0
+    angle0,
+    rwy_classification,
+    int(runway_code)
 ])
 
 # Add feature to layer

--- a/qols/scripts/inner-horizontal-racetrack.py
+++ b/qols/scripts/inner-horizontal-racetrack.py
@@ -17,6 +17,8 @@ try:
     # Inner horizontal surface parameters from UI
     L = globals().get('radius', 4000)  # Distance L / Radius from UI
     height = globals().get('height', 45.0)  # Height for 3D polygon (new parameter)
+    runway_code = globals().get('code', 4)
+    rwy_classification = globals().get('rwyClassification', 'Precision Approach CAT I')
     
     # Direction parameter
     s = globals().get('direction', 0)  # 0 for start to end, -1 for end to start
@@ -26,7 +28,7 @@ try:
     threshold_layer = globals().get('threshold_layer', None)
     use_selected_feature = globals().get('use_selected_feature', True)
     
-    print(f"InnerHorizontal: Using parameters - radius: {L}m, height: {height}m")
+    print(f"InnerHorizontal: Using parameters - radius: {L}m, height: {height}m, code: {runway_code}, class: {rwy_classification}")
     print(f"InnerHorizontal: Direction parameter s: {s}, Use selected: {use_selected_feature}")
     
 except Exception as e:
@@ -38,6 +40,8 @@ except Exception as e:
     runway_layer = None
     threshold_layer = None
     use_selected_feature = True
+    runway_code = 4
+    rwy_classification = 'Precision Approach CAT I'
 
 print(f"InnerHorizontal: Final values - radius: {L}m, height: {height}m, direction: {s}")
 
@@ -78,7 +82,8 @@ except Exception as e:
     raise
 
 # Create memory layer for 3D polygon (PolygonZ)
-v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", "Inner Horizontal Surface", "memory")
+layer_name = f"InnerHorizontal_{rwy_classification}_Code{runway_code}"
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", layer_name, "memory")
 v_layer_provider = v_layer.dataProvider()
 
 # Add attributes for the polygon
@@ -90,7 +95,9 @@ v_layer_provider.addAttributes([
     QgsField("runway_start_y", QVariant.Double),
     QgsField("runway_end_x", QVariant.Double),
     QgsField("runway_end_y", QVariant.Double),
-    QgsField("azimuth", QVariant.Double)
+    QgsField("azimuth", QVariant.Double),
+    QgsField("RWYType", QVariant.String),
+    QgsField("Code", QVariant.Int)
 ])
 v_layer.updateFields()
 
@@ -316,7 +323,9 @@ for feat in selection:
         start_point.y(),
         end_point.x(),
         end_point.y(),
-        azimuth
+        azimuth,
+        rwy_classification,
+        int(runway_code)
     ])
     
     # Add feature to layer


### PR DESCRIPTION
## Summary

- Replaced hardcoded values in the Take-Off surface with the parameters exposed in the UI: Divergence (%), Start Distance (m), Surface Length (m), Slope (%), Width Dep (m), Max Width Dep (m), CWY Length (m), and Start Elevation (Z0).
- Added a checkbox for runway Code 3/4 to switch the default final width between 1800 m (checked, default) and 1200 m (unchecked), while still allowing manual overrides.
- Aligned direction handling with other surfaces via a `direction` flag (s = 0/-1) that rotates azimuth by 180° when needed.

## Files changed

- `qols/scripts/take-off-surface_UTM.py`

  - Now consumes UI-provided parameters:
    - `divergencePct` (percentage), `startDistance` (meters), `surfaceLength` (meters), `slopePct` (percentage), plus existing fields `widthDep`, `maxWidthDep`, `CWYLength`, `Z0`.
  - Converts percentages to ratios for geometry: `divergence_ratio`, `slope_ratio`.
  - Start distance is computed as `dD = max(startDistance, CWYLength)` instead of a fixed 60 m.
  - Distance to reach final width uses `divergence_ratio` rather than a fixed 12.5%.
  - End of surface location and vertical growth use `surfaceLength` and `slope_ratio` (not a fixed 15000 m / 2%).
  - Uses `direction` (s = 0/-1) to flip azimuth by 180° for reverse direction, consistent with the Approach script.
  - Added console logs to trace parameters used at runtime.
  - Note: `ZE` remains as in previous logic. If dynamic derivation is desired, we can address it in a follow-up.

- `qols/qols_panel_base.ui`

  - Added `check_finalWidth1800_takeoff` to the Take-Off tab.
  - Label: “Use 1800 m final width (Code 3/4)”. Default checked. Visible only when Code is 3 or 4.

- `qols/qols_dockwidget.py`
  - Wired the new checkbox:
    - Visibility toggles for Code 3/4 only.
    - When checked: sets default Max Width Dep to 1800 m; when unchecked: 1200 m.
    - The Max Width Dep field remains editable; user overrides are preserved.
    - Updates on Code change and on checkbox toggle.
  - Passes `direction` to the Take-Off script, aligning with the Approach path.
  - Added debug logging for Take-Off parameter collection and checkbox behavior.

## UX behavior

- Code 3/4:
  - Checkbox is visible. Checked (default) applies 1800 m to “Max Width Dep”; unchecked applies 1200 m.
  - The user can still type any value; the calculation uses whatever is in the field at execution time.
- Code 1/2:
  - Checkbox is hidden. Table/user values apply as usual.

## Requirements coverage (Issue #33)

- Use table/UI values in calculations (divergence, start distance, length, slope): Done.
- Checkbox for Code 3/4 to toggle final width 1200/1800 (default 1800): Done.
- Keep user override capability for final width: Done.

## Considerations

- Backward compatibility: Default remains 1800 m for Code 3/4 (checkbox checked), preserving previous behavior.
- `ZE` is currently maintained from prior logic. If it should be derived from the runway profile or selection, we can propose a small follow-up.
- Extra logs were added to simplify validation in client environments.

## Risks

- If `divergencePct = 0`, the distance to reach maximum width becomes 0 to avoid division by zero. Geometry remains consistent but there will be no lateral expansion.

---

Closes #33
