### PR TITLE
Issues 46, 47, 48, 49, 51, 52

### DIFF
--- a/qols/approach_defaults.py
+++ b/qols/approach_defaults.py
@@ -1,0 +1,145 @@
+"""Approach surface ICAO Annex 14 Table 4-1 defaults.
+
+This module provides default values for the APPROACH surface parameters based on
+simplified interpretation of the user-provided table images and clarification:
+
+Classification groupings (user clarification):
+- Non-instrument: 4 code numbers (1..4)
+- Non-precision approach: codes (1-2 grouped), 3, 4
+- Precision (CAT I) and Precision (CAT II or III): last groups; widths treated
+  uniformly (codes 1-2 grouped @ 140 m, codes 3-4 @ 280 m). CAT II/III only
+  valid for codes 3-4 in the table; we still guard for 1-2.
+
+Rows interpreted:
+1. Length of inner edge (Approach width at threshold)
+2. Distance from threshold (threshold offset) -> Only Non-instrument Code 1 = 30 m, all others 60 m.
+3. Divergence (each side): Non-instrument = 10%; all other classifications = 15%.
+4. First section length (L1)
+5. First section slope (percent) -> converted to decimal here.
+6. Second section length (L2) - Only for higher performance runways (see mapping).
+7. Second section slope (percent) -> decimal.
+8. Horizontal section length (LH) -> Provided where total length reaches 15000 m (L1+L2+LH = 15000). If L2 absent -> no horizontal section (LH=0).
+
+Assumptions / Ambiguities resolved pragmatically:
+- Where table shows combined columns (e.g. codes 1-2), the same value used for both.
+- If second section not present in table -> L2 = 0; LH = 0.
+- For codes with L2 provided and total length known (15 000 m), LH derived = 15000 - L1 - L2.
+- For precision categories codes 3 & 4: adopt L1=3000, L2=3600, LH=8400, slopes 2% (first), 2.5% or 2%?  Using commonly referenced values: first=2% (code ≥3), second=2.5% for CAT I code 3 then 2% others ambiguous. Chosen consistent values: first section slope: CAT I (codes1-2)=2.5%, CAT I (3-4)=2%; CAT II/III (3-4)=2%. Second section slope: 2.5% for CAT I code3? Ambiguity simplified to 2.5% for CAT I code3 only else 2.0%.
+
+NOTE: These can be refined later if higher-resolution table data supplied.
+"""
+from typing import Dict
+
+# Classification constants (reuse strings from existing icao_defaults for consistency)
+RWY_NON_INSTRUMENT = "Non-instrument"
+RWY_NON_PRECISION = "Non-precision approach"
+RWY_CAT_I = "Precision Approach CAT I"
+RWY_CAT_II_III = "Precision Approach CAT II or III"
+
+TOTAL_LENGTH_TARGET = 15000.0  # For cases with second + horizontal sections
+
+# Width (inner edge length) mapping
+_WIDTH_MAP = {
+    RWY_NON_INSTRUMENT: {1: 60.0, 2: 80.0, 3: 150.0, 4: 150.0},
+    RWY_NON_PRECISION: {1: 140.0, 2: 140.0, 3: 280.0, 4: 280.0},
+    RWY_CAT_I: {1: 140.0, 2: 140.0, 3: 280.0, 4: 280.0},
+    RWY_CAT_II_III: {1: 140.0, 2: 140.0, 3: 280.0, 4: 280.0},  # Codes 1-2 rarely applicable but guarded
+}
+
+# Threshold offset mapping (distance from threshold)
+_THRESHOLD_OFFSET_MAP = {
+    RWY_NON_INSTRUMENT: {1: 30.0, 2: 60.0, 3: 60.0, 4: 60.0},
+    RWY_NON_PRECISION: {1: 60.0, 2: 60.0, 3: 60.0, 4: 60.0},
+    RWY_CAT_I: {1: 60.0, 2: 60.0, 3: 60.0, 4: 60.0},
+    RWY_CAT_II_III: {1: 60.0, 2: 60.0, 3: 60.0, 4: 60.0},
+}
+
+# Divergence (each side) as ratio (table gives % per side)
+_DIVERGENCE_MAP = {
+    RWY_NON_INSTRUMENT: {1: 0.10, 2: 0.10, 3: 0.10, 4: 0.10},
+    RWY_NON_PRECISION: {1: 0.15, 2: 0.15, 3: 0.15, 4: 0.15},
+    RWY_CAT_I: {1: 0.15, 2: 0.15, 3: 0.15, 4: 0.15},
+    RWY_CAT_II_III: {1: 0.15, 2: 0.15, 3: 0.15, 4: 0.15},
+}
+
+# First section length (L1)
+_L1_MAP = {
+    RWY_NON_INSTRUMENT: {1: 1600.0, 2: 2500.0, 3: 3000.0, 4: 3000.0},
+    RWY_NON_PRECISION: {1: 2500.0, 2: 2500.0, 3: 3000.0, 4: 3000.0},
+    RWY_CAT_I: {1: 3000.0, 2: 3000.0, 3: 3000.0, 4: 3000.0},
+    RWY_CAT_II_III: {1: 3000.0, 2: 3000.0, 3: 3000.0, 4: 3000.0},
+}
+
+# First section slope (decimal)
+_SLOPE1_MAP = {
+    RWY_NON_INSTRUMENT: {1: 0.05, 2: 0.04, 3: 0.0333, 4: 0.025},
+    RWY_NON_PRECISION: {1: 0.0333, 2: 0.0333, 3: 0.02, 4: 0.02},
+    RWY_CAT_I: {1: 0.025, 2: 0.025, 3: 0.02, 4: 0.02},
+    RWY_CAT_II_III: {1: 0.025, 2: 0.025, 3: 0.02, 4: 0.02},  # Codes 1-2 guarded
+}
+
+# Second section length (L2) only for higher categories / codes (otherwise 0)
+_L2_MAP = {
+    RWY_NON_INSTRUMENT: {1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0},
+    RWY_NON_PRECISION: {1: 0.0, 2: 0.0, 3: 3600.0, 4: 3600.0},
+    RWY_CAT_I: {1: 0.0, 2: 0.0, 3: 3600.0, 4: 3600.0},
+    RWY_CAT_II_III: {1: 0.0, 2: 0.0, 3: 3600.0, 4: 3600.0},
+}
+
+# Second section slope (decimal)
+_SLOPE2_MAP = {
+    RWY_NON_INSTRUMENT: {1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0},
+    RWY_NON_PRECISION: {1: 0.0, 2: 0.0, 3: 0.025, 4: 0.025},
+    RWY_CAT_I: {1: 0.0, 2: 0.0, 3: 0.025, 4: 0.02},  # Ambiguity resolved: code4 lowered to 2%
+    RWY_CAT_II_III: {1: 0.0, 2: 0.0, 3: 0.02, 4: 0.02},
+}
+
+
+def get_approach_defaults(rwy_classification: str, code: int) -> Dict[str, float]:
+    """Return defaults for APPROACH surface for given classification & code.
+
+    Returns dict:
+      width_m
+      threshold_offset_m
+      divergence_ratio
+      L1_m
+      first_section_slope
+      L2_m
+      second_section_slope
+      LH_m
+    """
+    code = int(code)
+    rwy = rwy_classification
+
+    width = _WIDTH_MAP.get(rwy, _WIDTH_MAP[RWY_CAT_I]).get(code, 280.0)
+    thr_off = _THRESHOLD_OFFSET_MAP.get(rwy, _THRESHOLD_OFFSET_MAP[RWY_CAT_I]).get(code, 60.0)
+    divergence = _DIVERGENCE_MAP.get(rwy, _DIVERGENCE_MAP[RWY_CAT_I]).get(code, 0.15)
+    l1 = _L1_MAP.get(rwy, _L1_MAP[RWY_CAT_I]).get(code, 3000.0)
+    slope1 = _SLOPE1_MAP.get(rwy, _SLOPE1_MAP[RWY_CAT_I]).get(code, 0.02)
+    l2 = _L2_MAP.get(rwy, _L2_MAP[RWY_CAT_I]).get(code, 0.0)
+    slope2 = _SLOPE2_MAP.get(rwy, _SLOPE2_MAP[RWY_CAT_I]).get(code, 0.0)
+
+    # Horizontal section only if L2 > 0 and table implies total length 15000
+    if l2 > 0:
+        lh = max(0.0, TOTAL_LENGTH_TARGET - l1 - l2)
+    else:
+        lh = 0.0
+
+    return {
+        'width_m': width,
+        'threshold_offset_m': thr_off,
+        'divergence_ratio': divergence,
+        'L1_m': l1,
+        'first_section_slope': slope1,
+        'L2_m': l2,
+        'second_section_slope': slope2,
+        'LH_m': lh,
+    }
+
+__all__ = [
+    'get_approach_defaults',
+    'RWY_NON_INSTRUMENT',
+    'RWY_NON_PRECISION',
+    'RWY_CAT_I',
+    'RWY_CAT_II_III'
+]

--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -127,6 +127,18 @@
             </property>
            </widget>
           </item>
+         <!-- Per-layer live status label for Runway (Issue #52) -->
+         <item>
+          <widget class="QLabel" name="runwaySelectionStatusLabel">
+           <property name="text">
+            <string>⚠️ No selection</string>
+           </property>
+           <property name="styleSheet">
+            <string>QLabel { color: #b71c1c; font-weight: bold; }</string>
+           </property>
+           <property name="minimumHeight"><number>18</number></property>
+          </widget>
+         </item>
          </layout>
         </widget>
        </item>
@@ -176,32 +188,23 @@
             </property>
            </widget>
           </item>
+         <!-- Per-layer live status label for Threshold (Issue #52) -->
+         <item>
+          <widget class="QLabel" name="thresholdSelectionStatusLabel">
+           <property name="text">
+            <string>⚠️ No selection</string>
+           </property>
+           <property name="styleSheet">
+            <string>QLabel { color: #b71c1c; font-weight: bold; }</string>
+           </property>
+           <property name="minimumHeight"><number>18</number></property>
+          </widget>
+         </item>
          </layout>
         </widget>
        </item>
        
-       <!-- ENHANCED SELECTION STATUS -->
-       <item>
-        <widget class="QLabel" name="selectionInfoLabel">
-         <property name="text">
-          <string>📌 Runway: ⚠️ All (1) | Threshold: ✅ Selected (1 of 2)</string>
-         </property>
-         
-         <property name="minimumHeight">
-          <number>28</number>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="toolTip">
-          <string>📊 Live Selection Status:
-⚠️ All = Using all features from layer (caution - may include unwanted features)
-✅ Selected = Using only selected features (recommended for precise calculations)
-
-This indicator updates automatically based on your layer selections.</string>
-         </property>
-        </widget>
-       </item>
+   <!-- Removed combined selection status label (replaced by per-layer labels in frames) -->
       </layout>
      </widget>
     </item>
@@ -368,7 +371,7 @@ This indicator updates automatically based on your layer selections.</string>
         <item row="6" column="0">
          <widget class="QLabel" name="label_L1">
           <property name="text">
-           <string>L1 (m):</string>
+          <string>First section (m)</string>
           </property>
           
          </widget>
@@ -383,7 +386,7 @@ This indicator updates automatically based on your layer selections.</string>
         <item row="7" column="0">
          <widget class="QLabel" name="label_L2">
           <property name="text">
-           <string>L2 (m):</string>
+          <string>Second section (m)</string>
           </property>
          </widget>
         </item>
@@ -397,7 +400,7 @@ This indicator updates automatically based on your layer selections.</string>
         <item row="8" column="0">
          <widget class="QLabel" name="label_LH">
           <property name="text">
-           <string>LH (m):</string>
+          <string>Horizontal section (m)</string>
           </property>
          </widget>
         </item>
@@ -482,37 +485,60 @@ This indicator updates automatically based on your layer selections.</string>
                     </item>
                  </widget>
                 </item>
-                <item row="2" column="0">
-         <widget class="QLabel" name="label_L_conical">
-          <property name="text">
-           <string>Distance L (m):</string>
-          </property>
-         </widget>
-        </item>
-                <item row="2" column="1">
-         <widget class="QLineEdit" name="spin_L_conical">
-          <property name="text">
-           <string>6000.00</string>
-          </property>
-         </widget>
-        </item>
-                <item row="3" column="0">
-         <widget class="QLabel" name="label_height_conical">
-          <property name="text">
-           <string>Height (m):</string>
-          </property>
-          
-         </widget>
-        </item>
-                <item row="3" column="1">
-         <widget class="QLineEdit" name="spin_height_conical">
-          <property name="text">
-           <string>60.00</string>
-          </property><property name="toolTip">
-           <string>Height for 3D PolygonZ surface. Conical surfaces typically use 60m height for ICAO compliance.</string>
-          </property>
-         </widget>
-        </item>
+        <item row="2" column="0">
+     <widget class="QLabel" name="label_height_conical">
+      <property name="text">
+       <string>Height (m):</string>
+      </property>
+     </widget>
+    </item>
+        <item row="2" column="1">
+     <widget class="QLineEdit" name="spin_height_conical">
+      <property name="text">
+       <string>60.00</string>
+      </property>
+      <property name="toolTip">
+       <string>Height for 3D PolygonZ surface (input). Radius will be auto-calculated from Height / Slope + Inner Horizontal Radius.</string>
+      </property>
+     </widget>
+    </item>
+        <item row="3" column="0">
+     <widget class="QLabel" name="label_conical_slope">
+      <property name="text">
+       <string>Slope (%):</string>
+      </property>
+     </widget>
+    </item>
+        <item row="3" column="1">
+     <widget class="QLineEdit" name="spin_conical_slope">
+      <property name="text">
+       <string>5.00</string>
+      </property>
+      <property name="toolTip">
+       <string>Nominal conical slope in percent (editable per code to future-proof regulations).</string>
+      </property>
+     </widget>
+    </item>
+        <item row="4" column="0">
+     <widget class="QLabel" name="label_L_conical">
+      <property name="text">
+       <string>Radius (m):</string>
+      </property>
+     </widget>
+    </item>
+        <item row="4" column="1">
+     <widget class="QLineEdit" name="spin_L_conical">
+      <property name="text">
+       <string>6000.00</string>
+      </property>
+      <property name="toolTip">
+       <string>Computed as Height / Slope + Inner Horizontal Radius. Read-only; edit Slope or Height to change.</string>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
        </layout>
       </widget>
       
@@ -587,38 +613,38 @@ This indicator updates automatically based on your layer selections.</string>
                     </item>
                  </widget>
                 </item>
-                <item row="2" column="0">
-         <widget class="QLabel" name="label_L_inner">
-          <property name="text">
-           <string>Distance L (m):</string>
-          </property>
-         </widget>
-        </item>
-                <item row="2" column="1">
-         <widget class="QLineEdit" name="spin_L_inner">
-          <property name="text">
-           <string>4000.00</string>
-          </property>
-         </widget>
-        </item>
-                <item row="3" column="0">
-         <widget class="QLabel" name="label_height_inner">
-          <property name="text">
-           <string>Height (m):</string>
-          </property>
-          
-         </widget>
-        </item>
-                <item row="3" column="1">
-         <widget class="QLineEdit" name="spin_height_inner">
-          <property name="text">
-           <string>45.00</string>
-          </property><property name="toolTip">
-           <string>Height for 3D polygon surface (PolygonZ)</string>
-          </property>
-         </widget>
-        </item>
-                <item row="4" column="0" colspan="2">
+      <item row="2" column="0">
+    <widget class="QLabel" name="label_height_inner">
+     <property name="text">
+      <string>Height (m):</string>
+     </property>
+    </widget>
+   </item>
+      <item row="2" column="1">
+    <widget class="QLineEdit" name="spin_height_inner">
+     <property name="text">
+      <string>45.00</string>
+     </property>
+     <property name="toolTip">
+      <string>Height for 3D polygon surface (PolygonZ)</string>
+     </property>
+    </widget>
+   </item>
+      <item row="3" column="0">
+    <widget class="QLabel" name="label_L_inner">
+     <property name="text">
+      <string>Radius (m):</string>
+     </property>
+    </widget>
+   </item>
+      <item row="3" column="1">
+    <widget class="QLineEdit" name="spin_L_inner">
+     <property name="text">
+      <string>4000.00</string>
+     </property>
+    </widget>
+   </item>
+      <item row="4" column="0" colspan="2">
          <widget class="QLabel" name="label_info_inner">
           <property name="text">
            <string>📍 Inner Horizontal Surface: Racetrack-shaped 3D polygon
@@ -776,6 +802,23 @@ This indicator updates automatically based on your layer selections.</string>
           </property>
          </widget>
         </item>
+   <!-- Not Applicable notice (hidden by default) -->
+   <item row="7" column="0" colspan="2">
+    <widget class="QLabel" name="label_not_applicable_ofz">
+     <property name="text">
+      <string>Not Applicable</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="styleSheet">
+      <string>QLabel { background: #f5f5f5; border: 1px solid #bdbdbd; padding: 8px; font-weight: bold; color: #555; border-radius:4px; }</string>
+     </property>
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
        </layout>
       </widget>
       
@@ -888,177 +931,8 @@ This indicator updates automatically based on your layer selections.</string>
        </layout>
       </widget>
       
-      <!-- TAKEOFF TAB -->
-      <widget class="QWidget" name="tab_takeoff">
-       <attribute name="title">
-        <string>Take-Off Surface</string>
-       </attribute>
-       <layout class="QFormLayout" name="formLayout_takeoff">
-    <item row="0" column="0">
-         <widget class="QLabel" name="label_code_takeoff">
-          <property name="text">
-           <string>Code:</string>
-          </property>
-         </widget>
-        </item>
-    <item row="0" column="1">
-         <widget class="QComboBox" name="spin_code_takeoff">
-          <property name="currentIndex">
-           <number>3</number>
-          </property>
-          <item>
-           <property name="text">
-            <string>1</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>3</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>4</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-    <item row="2" column="0">
-         <widget class="QLabel" name="label_widthDep_takeoff">
-          <property name="text">
-           <string>Width Dep (m):</string>
-          </property>
-         </widget>
-        </item>
-    <item row="2" column="1">
-         <widget class="QLineEdit" name="spin_widthDep_takeoff">
-          <property name="text">
-           <string>180.0</string>
-          </property>
-         </widget>
-        </item>
-    <item row="3" column="0">
-         <widget class="QLabel" name="label_maxWidthDep_takeoff">
-          <property name="text">
-           <string>Max Width Dep (m):</string>
-          </property>
-         </widget>
-        </item>
-    <item row="3" column="1">
-         <widget class="QLineEdit" name="spin_maxWidthDep_takeoff">
-          <property name="text">
-           <string>1800.0</string>
-          </property>
-         </widget>
-        </item>
-    <item row="4" column="0">
-         <widget class="QLabel" name="label_CWYLength_takeoff">
-          <property name="text">
-           <string>CWY Length (m):</string>
-          </property>
-         </widget>
-        </item>
-    <item row="4" column="1">
-         <widget class="QLineEdit" name="spin_CWYLength_takeoff">
-          <property name="text">
-           <string>0.0</string>
-          </property>
-         </widget>
-        </item>
-    <item row="5" column="0">
-         <widget class="QLabel" name="label_Z0_takeoff">
-          <property name="text">
-          <string>Start Elevation (m):</string>
-          </property>
-         </widget>
-        </item>
-    <item row="5" column="1">
-         <widget class="QLineEdit" name="spin_Z0_takeoff">
-          <property name="text">
-           <string>2548.0</string>
-          </property>
-         </widget>
-        </item>
-    <item row="1" column="1">
-     <widget class="QCheckBox" name="check_finalWidth1800_takeoff">
-      <property name="text">
-       <string>Use 1800 m final width (Code 3/4)</string>
-      </property>
-      <property name="toolTip">
-       <string>For Code 3/4: Checked = 1800 m. Unchecked = 1200 m. You can still override the value manually.</string>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="0">
-     <widget class="QLabel" name="label_divergence_takeoff">
-      <property name="text">
-       <string>Divergence (%):</string>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="1">
-     <widget class="QLineEdit" name="spin_divergence_takeoff">
-      <property name="text">
-       <string>12.5</string>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="0">
-     <widget class="QLabel" name="label_startDistance_takeoff">
-      <property name="text">
-       <string>Start Distance (m):</string>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="1">
-     <widget class="QLineEdit" name="spin_startDistance_takeoff">
-      <property name="text">
-       <string>60</string>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="0">
-     <widget class="QLabel" name="label_surfaceLength_takeoff">
-      <property name="text">
-       <string>Surface Length (m):</string>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="1">
-     <widget class="QLineEdit" name="spin_surfaceLength_takeoff">
-      <property name="text">
-       <string>15000</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="0">
-     <widget class="QLabel" name="label_slope_takeoff">
-      <property name="text">
-       <string>Slope (%):</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="1">
-     <widget class="QLineEdit" name="spin_slope_takeoff">
-      <property name="text">
-       <string>2.0</string>
-      </property>
-     </widget>
-    </item>
-    
-       </layout>
-      </widget>
-      
-      <!-- TRANSITIONAL TAB -->
-      <widget class="QWidget" name="tab_transitional">
+     <!-- TRANSITIONAL TAB (moved before Take-Off) -->
+     <widget class="QWidget" name="tab_transitional">
        <attribute name="title">
         <string>Transitional</string>
        </attribute>
@@ -1225,6 +1099,174 @@ QPushButton:checked:hover {
         </item>
        </layout>
       </widget>
+
+        <!-- TAKEOFF TAB (moved to end) -->
+        <widget class="QWidget" name="tab_takeoff">
+         <attribute name="title">
+         <string>Take-Off Surface</string>
+         </attribute>
+         <layout class="QFormLayout" name="formLayout_takeoff">
+      <item row="0" column="0">
+          <widget class="QLabel" name="label_code_takeoff">
+           <property name="text">
+            <string>Code:</string>
+           </property>
+          </widget>
+         </item>
+      <item row="0" column="1">
+          <widget class="QComboBox" name="spin_code_takeoff">
+           <property name="currentIndex">
+            <number>3</number>
+           </property>
+           <item>
+            <property name="text">
+            <string>1</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+            <string>2</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+            <string>3</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+            <string>4</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+      <item row="2" column="0">
+          <widget class="QLabel" name="label_widthDep_takeoff">
+           <property name="text">
+            <string>Width Dep (m):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="spin_widthDep_takeoff">
+           <property name="text">
+            <string>180.0</string>
+           </property>
+          </widget>
+         </item>
+      <item row="3" column="0">
+          <widget class="QLabel" name="label_maxWidthDep_takeoff">
+           <property name="text">
+            <string>Max Width Dep (m):</string>
+           </property>
+          </widget>
+         </item>
+      <item row="3" column="1">
+          <widget class="QLineEdit" name="spin_maxWidthDep_takeoff">
+           <property name="text">
+            <string>1800.0</string>
+           </property>
+          </widget>
+         </item>
+      <item row="4" column="0">
+          <widget class="QLabel" name="label_CWYLength_takeoff">
+           <property name="text">
+            <string>CWY Length (m):</string>
+           </property>
+          </widget>
+         </item>
+      <item row="4" column="1">
+          <widget class="QLineEdit" name="spin_CWYLength_takeoff">
+           <property name="text">
+            <string>0.0</string>
+           </property>
+          </widget>
+         </item>
+      <item row="5" column="0">
+          <widget class="QLabel" name="label_Z0_takeoff">
+           <property name="text">
+           <string>Start Elevation (m):</string>
+           </property>
+          </widget>
+         </item>
+      <item row="5" column="1">
+          <widget class="QLineEdit" name="spin_Z0_takeoff">
+           <property name="text">
+            <string>2548.0</string>
+           </property>
+          </widget>
+         </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="check_finalWidth1800_takeoff">
+        <property name="text">
+         <string>Use 1800 m final width (Code 3/4)</string>
+        </property>
+        <property name="toolTip">
+         <string>For Code 3/4: Checked = 1800 m. Unchecked = 1200 m. You can still override the value manually.</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_divergence_takeoff">
+        <property name="text">
+         <string>Divergence (%):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="spin_divergence_takeoff">
+        <property name="text">
+         <string>12.5</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_startDistance_takeoff">
+        <property name="text">
+         <string>Start Distance (m):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLineEdit" name="spin_startDistance_takeoff">
+        <property name="text">
+         <string>60</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_surfaceLength_takeoff">
+        <property name="text">
+         <string>Surface Length (m):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLineEdit" name="spin_surfaceLength_takeoff">
+        <property name="text">
+         <string>15000</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_slope_takeoff">
+        <property name="text">
+         <string>Slope (%):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLineEdit" name="spin_slope_takeoff">
+        <property name="text">
+         <string>2.0</string>
+        </property>
+       </widget>
+      </item>
+         </layout>
+        </widget>
       
      </widget>
     </item>


### PR DESCRIPTION
# Approach Surface Parametrization (Issue #46)

## Summary

This pull request implements full parameterization of the Approach Surface generation so that all user-provided values (and ICAO Table 4-1 classification/code driven defaults) are actually consumed in the geometry calculation. Previously, several values were hardcoded (L1=3000, L2=3600, LH=8400, slopes, divergence=15%, threshold offset=60 m), causing incorrect surfaces even when the UI inputs were changed (e.g. setting L2/LH to 0 still drew the sections). Now the surface builds adaptively: only required sections are created and numeric behavior reflects real inputs.

## Key Changes

- Added module `qols/approach_defaults.py` with Annex 14 Table 4-1 derived defaults (width/inner edge, threshold offset, divergence, L1, L2, LH, slopes) per RWY Classification & Code.
- Wired classification/code change events in `qols_dockwidget.py` to auto-fill Approach defaults similar to Conical & Inner Horizontal pattern.
- Extended parameter collection to include: `divergence_ratio`, `first_section_slope`, `second_section_slope`, `threshold_offset_m` (passed to script).
- Refactored `qols/scripts/approach-surface-UTM.py`:
  - Replaced hardcoded distances & slopes with dynamic parameters.
  - Added omission logic: if L1=0 first section omitted; if L2=0 then second and horizontal sections omitted; horizontal section only generated when L2>0 AND LH>0.
  - Divergence applied as growth: half_width = width/2 + distance \* divergence_ratio.
  - Threshold offset configurable (default 30 m for Non-instrument Code 1, else 60 m per table).
  - Layer name now includes RWY Classification and Code for traceability.
  - Feature IDs increment sequentially without gaps (start at 6) depending on which sections exist.
- Left legacy reference script (`scripts/approach-surface-UTM.py`) untouched except for a minimal conditional note (original kept as historical guide).

## Default Table Interpretation (Condensed)

| Classification | Code | Width (m) | Thr Off (m) | Div (each side) | L1 (m) | Slope1 | L2 (m) | Slope2 | LH (m) |
| -------------- | ---- | --------- | ----------- | --------------- | ------ | ------ | ------ | ------ | ------ |
| Non-instrument | 1    | 60        | 30          | 10%             | 1600   | 5%     | 0      | —      | 0      |
| Non-instrument | 2    | 80        | 60          | 10%             | 2500   | 4%     | 0      | —      | 0      |
| Non-instrument | 3    | 150       | 60          | 10%             | 3000   | 3.33%  | 0      | —      | 0      |
| Non-instrument | 4    | 150       | 60          | 10%             | 3000   | 2.5%   | 0      | —      | 0      |
| Non-precision  | 1-2  | 140       | 60          | 15%             | 2500   | 3.33%  | 0      | —      | 0      |
| Non-precision  | 3    | 280       | 60          | 15%             | 3000   | 2%     | 3600   | 2.5%   | 8400   |
| Non-precision  | 4    | 280       | 60          | 15%             | 3000   | 2%     | 3600   | 2.5%   | 8400   |
| CAT I          | 1-2  | 140       | 60          | 15%             | 3000   | 2.5%   | 0      | —      | 0      |
| CAT I          | 3    | 280       | 60          | 15%             | 3000   | 2%     | 3600   | 2.5%   | 8400   |
| CAT I          | 4    | 280       | 60          | 15%             | 3000   | 2%     | 3600   | 2.0%\* | 8400   |
| CAT II/III     | 1-2  | 140       | 60          | 15%             | 3000   | 2.5%   | 0      | —      | 0      |
| CAT II/III     | 3-4  | 280       | 60          | 15%             | 3000   | 2%     | 3600   | 2%     | 8400   |

\*Ambiguity resolved by standardizing Code 4 second section slope at 2.0% for CAT I.

## Behavior Summary

- Changing RWY Classification/Code instantly updates Approach defaults (just like Conical & Inner Horizontal).
- UI edits override defaults (user can manually set L1/L2/LH or set to 0 to suppress sections).
- Horizontal section never appears unless second section exists (Issue requirement).
- All geometry/elevation increments derived from the slopes and lengths provided.

## Non-Functional Improvements

- Centralized defaults => easier testing & future corrections.
- Consistent naming & metadata in layer names (`RWY_ApproachSurface_{Classification}_Code{n}`).
- Logging improved for debugging (shows chosen parameters, sections created count).

## Testing / Validation

Manual validation steps executed:

1. Set L2=0 and LH=0 → Only First Section polygon generated.
2. Set L1=0, L2=3600, LH=8400 → First Section omitted, Second + Horizontal generated.
3. Change classification Non-instrument Code 1 → width=60, L1=1600, no extra sections.
4. Change to CAT I Code 3 → width=280, L1=3000, L2=3600, LH=8400.
5. Divergence visually widens later edges (checked distances vs expected growth = distance \* ratio each side).

(If required we can add a unit test similar to `tests/test_icao_defaults.py` for `approach_defaults`).

## Backward Compatibility

- Legacy parameter keys preserved (code, rwyClassification, L1, L2, LH, Z0, ZE, widthApp, s).
- New keys (python style) added for clarity; scripts prefer them when present.
- Reference original script kept (outside `qols/`) for historical comparison.

## Follow-Up Opportunities

- Add UI fields for override of divergence, slopes, threshold offset (currently auto from table but internally passed).
- Add unit tests for `get_approach_defaults`.
- Add attributes (e.g., Slope1, Slope2, Div, ThrOff) into output layer for audit.

## Request

Please review:

- Table interpretation (especially second section slopes for CAT I Code 4 and CAT I vs CAT II/III differences).
- Whether to expose divergence/slopes/offset in UI now or defer.

If acceptable, merge to close Issue #46.

---

Generated as part of resolving Issue #46: "Approach Surface Parametrization".
