### PR TITLE
feat(#103): Block OLS calculations when project CRS is geographic

### DIFF
--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -27,7 +27,10 @@ from .. import logger  # CR-01
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
-from qgis.PyQt.QtWidgets import QApplication, QCheckBox, QComboBox, QDockWidget, QLabel, QLineEdit, QToolTip
+from qgis.PyQt.QtWidgets import (
+    QApplication, QCheckBox, QComboBox, QDockWidget,
+    QLabel, QLineEdit, QMessageBox, QToolTip,
+)
 from ..compat import TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
 
@@ -1326,9 +1329,30 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         except Exception as e:
             self.show_error_message(f"Error starting calculation: {str(e)}")
 
+    def _validate_project_crs(self) -> bool:
+        """Return True if project CRS is projected; show blocking dialog and return False if geographic."""
+        crs = QgsProject.instance().crs()
+        if crs.isGeographic():
+            QMessageBox.critical(
+                self,
+                "Projected Coordinate System Required",
+                f"The QGIS project is using a geographic (non-projected) coordinate system:\n\n"
+                f"  {crs.authid()} — {crs.description()}\n\n"
+                f"OLS calculations require a projected CRS that uses metres as units.\n\n"
+                f"To fix:\n"
+                f"  1. Go to Project → Properties → CRS\n"
+                f"  2. Select a projected CRS (e.g. a UTM zone for your area)\n"
+                f"  3. Re-run the calculation."
+            )
+            return False
+        return True
+
     def validate_layers(self):
         """Validate that required layers are selected with correct geometry types - ULTRA ROBUST VERSION."""
         try:
+            # CRITICAL CHECK 0: Project CRS must be projected (not geographic/lat-lon)
+            if not self._validate_project_crs():
+                return False
 
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()


### PR DESCRIPTION
## Summary

Closes #103.

When a user clicks **Calculate** with the QGIS project set to a geographic
(lat/lon) coordinate system the plugin now shows a **blocking modal dialog**
and aborts the calculation. Previously the scripts ran silently and produced
geometrically wrong output (all coordinates in degrees, not metres).

The check is inserted as the first guard inside `validate_layers()` so it
fires before any layer or geometry validation, and before the
`calculateClicked` signal is emitted to `plugin.py`.

---

## Changes

### `qols/ui/dockwidget.py`

**Import** — `QMessageBox` added to the `QtWidgets` import block (split to
multi-line form to stay within 119 chars):

```python
from qgis.PyQt.QtWidgets import (
    QApplication, QCheckBox, QComboBox, QDockWidget,
    QLabel, QLineEdit, QMessageBox, QToolTip,
)
```

**New method** `_validate_project_crs() -> bool` added immediately before
`validate_layers()`:

```python
def _validate_project_crs(self) -> bool:
    """Return True if project CRS is projected; show blocking dialog and return False if geographic."""
    crs = QgsProject.instance().crs()
    if crs.isGeographic():
        QMessageBox.critical(
            self,
            "Projected Coordinate System Required",
            f"The QGIS project is using a geographic (non-projected) coordinate system:\n\n"
            f"  {crs.authid()} — {crs.description()}\n\n"
            f"OLS calculations require a projected CRS that uses metres as units.\n\n"
            f"To fix:\n"
            f"  1. Go to Project → Properties → CRS\n"
            f"  2. Select a projected CRS (e.g. a UTM zone for your area)\n"
            f"  3. Re-run the calculation."
        )
        return False
    return True
```

`QMessageBox.critical()` opens a **modal dialog** — it blocks until the user
clicks OK, which is the behaviour requested in the issue. The existing
`show_error_message()` (message bar) is intentionally not used here because
it is non-blocking and auto-dismisses.

**`validate_layers()`** — new CRITICAL CHECK 0 added as the very first guard:

```python
def validate_layers(self):
    try:
        # CRITICAL CHECK 0: Project CRS must be projected (not geographic/lat-lon)
        if not self._validate_project_crs():
            return False
        # … existing checks 1–6 …
```

### `tests/test_dockwidget_logic.py`

Two new tests in a new section `# 7. _validate_project_crs`:

| Test | What it verifies |
| --- | --- |
| `test_validate_project_crs_geographic_blocks` | Geographic CRS → returns `False`, `QMessageBox.critical` called once, message contains the CRS auth ID |
| `test_validate_project_crs_projected_passes` | Projected CRS → returns `True`, `QMessageBox.critical` never called |

---

## Commits

| Hash | Message |
| --- | --- |
| `TBD` | feat(#103): block calculations when project CRS is geographic |
