### PR TITLE
Rename "Runway Layer" to "Runway Layer Centerline" (#71)

### DIFF
--- a/PR_RUNWAY_LAYER_CENTERLINE_RENAME_ISSUE_71.md
+++ b/PR_RUNWAY_LAYER_CENTERLINE_RENAME_ISSUE_71.md
@@ -1,0 +1,58 @@
+# PR: Rename "Runway Layer" to "Runway Layer Centerline" (#71)
+
+## Summary
+
+This PR standardizes all user-facing occurrences of "Runway Layer" to "Runway Layer Centerline" to eliminate ambiguity and clearly reference the expected LINE geometry representing runway centerlines. The change spans UI labels and tooltips, validation messages, logs, and exceptions. No functional logic or algorithms were changed.
+
+## Rationale
+
+- Clarifies that the input is the centerline layer (LINE geometry), not polygons or other runway-related layers.
+- Aligns the terminology across the entire plugin for consistency and better UX.
+
+## Scope of Changes
+
+- Text-only updates across UI and messages. No changes to business logic, data models, or geometry computations.
+
+## Files Updated
+
+- UI
+  - `qols/qols_panel_base.ui`: label and tooltip updated to "Runway Layer Centerline".
+- Framework and messages
+  - `qols/qols_dockwidget.py`: validation messages, prompts, and logs updated.
+  - `qols/qols.py`: critical error messages and logs updated.
+  - `qols/icon_manager.py`: helper/guide text updated.
+- Scripts
+  - `qols/scripts/approach-surface-UTM.py`
+  - `qols/scripts/OFZ_UTM.py`
+  - `qols/scripts/TransitionalSurface_UTM.py`
+  - `qols/scripts/take-off-surface_UTM.py`
+  - `qols/scripts/conical.py`
+  - `qols/scripts/inner-horizontal-racetrack.py`
+
+## User Impact
+
+- UI label now reads "Runway Layer Centerline"; tooltips and message bar errors reflect the same terminology.
+- No change to existing project files or layer filtering behavior. Users still select LINE geometry layers (centerlines) as before.
+
+## Testing
+
+1. Reload the plugin in QGIS.
+2. Open the dock and verify the label reads "Runway Layer Centerline" and the tooltip mentions "centerlines".
+3. Attempt to run without selecting a centerline layer and confirm the error message mentions "Runway Layer Centerline".
+4. Run each generator (Approach, OFZ, Transitional, Take-Off, Inner Horizontal/Conical) with a valid centerline layer and confirm normal operation (no behavior change expected).
+
+## Backward Compatibility
+
+- Backward compatible. Only user-facing strings were changed. No API, logic, or data format changes.
+
+## Documentation
+
+- Inline UI texts updated; no external docs required. Release notes should mention the terminology update for clarity.
+
+## Versioning
+
+- Recommended: Patch or minor bump due to UI text changes (no functional changes).
+
+## Related Issues
+
+- Closes #71.

--- a/qols/icon_manager.py
+++ b/qols/icon_manager.py
@@ -93,7 +93,7 @@ def apply_custom_icons_to_combos(dockwidget, icon_manager):
         
         # Add tooltips to make the purpose clearer
         dockwidget.runwayLayerCombo.setToolTip(
-            "🛬 Select runway layer\n"
+            "🛬 Select Runway Layer Centerline\n"
             "Choose the vector layer containing runway geometries.\n"
             "Should contain LineString or Polygon features representing runways."
         )

--- a/qols/qols.py
+++ b/qols/qols.py
@@ -398,14 +398,14 @@ class QOLS:
             threshold_layer = params.get('threshold_layer')
             
             if runway_layer is None:
-                raise Exception("CRITICAL ERROR: No runway layer in parameters. Execution aborted.")
+                raise Exception("CRITICAL ERROR: No Runway Layer Centerline in parameters. Execution aborted.")
             
             if threshold_layer is None:
                 raise Exception("CRITICAL ERROR: No threshold layer in parameters. Execution aborted.")
             
             # SAFETY CHECK: Ensure layer objects are valid QGIS layers
             if not isinstance(runway_layer, QgsVectorLayer):
-                raise Exception(f"CRITICAL ERROR: Runway layer is not a valid QgsVectorLayer: {type(runway_layer)}")
+                raise Exception(f"CRITICAL ERROR: Runway Layer Centerline is not a valid QgsVectorLayer: {type(runway_layer)}")
             
             if not isinstance(threshold_layer, QgsVectorLayer):
                 raise Exception(f"CRITICAL ERROR: Threshold layer is not a valid QgsVectorLayer: {type(threshold_layer)}")
@@ -413,21 +413,21 @@ class QOLS:
             # SAFETY CHECK: Ensure layers still exist in project
             project_layers = list(QgsProject.instance().mapLayers().values())
             if runway_layer not in project_layers:
-                raise Exception(f"CRITICAL ERROR: Runway layer '{runway_layer.name()}' not found in current project.")
+                raise Exception(f"CRITICAL ERROR: Runway Layer Centerline '{runway_layer.name()}' not found in current project.")
             
             if threshold_layer not in project_layers:
                 raise Exception(f"CRITICAL ERROR: Threshold layer '{threshold_layer.name()}' not found in current project.")
             
             # SAFETY CHECK: Verify layer validity and accessibility
             if not runway_layer.isValid():
-                raise Exception(f"CRITICAL ERROR: Runway layer '{runway_layer.name()}' is invalid or corrupted.")
+                raise Exception(f"CRITICAL ERROR: Runway Layer Centerline '{runway_layer.name()}' is invalid or corrupted.")
             
             if not threshold_layer.isValid():
                 raise Exception(f"CRITICAL ERROR: Threshold layer '{threshold_layer.name()}' is invalid or corrupted.")
             
             # SAFETY CHECK: Verify layers have features
             if runway_layer.featureCount() == 0:
-                raise Exception(f"CRITICAL ERROR: Runway layer '{runway_layer.name()}' contains no features.")
+                raise Exception(f"CRITICAL ERROR: Runway Layer Centerline '{runway_layer.name()}' contains no features.")
             
             if threshold_layer.featureCount() == 0:
                 raise Exception(f"CRITICAL ERROR: Threshold layer '{threshold_layer.name()}' contains no features.")
@@ -438,7 +438,7 @@ class QOLS:
             
             print(f"QOLS: EXECUTING SCRIPT WITH VALIDATED PARAMETERS:")
             print(f"  Script: {script_path}")
-            print(f"  Runway Layer: '{runway_layer.name()}' ({runway_layer.featureCount()} features)")
+            print(f"  Runway Layer Centerline: '{runway_layer.name()}' ({runway_layer.featureCount()} features)")
             print(f"  Threshold Layer: '{threshold_layer.name()}' ({threshold_layer.featureCount()} features)")
             print(f"  Use Runway Selected: {use_runway_selected}")
             print(f"  Use Threshold Selected: {use_threshold_selected}")

--- a/qols/qols_dockwidget.py
+++ b/qols/qols_dockwidget.py
@@ -507,11 +507,11 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
             
-            # Connect to runway layer selection changes
+            # Connect to Runway Layer Centerline selection changes
             if runway_layer and isinstance(runway_layer, QgsVectorLayer):
                 runway_layer.selectionChanged.connect(self.update_selection_info)
                 self.connected_runway_layer = runway_layer
-                print(f"QOLS: Connected to runway layer selection signals: {runway_layer.name()}")
+                print(f"QOLS: Connected to Runway Layer Centerline selection signals: {runway_layer.name()}")
             
             # Connect to threshold layer selection changes  
             if threshold_layer and isinstance(threshold_layer, QgsVectorLayer):
@@ -528,7 +528,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             if self.connected_runway_layer:
                 try:
                     self.connected_runway_layer.selectionChanged.disconnect(self.update_selection_info)
-                    print(f"QOLS: Disconnected from runway layer: {self.connected_runway_layer.name()}")
+                    print(f"QOLS: Disconnected from Runway Layer Centerline: {self.connected_runway_layer.name()}")
                 except:
                     pass  # Signal might not be connected
                 self.connected_runway_layer = None
@@ -978,7 +978,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         try:
             print("QOLS: Setting up layer filters")
             
-            # Configure runway layer combo - only show LINE geometry layers
+            # Configure Runway Layer Centerline combo - only show LINE geometry layers
             self.runwayLayerCombo.setFilters(QgsMapLayerProxyModel.VectorLayer)
             self.runwayLayerCombo.setExceptedLayerList([])
             # Enable additional display options for runway combo
@@ -1011,7 +1011,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             vector_layers = [layer for layer in QgsProject.instance().mapLayers().values() 
                            if isinstance(layer, QgsVectorLayer)]
             
-            # Filter runway layers - only show LINE geometry
+            # Filter Runway Layer Centerline layers - only show LINE geometry
             runway_excluded = []
             threshold_excluded = []
             
@@ -1482,14 +1482,14 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
             
-            # Validate runway layer
+            # Validate Runway Layer Centerline
             if runway_layer:
                 if runway_layer.geometryType() != QgsWkbTypes.LineGeometry:
                     geom_type = self.get_layer_geometry_info(runway_layer)
                     self.show_error_message(
-                        f"Invalid Runway Layer!\n"
+                        f"Invalid Runway Layer Centerline!\n"
                         f"'{runway_layer.name()}' contains {geom_type} geometry.\n"
-                        f"Runway layer must contain LINE geometry (runway lines)."
+                        f"Runway Layer Centerline must contain LINE geometry (runway lines)."
                     )
                     # Reset to no selection
                     self.runwayLayerCombo.setCurrentIndex(-1)
@@ -1706,9 +1706,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # CRITICAL CHECK 1: Ensure layers are selected
             if not runway_layer:
                 self.show_error_message(
-                    "No Runway Layer Selected!\n\n"
-                    "Please select a runway layer from the dropdown.\n"
-                    "The runway layer must contain LINE geometry (runway lines)."
+                    "No Runway Layer Centerline Selected!\n\n"
+                    "Please select a Runway Layer Centerline from the dropdown.\n"
+                    "The Runway Layer Centerline must contain LINE geometry (runway lines)."
                 )
                 return False
             
@@ -1723,9 +1723,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # CRITICAL CHECK 2: Ensure layers are valid QGIS objects
             if not isinstance(runway_layer, QgsVectorLayer):
                 self.show_error_message(
-                    f"Invalid Runway Layer Object!\n\n"
+                    f"Invalid Runway Layer Centerline Object!\n\n"
                     f"Selected object is not a valid vector layer: {type(runway_layer)}\n"
-                    f"Please select a different runway layer."
+                    f"Please select a different Runway Layer Centerline."
                 )
                 return False
             
@@ -1741,9 +1741,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             project_layers = list(QgsProject.instance().mapLayers().values())
             if runway_layer not in project_layers:
                 self.show_error_message(
-                    f"Runway Layer Not Found!\n\n"
+                    f"Runway Layer Centerline Not Found!\n\n"
                     f"Layer '{runway_layer.name()}' is no longer in the project.\n"
-                    f"It may have been removed. Please select a different runway layer."
+                    f"It may have been removed. Please select a different Runway Layer Centerline."
                 )
                 return False
             
@@ -1758,9 +1758,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # CRITICAL CHECK 4: Ensure layers are valid and accessible
             if not runway_layer.isValid():
                 self.show_error_message(
-                    f"Corrupted Runway Layer!\n\n"
+                    f"Corrupted Runway Layer Centerline!\n\n"
                     f"Layer '{runway_layer.name()}' is invalid or corrupted.\n"
-                    f"Please check the layer source and select a different runway layer."
+                    f"Please check the layer source and select a different Runway Layer Centerline."
                 )
                 return False
             
@@ -1772,7 +1772,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 )
                 return False
             
-            # CRITICAL CHECK 5: Validate runway layer geometry (must be LINE)
+            # CRITICAL CHECK 5: Validate Runway Layer Centerline geometry (must be LINE)
             if runway_layer.geometryType() != QgsWkbTypes.LineGeometry:
                 runway_geom_type = self.get_layer_geometry_info(runway_layer)
                 self.show_error_message(
@@ -1802,9 +1802,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             
             if runway_total == 0:
                 self.show_error_message(
-                    f"Empty Runway Layer!\n\n"
+                    f"Empty Runway Layer Centerline!\n\n"
                     f"Layer '{runway_layer.name()}' contains no features.\n"
-                    f"Please select a runway layer with runway line features."
+                    f"Please select a Runway Layer Centerline with runway line features."
                 )
                 return False
             
@@ -1854,7 +1854,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             
             # SUCCESS: All validations passed
             print(f"QOLS: ✅ ALL VALIDATIONS PASSED")
-            print(f"QOLS: Runway Layer: '{runway_layer.name()}' (LINE geometry, {runway_total} features)")
+            print(f"QOLS: Runway Layer Centerline: '{runway_layer.name()}' (LINE geometry, {runway_total} features)")
             print(f"QOLS: Threshold Layer: '{threshold_layer.name()}' (POINT geometry, {threshold_total} features)")
             print(f"QOLS: Selection Mode: Runway={'selected' if use_runway_selected else 'all'}, Threshold={'selected' if use_threshold_selected else 'all'}")
             
@@ -1912,7 +1912,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             
             # SAFETY CHECK: Ensure layers are still valid (could have been removed)
             if not runway_layer:
-                raise Exception("CRITICAL ERROR: No runway layer selected. This should not happen after validation.")
+                raise Exception("CRITICAL ERROR: No Runway Layer Centerline selected. This should not happen after validation.")
             
             if not threshold_layer:
                 raise Exception("CRITICAL ERROR: No threshold layer selected. This should not happen after validation.")
@@ -1920,14 +1920,14 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # SAFETY CHECK: Ensure layers are still in project (could have been removed)
             project_layers = QgsProject.instance().mapLayers().values()
             if runway_layer not in project_layers:
-                raise Exception(f"CRITICAL ERROR: Runway layer '{runway_layer.name()}' no longer exists in project.")
+                raise Exception(f"CRITICAL ERROR: Runway Layer Centerline '{runway_layer.name()}' no longer exists in project.")
             
             if threshold_layer not in project_layers:
                 raise Exception(f"CRITICAL ERROR: Threshold layer '{threshold_layer.name()}' no longer exists in project.")
             
             # SAFETY CHECK: Re-verify geometry types (layers could have changed)
             if runway_layer.geometryType() != QgsWkbTypes.LineGeometry:
-                raise Exception(f"CRITICAL ERROR: Runway layer '{runway_layer.name()}' geometry changed to {self.get_layer_geometry_info(runway_layer)}.")
+                raise Exception(f"CRITICAL ERROR: Runway Layer Centerline '{runway_layer.name()}' geometry changed to {self.get_layer_geometry_info(runway_layer)}.")
             
             if threshold_layer.geometryType() != QgsWkbTypes.PointGeometry:
                 raise Exception(f"CRITICAL ERROR: Threshold layer '{threshold_layer.name()}' geometry changed to {self.get_layer_geometry_info(threshold_layer)}.")

--- a/qols/qols_panel_base.ui
+++ b/qols/qols_panel_base.ui
@@ -143,7 +143,7 @@
           <item>
            <widget class="QLabel" name="runwayTitleLabel">
             <property name="text">
-             <string>Runway Layer</string>
+             <string>Runway Layer Centerline</string>
             </property>
             <property name="styleSheet">
              <string>QLabel { font-weight: bold; }</string>
@@ -166,7 +166,7 @@
                <number>28</number>
               </property>
               <property name="toolTip">
-               <string>Select the runway layer from your project. This layer should contain line features representing runway centerlines.</string>
+               <string>Select the Runway Layer Centerline from your project. This layer should contain line features representing runway centerlines.</string>
               </property>
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">

--- a/qols/scripts/OFZ_UTM.py
+++ b/qols/scripts/OFZ_UTM.py
@@ -72,7 +72,7 @@ map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 # ENHANCED LAYER SELECTION - Use layers from UI
 try:
     if runway_layer is not None:
-        print(f"OFZ: Using runway layer from UI: {runway_layer.name()}")
+        print(f"OFZ: Using Runway Layer Centerline from UI: {runway_layer.name()}")
         
         if use_selected_feature:
             # Require explicit feature selection
@@ -83,7 +83,7 @@ try:
         else:
             selection = list(runway_layer.getFeatures())
             if not selection:
-                raise Exception("No features found in runway layer.")
+                raise Exception("No features found in Runway Layer Centerline.")
             print(f"OFZ: Using first feature from layer (selection disabled)")
         
         print(f"OFZ: Processing {len(selection)} runway features")
@@ -94,12 +94,12 @@ try:
         print(f"OFZ: Runway length: {rwy_length}, slope: {rwy_slope}")
         
     else:
-        # No fallback - require explicit runway layer selection
-        raise Exception("No runway layer provided. Please select a runway layer from the UI.")
+        # No fallback - require explicit Runway Layer Centerline selection
+        raise Exception("No Runway Layer Centerline provided. Please select a Runway Layer Centerline from the UI.")
 
 except Exception as e:
-    print(f"OFZ: Error with runway layer: {e}")
-    iface.messageBar().pushMessage("OFZ Error", f"Runway layer error: {str(e)}", level=Qgis.Critical)
+    print(f"OFZ: Error with Runway Layer Centerline: {e}")
+    iface.messageBar().pushMessage("OFZ Error", f"Runway Layer Centerline error: {str(e)}", level=Qgis.Critical)
     raise
 
 # Calculate ZIHs

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -71,7 +71,7 @@ map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 # ENHANCED LAYER SELECTION - Use layers from UI
 try:
     if runway_layer is not None:
-        print(f"TransitionalSurface: Using runway layer from UI: {runway_layer.name()}")
+        print(f"TransitionalSurface: Using Runway Layer Centerline from UI: {runway_layer.name()}")
         
         if use_selected_feature:
             # Require explicit feature selection
@@ -82,7 +82,7 @@ try:
         else:
             selection = list(runway_layer.getFeatures())
             if not selection:
-                raise Exception("No features found in runway layer.")
+                raise Exception("No features found in Runway Layer Centerline.")
             print(f"TransitionalSurface: Using first feature from layer (selection disabled)")
         
         print(f"TransitionalSurface: Processing {len(selection)} runway features")
@@ -93,12 +93,12 @@ try:
         print(f"TransitionalSurface: Runway length: {rwy_length}, slope: {rwy_slope}")
         
     else:
-        # No fallback - require explicit runway layer selection
-        raise Exception("No runway layer provided. Please select a runway layer from the UI.")
+        # No fallback - require explicit Runway Layer Centerline selection
+        raise Exception("No Runway Layer Centerline provided. Please select a Runway Layer Centerline from the UI.")
 
 except Exception as e:
-    print(f"TransitionalSurface: Error with runway layer: {e}")
-    iface.messageBar().pushMessage("TransitionalSurface Error", f"Runway layer error: {str(e)}", level=Qgis.Critical)
+    print(f"TransitionalSurface: Error with Runway Layer Centerline: {e}")
+    iface.messageBar().pushMessage("TransitionalSurface Error", f"Runway Layer Centerline error: {str(e)}", level=Qgis.Critical)
     raise
 
 # Calculate ZIHs

--- a/qols/scripts/approach-surface-UTM.py
+++ b/qols/scripts/approach-surface-UTM.py
@@ -70,7 +70,7 @@ map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 # ENHANCED LAYER SELECTION - Use layers from UI
 try:
     if runway_layer is not None:
-        print(f"QOLS: Using runway layer from UI: {runway_layer.name()}")
+        print(f"QOLS: Using Runway Layer Centerline from UI: {runway_layer.name()}")
         
         if use_selected_feature:
             # Require explicit feature selection
@@ -82,7 +82,7 @@ try:
             # Use all features (take first one)
             selection = list(runway_layer.getFeatures())
             if not selection:
-                raise Exception("No features found in runway layer.")
+                raise Exception("No features found in Runway Layer Centerline.")
             print(f"QOLS: Using first feature from layer (selection disabled)")
         
         print(f"QOLS: Processing {len(selection)} runway features")
@@ -92,12 +92,12 @@ try:
         print(f"QOLS: Runway length: {rwy_length}, slope: {rwy_slope}")
 
     else:
-        # No fallback - require explicit runway layer selection
-        raise Exception("No runway layer provided. Please select a runway layer from the UI.")
+        # No fallback - require explicit Runway Layer Centerline selection
+        raise Exception("No Runway Layer Centerline provided. Please select a Runway Layer Centerline from the UI.")
 
 except Exception as e:
-    print(f"QOLS: Error with runway layer: {e}")
-    iface.messageBar().pushMessage("QOLS Error", f"Runway layer error: {str(e)}", level=Qgis.Critical)
+    print(f"QOLS: Error with Runway Layer Centerline: {e}")
+    iface.messageBar().pushMessage("QOLS Error", f"Runway Layer Centerline error: {str(e)}", level=Qgis.Critical)
     raise
 
 # Calculate ZIH at start (legacy name ZIHs)

--- a/qols/scripts/conical.py
+++ b/qols/scripts/conical.py
@@ -57,7 +57,7 @@ map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 # ENHANCED LAYER SELECTION - Use layers from UI
 try:
     if runway_layer is not None:
-        print(f"Conical: Using runway layer from UI: {runway_layer.name()}")
+        print(f"Conical: Using Runway Layer Centerline from UI: {runway_layer.name()}")
         
         if use_selected_feature:
             # Require explicit feature selection
@@ -69,18 +69,18 @@ try:
             # Use all features (take first one)
             selection = list(runway_layer.getFeatures())
             if not selection:
-                raise Exception("No features found in runway layer.")
+                raise Exception("No features found in Runway Layer Centerline.")
             print(f"Conical: Using first feature from layer (selection disabled)")
         
         print(f"Conical: Processing {len(selection)} runway features")
         
     else:
-        # No fallback - require explicit runway layer selection
-        raise Exception("No runway layer provided. Please select a runway layer from the UI.")
+        # No fallback - require explicit Runway Layer Centerline selection
+        raise Exception("No Runway Layer Centerline provided. Please select a Runway Layer Centerline from the UI.")
         
 except Exception as e:
-    print(f"Conical: Error with runway layer: {e}")
-    iface.messageBar().pushMessage("Conical Error", f"Runway layer error: {str(e)}", level=Qgis.Critical)
+    print(f"Conical: Error with Runway Layer Centerline: {e}")
+    iface.messageBar().pushMessage("Conical Error", f"Runway Layer Centerline error: {str(e)}", level=Qgis.Critical)
     raise
 
 # Get the azimuth of the line - USING ORIGINAL CALCULATION LOGIC

--- a/qols/scripts/inner-horizontal-racetrack.py
+++ b/qols/scripts/inner-horizontal-racetrack.py
@@ -58,7 +58,7 @@ trfm = QgsCoordinateTransform(dest_crs, source_crs, QgsProject.instance())
 # ENHANCED LAYER SELECTION - Use layers from UI
 try:
     if runway_layer is not None:
-        print(f"InnerHorizontal: Using runway layer from UI: {runway_layer.name()}")
+        print(f"InnerHorizontal: Using Runway Layer Centerline from UI: {runway_layer.name()}")
         
         if use_selected_feature:
             selection = runway_layer.selectedFeatures()
@@ -68,17 +68,17 @@ try:
         else:
             selection = list(runway_layer.getFeatures())
             if not selection:
-                raise Exception("No features found in runway layer.")
+                raise Exception("No features found in Runway Layer Centerline.")
             print(f"InnerHorizontal: Using first feature from layer")
         
         print(f"InnerHorizontal: Processing {len(selection)} runway features")
         
     else:
-        raise Exception("No runway layer provided. Please select a runway layer from the UI.")
+        raise Exception("No Runway Layer Centerline provided. Please select a Runway Layer Centerline from the UI.")
         
 except Exception as e:
-    print(f"InnerHorizontal: Error with runway layer: {e}")
-    iface.messageBar().pushMessage("InnerHorizontal Error", f"Runway layer error: {str(e)}", level=Qgis.Critical)
+    print(f"InnerHorizontal: Error with Runway Layer Centerline: {e}")
+    iface.messageBar().pushMessage("InnerHorizontal Error", f"Runway Layer Centerline error: {str(e)}", level=Qgis.Critical)
     raise
 
 # Create memory layer for 3D polygon (PolygonZ)

--- a/qols/scripts/take-off-surface_UTM.py
+++ b/qols/scripts/take-off-surface_UTM.py
@@ -93,23 +93,23 @@ except Exception as e:
     print(f"TakeOffSurface: CRS Traceback: {traceback.format_exc()}")
     raise
 
-# RUNWAY LAYER SELECTION - Hybrid approach
+# RUNWAY LAYER CENTERLINE SELECTION - Hybrid approach
 try:
     if runway_layer:
         # Use layer from UI
-        print(f"TakeOffSurface: Using runway layer from UI: {runway_layer.name()}")
+        print(f"TakeOffSurface: Using Runway Layer Centerline from UI: {runway_layer.name()}")
         layer = runway_layer
         selection = layer.selectedFeatures()
         if not selection:
             # No selection, use all features
             selection = list(layer.getFeatures())
             if not selection:
-                raise Exception("No features found in runway layer.")
+                raise Exception("No features found in Runway Layer Centerline.")
             print(f"TakeOffSurface: No selection, using first feature from layer")
             selection = [selection[0]]
     else:
-        # ORIGINAL METHOD - Gets the runway layer based on name and selected feature
-        print("TakeOffSurface: No runway layer from UI, searching by name")
+        # ORIGINAL METHOD - Gets the Runway Layer Centerline based on name and selected feature
+        print("TakeOffSurface: No Runway Layer Centerline from UI, searching by name")
         for layer in QgsProject.instance().mapLayers().values():
             if "runway" in layer.name():
                 layer = layer
@@ -120,9 +120,9 @@ try:
                         selection = [selection[0]]
                 break
         else:
-            raise Exception("No runway layer found")
+            raise Exception("No Runway Layer Centerline found")
     
-    print(f"TakeOffSurface: Using runway layer: {layer.name()}")
+    print(f"TakeOffSurface: Using Runway Layer Centerline: {layer.name()}")
     
     # ORIGINAL runway calculations
     rwy_geom = selection[0].geometry()
@@ -131,8 +131,8 @@ try:
     print(f"TakeOffSurface: rwy_length={rwy_length}")
     
 except Exception as e:
-    print(f"TakeOffSurface: Error with runway layer: {e}")
-    iface.messageBar().pushMessage("TakeOffSurface Error", f"Runway layer error: {str(e)}", level=Qgis.Critical)
+    print(f"TakeOffSurface: Error with Runway Layer Centerline: {e}")
+    iface.messageBar().pushMessage("TakeOffSurface Error", f"Runway Layer Centerline error: {str(e)}", level=Qgis.Critical)
     raise
 
 # ORIGINAL ZIHs calculation (kept for compatibility; not used in geometry below)


### PR DESCRIPTION
## Summary

This PR standardizes all user-facing occurrences of "Runway Layer" to "Runway Layer Centerline" to eliminate ambiguity and clearly reference the expected LINE geometry representing runway centerlines. The change spans UI labels and tooltips, validation messages, logs, and exceptions. No functional logic or algorithms were changed.
<img width="421" height="103" alt="image" src="https://github.com/user-attachments/assets/ade3a963-284f-4710-8530-fd9ffe5bffee" />
