### PR TITLE
fix(#105): Fix selection-not-detected — `eventFilter` Qt6 compat + `selectionChanged` lambda wrapper

### DIFF
--- a/qols/compat.py
+++ b/qols/compat.py
@@ -6,7 +6,7 @@ The rest of the codebase imports from this module instead of
 branching on the Qt version inline.
 """
 
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import Qt, QEvent
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtWidgets import QDialogButtonBox
 from qgis.core import Qgis
@@ -83,6 +83,16 @@ except AttributeError:
     MSG_CRITICAL = Qgis.Critical  # type: ignore[attr-defined]
     MSG_SUCCESS = Qgis.Success  # type: ignore[attr-defined]
 
+# ---------------------------------------------------------------------------
+# QEvent mouse-move type constant
+# Qt5 (PyQt5):  QEvent.MouseMove       (flat attribute on class)
+# Qt6 (PyQt6):  QEvent.Type.MouseMove  (scoped enum)
+# ---------------------------------------------------------------------------
+try:
+    EVENT_MOUSE_MOVE = QEvent.Type.MouseMove
+except AttributeError:
+    EVENT_MOUSE_MOVE = QEvent.MouseMove  # type: ignore[attr-defined]
+
 __all__ = [
     "DOCK_RIGHT", "DOCK_LEFT",
     "BTN_SAVE", "BTN_CANCEL",
@@ -90,4 +100,5 @@ __all__ = [
     "COLOR_LIGHT_GRAY", "COLOR_DARK_GRAY",
     "RENDER_ANTIALIAS",
     "MSG_INFO", "MSG_WARNING", "MSG_CRITICAL", "MSG_SUCCESS",
+    "EVENT_MOUSE_MOVE",
 ]

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -28,7 +28,7 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import QApplication, QCheckBox, QComboBox, QDockWidget, QLabel, QLineEdit, QToolTip
-from ..compat import TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
+from ..compat import TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL, EVENT_MOUSE_MOVE
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
 
 # Load the UI file
@@ -121,6 +121,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         # Track connected layers for selection signals (Issue #59)
         self.connected_runway_layer = None
         self.connected_threshold_layer = None
+        # Lambda slots stored for proper selectionChanged disconnection (Issue #105)
+        self._runway_selection_slot = None
+        self._threshold_selection_slot = None
         # State tracking for dropdown tooltip optimization (BUG-05)
         self._last_runway_count = 0
         self._last_threshold_count = 0
@@ -493,15 +496,23 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
 
-            # Connect to Runway Layer Centerline selection changes
+            # Connect to Runway Layer Centerline selection changes.
+            # Lambda wrapper discards the 3 args emitted by selectionChanged so the
+            # 0-arg update_selection_info slot is called correctly in both Qt5 and Qt6.
             if runway_layer and isinstance(runway_layer, QgsVectorLayer):
-                runway_layer.selectionChanged.connect(self.update_selection_info)
+                self._runway_selection_slot = lambda *_: self.update_selection_info()
+                runway_layer.selectionChanged.connect(self._runway_selection_slot)
                 self.connected_runway_layer = runway_layer
+            else:
+                self._runway_selection_slot = None
 
             # Connect to threshold layer selection changes
             if threshold_layer and isinstance(threshold_layer, QgsVectorLayer):
-                threshold_layer.selectionChanged.connect(self.update_selection_info)
+                self._threshold_selection_slot = lambda *_: self.update_selection_info()
+                threshold_layer.selectionChanged.connect(self._threshold_selection_slot)
                 self.connected_threshold_layer = threshold_layer
+            else:
+                self._threshold_selection_slot = None
 
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
@@ -509,19 +520,25 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
     def disconnect_layer_selection_signals(self):
         """Disconnect from previously connected layer selection signals."""
         try:
-            if self.connected_runway_layer:
+            if self.connected_runway_layer and self._runway_selection_slot:
                 try:
-                    self.connected_runway_layer.selectionChanged.disconnect(self.update_selection_info)
+                    self.connected_runway_layer.selectionChanged.disconnect(
+                        self._runway_selection_slot
+                    )
                 except RuntimeError:
                     pass  # Signal might not be connected
                 self.connected_runway_layer = None
+                self._runway_selection_slot = None
 
-            if self.connected_threshold_layer:
+            if self.connected_threshold_layer and self._threshold_selection_slot:
                 try:
-                    self.connected_threshold_layer.selectionChanged.disconnect(self.update_selection_info)
+                    self.connected_threshold_layer.selectionChanged.disconnect(
+                        self._threshold_selection_slot
+                    )
                 except RuntimeError:
                     pass  # Signal might not be connected
                 self.connected_threshold_layer = None
+                self._threshold_selection_slot = None
 
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
@@ -940,7 +957,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         """Handle events for dropdown hover tooltips - Native QGIS styling only."""
         try:
             # Check if this is a mouse move event in one of our dropdown views
-            if event.type() == event.MouseMove:
+            if event.type() == EVENT_MOUSE_MOVE:
                 # Get the view that received the event
                 if obj == self.runwayLayerCombo.view() or obj == self.thresholdLayerCombo.view():
                     # Get the item under the mouse
@@ -959,7 +976,11 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                             obj.setToolTip(tooltip)
 
                             # Method 2: Force show tooltip at mouse position (native QGIS style)
-                            QToolTip.showText(event.globalPos(), tooltip, obj)
+                            try:
+                                _gpos = event.globalPosition().toPoint()  # Qt6
+                            except AttributeError:
+                                _gpos = event.globalPos()                 # Qt5
+                            QToolTip.showText(_gpos, tooltip, obj)
 
                         return False  # Let the event propagate normally
                     else:


### PR DESCRIPTION
# fix(#105): Fix selection-not-detected — `eventFilter` Qt6 compat + `selectionChanged` lambda wrapper

## Summary
<img width="1406" height="1032" alt="{56561A35-C902-40CB-998A-809A74808F8F}" src="https://github.com/user-attachments/assets/61b88dc2-c7cd-41ee-8142-79d12ce3c80b" />

Closes #105.

Two bugs caused the "Selection not detected" symptom on QGIS4 (Qt6):

1. **`eventFilter` flooded the log** with `WARNING Unhandled error: 'QEvent' object has no attribute 'MouseMove'` on every event — hundreds per second. The comparison `event.type() == event.MouseMove` fails in Qt6 because the enum is scoped to `QEvent.Type.MouseMove`. Hover tooltips on the layer combo dropdowns were completely broken.

2. **`selectionChanged` slot was never called** when features were selected in the QGIS canvas. `QgsVectorLayer.selectionChanged` emits 3 C++ args (`selected`, `deselected`, `clearAndSelect`). The `update_selection_info` slot was decorated `@pyqtSlot()` (0 args), registering it as a C++ slot `void()`. In PyQt6, overload resolution does not call a `void()` slot when the signal emits 3 args — the slot was silently never invoked.

---

## Changes

### `qols/compat.py`

**New shim** `EVENT_MOUSE_MOVE` — Qt5/Qt6 compatible `QEvent` mouse-move type constant:

```python
try:
    EVENT_MOUSE_MOVE = QEvent.Type.MouseMove   # Qt6
except AttributeError:
    EVENT_MOUSE_MOVE = QEvent.MouseMove        # Qt5
```

Added to `__all__`.

### `qols/ui/dockwidget.py`

**Import** — `EVENT_MOUSE_MOVE` added to `from ..compat import`.

**`__init__`** — two new instance attributes for lambda teardown:
```python
self._runway_selection_slot = None
self._threshold_selection_slot = None
```

**`eventFilter`** (line 943) — replaced `event.MouseMove` with the compat shim:
```python
if event.type() == EVENT_MOUSE_MOVE:
```

**`eventFilter`** (line 962) — `event.globalPos()` removed in Qt6; added Qt5/Qt6 fallback:
```python
try:
    _gpos = event.globalPosition().toPoint()  # Qt6
except AttributeError:
    _gpos = event.globalPos()                 # Qt5
QToolTip.showText(_gpos, tooltip, obj)
```

**`connect_layer_selection_signals`** — replaced direct `.connect(self.update_selection_info)` with
lambda wrappers that explicitly discard the 3 signal args:
```python
self._runway_selection_slot = lambda *_: self.update_selection_info()
runway_layer.selectionChanged.connect(self._runway_selection_slot)
```
Same pattern for threshold. Stored on `self` so `disconnect_layer_selection_signals` can
properly remove them.

**`disconnect_layer_selection_signals`** — now disconnects via the stored lambda reference
and resets both the layer tracker and the slot tracker to `None`.

### `tests/test_dockwidget_logic.py`

Two new tests in section `# 8. eventFilter / selectionChanged — issue #105`:

| Test | What it verifies |
| --- | --- |
| `test_eventfilter_mousemove_uses_compat_shim` | Qt6-style event (no `MouseMove` attr) → no "MouseMove" warning logged; compat shim is used |
| `test_connect_selection_signals_lambda_stored` | After `connect_layer_selection_signals`, `_runway_selection_slot` is stored; calling it with 3 args triggers `update_selection_info` |

---

## Commits

| Hash | Message |
| --- | --- |
| `TBD` | fix(#105): fix eventFilter Qt6 compat and selectionChanged lambda wrapper |
