### PR TITLE
issues 62, 65

### DIFF
--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -667,17 +667,17 @@
            <string>60.00</string>
           </property>
           <property name="toolTip">
-           <string>Height for 3D PolygonZ surface (input). Radius will be auto-calculated from Height / Slope + Inner Horizontal Radius.</string>
+                     <string>Height for 3D PolygonZ surface (input). Radius will be auto-calculated from Height / Slope + Inner Horizontal Radius.</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_conical_slope">
-          <property name="text">
-           <string>Slope (%):</string>
-          </property>
-         </widget>
-        </item>
+                <item row="7" column="0">
+                 <widget class="QLabel" name="label_conical_slope">
+                    <property name="text">
+                     <string>Slope (%):</string>
+                    </property>
+                 </widget>
+                </item>
         <item row="7" column="1">
          <widget class="QLineEdit" name="spin_conical_slope">
           <property name="text">
@@ -735,7 +735,19 @@
        <attribute name="title">
         <string>OFZ</string>
        </attribute>
-       <layout class="QFormLayout" name="formLayout_ofz">
+    <layout class="QFormLayout" name="formLayout_ofz">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <property name="labelAlignment">
+      <set>Qt::AlignRight|Qt::AlignVCenter</set>
+     </property>
+     <property name="horizontalSpacing">
+      <number>15</number>
+     </property>
+     <property name="verticalSpacing">
+      <number>6</number>
+     </property>
         <item row="0" column="0">
          <widget class="QLabel" name="label_rwyClassification_ofz">
           <property name="text">
@@ -983,10 +995,10 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0" colspan="2">
-         <widget class="QLabel" name="label_info_outer">
-          <property name="text">
-           <string>Outer Horizontal Surface: 15,000m circle centered on ARP
+                <item row="3" column="0" colspan="2">
+                 <widget class="QLabel" name="label_info_outer">
+                    <property name="text">
+                     <string>Outer Horizontal Surface: 15,000 m circle centered on ARP
 - Code 3 or 4 airports only (DOC 9137 Part 6)
 - Requires Aerodrome Reference Point (ARP)
 - Fixed radius for obstacle limitation</string>
@@ -995,6 +1007,9 @@
           <property name="wordWrap">
            <bool>true</bool>
           </property>
+                    <property name="styleSheet">
+                     <string>QLabel { background-color: #e8f2ff; color: #1f4e79; font-size: 11px; border: 1px solid #c5d9f2; border-radius: 4px; padding: 8px; }</string>
+                    </property>
          </widget>
         </item>
        </layout>
@@ -1005,7 +1020,19 @@
        <attribute name="title">
         <string>Transitional</string>
        </attribute>
-       <layout class="QFormLayout" name="formLayout_transitional">
+    <layout class="QFormLayout" name="formLayout_transitional">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <property name="labelAlignment">
+      <set>Qt::AlignRight|Qt::AlignVCenter</set>
+     </property>
+     <property name="horizontalSpacing">
+      <number>15</number>
+     </property>
+     <property name="verticalSpacing">
+      <number>6</number>
+     </property>
         <item row="0" column="0">
          <widget class="QLabel" name="label_rwyClassification_transitional">
           <property name="text">
@@ -1174,7 +1201,19 @@ QPushButton:checked:hover {
          <attribute name="title">
          <string>Take-Off Surface</string>
          </attribute>
-         <layout class="QFormLayout" name="formLayout_takeoff">
+            <layout class="QFormLayout" name="formLayout_takeoff">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+        </property>
+        <property name="labelAlignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+        <property name="horizontalSpacing">
+         <number>15</number>
+        </property>
+        <property name="verticalSpacing">
+         <number>6</number>
+        </property>
       <item row="0" column="0">
           <widget class="QLabel" name="label_code_takeoff">
            <property name="text">

--- a/qols/rules/icao_annex14.json
+++ b/qols/rules/icao_annex14.json
@@ -5,7 +5,7 @@
     "height_m": 45.0,
     "radius_m": {
       "Non-instrument": { "1": 2000, "2": 2500, "3": 4000, "4": 4000 },
-      "Non-precision approach": { "1": 3000, "2": 3000, "3": 4000, "4": 4000 },
+      "Non-precision approach": { "1": 3500, "2": 3500, "3": 4000, "4": 4000 },
       "Precision Approach CAT I": {
         "1": 3500,
         "2": 3500,
@@ -34,5 +34,164 @@
       }
     },
     "default_radius_m": 6000
+  },
+  "approach": {
+    "width_m": {
+      "Non-instrument": { "1": 60, "2": 80, "3": 150, "4": 150 },
+      "Non-precision approach": { "1": 140, "2": 140, "3": 280, "4": 280 },
+      "Precision Approach CAT I": { "1": 140, "2": 140, "3": 280, "4": 280 },
+      "Precision Approach CAT II or III": {
+        "1": 140,
+        "2": 140,
+        "3": 280,
+        "4": 280
+      }
+    },
+    "threshold_offset_m": {
+      "Non-instrument": { "1": 30, "2": 60, "3": 60, "4": 60 },
+      "Non-precision approach": { "1": 60, "2": 60, "3": 60, "4": 60 },
+      "Precision Approach CAT I": { "1": 60, "2": 60, "3": 60, "4": 60 },
+      "Precision Approach CAT II or III": { "1": 60, "2": 60, "3": 60, "4": 60 }
+    },
+    "divergence_pct": {
+      "Non-instrument": { "1": 10, "2": 10, "3": 10, "4": 10 },
+      "Non-precision approach": { "1": 15, "2": 15, "3": 15, "4": 15 },
+      "Precision Approach CAT I": { "1": 15, "2": 15, "3": 15, "4": 15 },
+      "Precision Approach CAT II or III": { "1": 15, "2": 15, "3": 15, "4": 15 }
+    },
+    "L1_m": {
+      "Non-instrument": { "1": 1600, "2": 2500, "3": 3000, "4": 3000 },
+      "Non-precision approach": { "1": 2500, "2": 2500, "3": 3000, "4": 3000 },
+      "Precision Approach CAT I": {
+        "1": 3000,
+        "2": 3000,
+        "3": 3000,
+        "4": 3000
+      },
+      "Precision Approach CAT II or III": {
+        "1": 3000,
+        "2": 3000,
+        "3": 3000,
+        "4": 3000
+      }
+    },
+    "slope1_pct": {
+      "Non-instrument": { "1": 5, "2": 4, "3": 3.33, "4": 2.5 },
+      "Non-precision approach": { "1": 3.33, "2": 3.33, "3": 2, "4": 2 },
+      "Precision Approach CAT I": { "1": 2.5, "2": 2.5, "3": 2, "4": 2 },
+      "Precision Approach CAT II or III": { "1": 2.5, "2": 2.5, "3": 2, "4": 2 }
+    },
+    "L2_m": {
+      "Non-instrument": { "1": 0, "2": 0, "3": 0, "4": 0 },
+      "Non-precision approach": { "1": 0, "2": 0, "3": 3600, "4": 3600 },
+      "Precision Approach CAT I": {
+        "1": 12000,
+        "2": 12000,
+        "3": 3600,
+        "4": 3600
+      },
+      "Precision Approach CAT II or III": {
+        "1": 0,
+        "2": 0,
+        "3": 3600,
+        "4": 3600
+      }
+    },
+    "slope2_pct": {
+      "Non-instrument": { "1": 0, "2": 0, "3": 0, "4": 0 },
+      "Non-precision approach": { "1": 0, "2": 0, "3": 2.5, "4": 2.5 },
+      "Precision Approach CAT I": { "1": 3, "2": 3, "3": 2.5, "4": 2.5 },
+      "Precision Approach CAT II or III": { "1": 0, "2": 0, "3": 2.5, "4": 2.5 }
+    },
+    "LH_m": {
+      "Non-instrument": { "1": 0, "2": 0, "3": 0, "4": 0 },
+      "Non-precision approach": { "1": 0, "2": 0, "3": 8400, "4": 8400 },
+      "Precision Approach CAT I": { "1": 0, "2": 0, "3": 8400, "4": 8400 },
+      "Precision Approach CAT II or III": {
+        "1": 0,
+        "2": 0,
+        "3": 8400,
+        "4": 8400
+      }
+    }
+  },
+  "transitional": {
+    "slope_pct": {
+      "Non-instrument": { "1": 20, "2": 20, "3": 14.3, "4": 14.3 },
+      "Non-precision approach": { "1": 20, "2": 20, "3": 14.3, "4": 14.3 },
+      "Precision Approach CAT I": {
+        "1": 14.3,
+        "2": 14.3,
+        "3": 14.3,
+        "4": 14.3
+      },
+      "Precision Approach CAT II or III": {
+        "1": 14.3,
+        "2": 14.3,
+        "3": 14.3,
+        "4": 14.3
+      }
+    }
+  },
+  "ofz": {
+    "width_m": {
+      "Precision Approach CAT I": { "1": 90, "2": 90, "3": 120, "4": 120 },
+      "Precision Approach CAT II or III": {
+        "1": 90,
+        "2": 90,
+        "3": 120,
+        "4": 120
+      }
+    },
+    "ih_slope_pct": {
+      "Precision Approach CAT I": { "1": 40, "2": 40, "3": 33.3, "4": 33.3 },
+      "Precision Approach CAT II or III": {
+        "1": 40,
+        "2": 40,
+        "3": 33.3,
+        "4": 33.3
+      }
+    }
+  },
+  "inner_approach": {
+    "width_m": {
+      "Precision Approach CAT I": { "1": 90, "2": 90, "3": 120, "4": 120 },
+      "Precision Approach CAT II or III": { "3": 120, "4": 120 }
+    },
+    "distance_from_threshold_m": {
+      "Precision Approach CAT I": { "1": 60, "2": 60, "3": 60, "4": 60 },
+      "Precision Approach CAT II or III": { "3": 60, "4": 60 }
+    },
+    "length_m": {
+      "Precision Approach CAT I": { "1": 900, "2": 900, "3": 900, "4": 900 },
+      "Precision Approach CAT II or III": { "3": 900, "4": 900 }
+    },
+    "slope_pct": {
+      "Precision Approach CAT I": { "1": 2.5, "2": 2.5, "3": 2.0, "4": 2.0 },
+      "Precision Approach CAT II or III": { "3": 2.0, "4": 2.0 }
+    }
+  },
+  "balked_landing": {
+    "width_m": {
+      "Precision Approach CAT I": { "1": 90, "2": 90, "3": 120, "4": 120 },
+      "Precision Approach CAT II or III": { "3": 120, "4": 120 }
+    },
+    "distance_from_threshold_m": {
+      "Precision Approach CAT I": {
+        "1": 1800,
+        "2": 1800,
+        "3": 1800,
+        "4": 1800
+      },
+      "Precision Approach CAT II or III": { "3": 1800, "4": 1800 }
+    },
+    "divergence_pct": {
+      "Precision Approach CAT I": { "1": 10, "2": 10, "3": 10, "4": 10 },
+      "Precision Approach CAT II or III": { "3": 10, "4": 10 }
+    },
+    "slope_pct": {
+      "Precision Approach CAT I": { "1": 4.0, "2": 4.0, "3": 3.33, "4": 3.33 },
+      "Precision Approach CAT II or III": { "3": 3.33, "4": 3.33 }
+    }
   }
 }

--- a/qols/rules_manager.py
+++ b/qols/rules_manager.py
@@ -94,6 +94,40 @@ class RuleManager:
         if isinstance(con, dict) and 'height_m' in con:
             con['height_m'] = normalize_map(con.get('height_m', {}))
 
+        # Approach (width, offsets, divergences, sections)
+        app = data.get('approach')
+        if isinstance(app, dict):
+            for key in ['width_m', 'threshold_offset_m', 'divergence_pct', 'L1_m', 'slope1_pct', 'L2_m', 'slope2_pct', 'LH_m']:
+                if key in app:
+                    app[key] = normalize_map(app.get(key, {}))
+
+        # Transitional (slope)
+        trn = data.get('transitional')
+        if isinstance(trn, dict) and 'slope_pct' in trn:
+            trn['slope_pct'] = normalize_map(trn.get('slope_pct', {}))
+
+        # OFZ (width and inner side slope toward ZIH)
+        ofz = data.get('ofz')
+        if isinstance(ofz, dict):
+            if 'width_m' in ofz:
+                ofz['width_m'] = normalize_map(ofz.get('width_m', {}))
+            if 'ih_slope_pct' in ofz:
+                ofz['ih_slope_pct'] = normalize_map(ofz.get('ih_slope_pct', {}))
+
+        # Inner Approach
+        ia = data.get('inner_approach')
+        if isinstance(ia, dict):
+            for key in ['width_m', 'distance_from_threshold_m', 'length_m', 'slope_pct']:
+                if key in ia:
+                    ia[key] = normalize_map(ia.get(key, {}))
+		
+        # Balked Landing
+        bl = data.get('balked_landing')
+        if isinstance(bl, dict):
+            for key in ['width_m', 'distance_from_threshold_m', 'divergence_pct', 'slope_pct']:
+                if key in bl:
+                    bl[key] = normalize_map(bl.get(key, {}))
+
     def list_rule_sets(self) -> Dict[str, Dict[str, Any]]:
         self.load()
         return dict(self._registry)
@@ -187,6 +221,112 @@ class RuleManager:
             result['radius_m'] = radius
         return result if result else None
 
+    def _class_code_lookup(self, mapping: Dict[str, Any], rwy_classification: str, code: int) -> Optional[float]:
+        try:
+            class_map = mapping.get(rwy_classification) or {}
+            val = class_map.get(str(int(code))) or class_map.get(int(code))
+            return float(val) if val is not None else None
+        except Exception:
+            return None
+
+    def get_approach_defaults(self, rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+        rs = self._get_active()
+        if not rs:
+            return None
+        app = rs.get('approach') or {}
+        if not isinstance(app, dict):
+            return None
+        keys = ['width_m', 'threshold_offset_m', 'divergence_pct', 'L1_m', 'slope1_pct', 'L2_m', 'slope2_pct', 'LH_m']
+        out: Dict[str, float] = {}
+        for k in keys:
+            m = app.get(k)
+            if isinstance(m, dict):
+                v = self._class_code_lookup(m, rwy_classification, code)
+                if v is not None:
+                    # Convert percentages to ratio for divergence and slopes where applicable
+                    if k in ['divergence_pct', 'slope1_pct', 'slope2_pct']:
+                        out[k.replace('_pct', '_ratio')] = v / 100.0
+                    else:
+                        out[k] = v
+        return out if out else None
+
+    def get_transitional_defaults(self, rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+        rs = self._get_active()
+        if not rs:
+            return None
+        trn = rs.get('transitional') or {}
+        if not isinstance(trn, dict):
+            return None
+        slope_pct_map = trn.get('slope_pct') or {}
+        slope = self._class_code_lookup(slope_pct_map, rwy_classification, code)
+        if slope is None:
+            return None
+        return {'slope_ratio': slope / 100.0, 'slope_pct': slope}
+
+    def get_ofz_defaults(self, rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+        rs = self._get_active()
+        if not rs:
+            return None
+        ofz = rs.get('ofz') or {}
+        if not isinstance(ofz, dict):
+            return None
+        width = self._class_code_lookup(ofz.get('width_m', {}), rwy_classification, code)
+        ihs = self._class_code_lookup(ofz.get('ih_slope_pct', {}), rwy_classification, code)
+        out: Dict[str, float] = {}
+        if width is not None:
+            out['width_m'] = width
+        if ihs is not None:
+            out['ih_slope_ratio'] = ihs / 100.0
+            out['ih_slope_pct'] = ihs
+        return out if out else None
+
+    def get_inner_approach_defaults(self, rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+        rs = self._get_active()
+        if not rs:
+            return None
+        ia = rs.get('inner_approach') or {}
+        if not isinstance(ia, dict):
+            return None
+        width = self._class_code_lookup(ia.get('width_m', {}), rwy_classification, code)
+        dist = self._class_code_lookup(ia.get('distance_from_threshold_m', {}), rwy_classification, code)
+        length = self._class_code_lookup(ia.get('length_m', {}), rwy_classification, code)
+        slope = self._class_code_lookup(ia.get('slope_pct', {}), rwy_classification, code)
+        out: Dict[str, float] = {}
+        if width is not None:
+            out['width_m'] = width
+        if dist is not None:
+            out['distance_from_threshold_m'] = dist
+        if length is not None:
+            out['length_m'] = length
+        if slope is not None:
+            out['slope_ratio'] = slope / 100.0
+            out['slope_pct'] = slope
+        return out if out else None
+
+    def get_balked_landing_defaults(self, rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+        rs = self._get_active()
+        if not rs:
+            return None
+        bl = rs.get('balked_landing') or {}
+        if not isinstance(bl, dict):
+            return None
+        width = self._class_code_lookup(bl.get('width_m', {}), rwy_classification, code)
+        dist = self._class_code_lookup(bl.get('distance_from_threshold_m', {}), rwy_classification, code)
+        div = self._class_code_lookup(bl.get('divergence_pct', {}), rwy_classification, code)
+        slope = self._class_code_lookup(bl.get('slope_pct', {}), rwy_classification, code)
+        out: Dict[str, float] = {}
+        if width is not None:
+            out['width_m'] = width
+        if dist is not None:
+            out['distance_from_threshold_m'] = dist
+        if div is not None:
+            out['divergence_ratio'] = div / 100.0
+            out['divergence_pct'] = div
+        if slope is not None:
+            out['slope_ratio'] = slope / 100.0
+            out['slope_pct'] = slope
+        return out if out else None
+
 
 # Singleton instance
 _RM = RuleManager()
@@ -214,3 +354,23 @@ def get_conical_defaults(rwy_classification: str, code: int) -> Optional[Dict[st
 
 def reload_rules():
     _RM.reload()
+
+
+def get_approach_defaults(rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+    return _RM.get_approach_defaults(rwy_classification, code)
+
+
+def get_transitional_defaults(rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+    return _RM.get_transitional_defaults(rwy_classification, code)
+
+
+def get_ofz_defaults(rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+    return _RM.get_ofz_defaults(rwy_classification, code)
+
+
+def get_inner_approach_defaults(rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+    return _RM.get_inner_approach_defaults(rwy_classification, code)
+
+
+def get_balked_landing_defaults(rwy_classification: str, code: int) -> Optional[Dict[str, float]]:
+    return _RM.get_balked_landing_defaults(rwy_classification, code)


### PR DESCRIPTION
# UI Alignment for OFZ, Transitional, and Take-Off (Issue #62)

Continuation of Issue #62 to expand the same UI alignment and styling standards applied earlier to the combined tab. This iteration aligns labels and inputs and standardizes spacing across the remaining tabs: OFZ, Transitional, and Take-Off.

## Summary

- Added consistent alignment and spacing to the following tabs:
  - OFZ
  - Transitional
  - Take-Off Surface
- No functional changes—purely layout polish for a cleaner, more consistent UI.

## Files Updated

- `qols/qols_panel_base.ui`
  - OFZ: `formLayout_ofz`
    - fieldGrowthPolicy = AllNonFixedFieldsGrow
    - labelAlignment = AlignRight|AlignVCenter
    - horizontalSpacing = 15, verticalSpacing = 6
  - Transitional: `formLayout_transitional`
    - fieldGrowthPolicy = AllNonFixedFieldsGrow
    - labelAlignment = AlignRight|AlignVCenter
    - horizontalSpacing = 15, verticalSpacing = 6
  - Take-Off: `formLayout_takeoff`
    - fieldGrowthPolicy = AllNonFixedFieldsGrow
    - labelAlignment = AlignRight|AlignVCenter
    - horizontalSpacing = 15, verticalSpacing = 6

## Behavior/UX

- Labels align uniformly to the right; inputs grow consistently across each tab.
- Spacing between rows/columns is standardized—forms no longer “jump” when switching tabs.
- Rotational control and checkboxes remain in place; only layout alignment was adjusted.

## Notes

- This is a visual-only change—no impact on calculations or rule application.
- Pairs with the earlier Issue #62 change that restored the blue “Workflow” background and standardized the combined tab layout.
