### PR TITLE
feat(#107,#108,#109): New OLS concept — Current/New selector, OFS Approach, OES Transitional

### DIFF
--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -231,6 +231,10 @@ class QOLS:
                 self.execute_takeoff_surface(params)
             elif st == SurfaceType.TRANSITIONAL:
                 self.execute_transitional_surface(params)
+            elif st == SurfaceType.NEW_OLS_OFS_APPROACH:
+                self.execute_new_ols_ofs_approach(params)
+            elif st == SurfaceType.NEW_OLS_OES_TRANSITIONAL:
+                self.execute_new_ols_oes_transitional(params)
             else:
                 raise ValueError(f"Unhandled surface type: {st!r}")
 
@@ -275,6 +279,14 @@ class QOLS:
 
     def execute_transitional_surface(self, params):
         script_path = os.path.join(self.plugin_dir, 'scripts', 'TransitionalSurface_UTM.py')
+        self.execute_script(script_path, params)
+
+    def execute_new_ols_ofs_approach(self, params):
+        script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-ofs-approach-UTM.py')
+        self.execute_script(script_path, params)
+
+    def execute_new_ols_oes_transitional(self, params):
+        script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-transitional-UTM.py')
         self.execute_script(script_path, params)
 
     def execute_combined_inner_conical_surface(self, params):

--- a/qols/scripts/new-ols-oes-transitional-UTM.py
+++ b/qols/scripts/new-ols-oes-transitional-UTM.py
@@ -1,0 +1,251 @@
+"""
+New OLS Concept — OES Transitional Surface
+Two triangular wings flanking the OFS Approach surface, per ICAO Figure 4-1.
+
+Geometry (plan view, one wing):
+  near_inner  — approach inner edge at start, Z = start_elevation
+  near_outer  — start + lateral_near outward, Z = cap_elevation
+  far_vertex  — approach inner edge at d_cap, Z = cap_elevation
+where:
+  d_cap        = cap_height / approach_slope   (≈ 1 802 m for 3.33 %, 60 m cap)
+  lateral_near = cap_height / trans_slope      (≈ 300 m for 20 % slope)
+
+Procedure to be used in Projected Coordinate System Only.
+"""
+myglobals = set(globals().keys())
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from math import sqrt, hypot
+
+_script_success = False
+
+
+def _normalize_polyline_points(geometry):
+    if geometry is None or geometry.isEmpty():
+        raise Exception("Empty geometry provided for runway centerline.")
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            raise Exception("Empty MultiLineString geometry.")
+
+        def part_len(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                dx = pts[i].x() - pts[i - 1].x()
+                dy = pts[i].y() - pts[i - 1].y()
+                total += sqrt(dx * dx + dy * dy)
+            return total
+
+        return [QgsPoint(p) for p in max(parts, key=part_len)]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [QgsPoint(p) for p in poly]
+    raise Exception("Line geometry cannot be converted to a polyline.")
+
+
+# ---------------------------------------------------------------------------
+# Parameter extraction
+# ---------------------------------------------------------------------------
+try:
+    width_m = globals().get('width_m', 175.0)
+    start_elevation_m = globals().get('start_elevation_m', 0.0)
+    highest_thr_elev_m = globals().get('highest_thr_elev_m', 0.0)
+    slope_pct = globals().get('slope_pct', 20.0)
+    cap_height_m = globals().get('cap_height_m', 60.0)
+    approach_slope_pct = globals().get('approach_slope_pct', 3.33)
+    divergence_ratio = globals().get('divergence_ratio', 0.10)
+    distance_from_threshold_m = globals().get('distance_from_threshold_m', 60.0)
+    direction = globals().get('direction', 0)
+    runway_layer = globals().get('runway_layer', None)
+    threshold_layer = globals().get('threshold_layer', None)
+    use_selected_feature = globals().get('use_selected_feature', True)
+
+    slope_ratio = slope_pct / 100.0
+    approach_slope = approach_slope_pct / 100.0
+    cap_elevation = highest_thr_elev_m + cap_height_m
+    half_inner = width_m / 2.0
+
+    height_to_cap = cap_elevation - start_elevation_m
+    if height_to_cap <= 0 or approach_slope <= 0 or slope_ratio <= 0:
+        raise Exception(
+            f"OES Transitional: degenerate parameters — "
+            f"height_to_cap={height_to_cap:.1f}, approach_slope={approach_slope:.4f}"
+        )
+
+    d_cap = height_to_cap / approach_slope
+    lateral_near = height_to_cap / slope_ratio
+    far_half_width = half_inner + d_cap * divergence_ratio
+
+    print(
+        f"QOLS New OLS OES: slope={slope_pct}%, cap_elev={cap_elevation:.1f}m, "
+        f"d_cap={d_cap:.1f}m, lateral_near={lateral_near:.1f}m, "
+        f"far_half_width={far_half_width:.1f}m"
+    )
+except Exception as e:
+    print(f"QOLS New OLS OES: Error getting parameters: {e}")
+    raise
+
+map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+
+# ---------------------------------------------------------------------------
+# Runway layer
+# ---------------------------------------------------------------------------
+try:
+    if runway_layer is None:
+        raise Exception("No Runway Layer Centerline provided.")
+    if use_selected_feature:
+        selection = runway_layer.selectedFeatures()
+        if not selection:
+            raise Exception("No runway features selected.")
+    else:
+        selection = runway_layer.selectedFeatures() or list(runway_layer.getFeatures())
+        if not selection:
+            raise Exception("No features found in Runway Layer.")
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+for feat in selection:
+    line_pts = _normalize_polyline_points(feat.geometry())
+    break
+
+start_point = line_pts[0]
+end_point = line_pts[-1]
+base_azimuth_deg = start_point.azimuth(end_point)
+
+# ---------------------------------------------------------------------------
+# Threshold layer
+# ---------------------------------------------------------------------------
+try:
+    if threshold_layer is None:
+        raise Exception("No threshold layer provided.")
+    if use_selected_feature:
+        threshold_sel = threshold_layer.selectedFeatures()
+        if not threshold_sel:
+            raise Exception("No threshold features selected.")
+    else:
+        threshold_sel = threshold_layer.selectedFeatures() or list(threshold_layer.getFeatures())
+        if not threshold_sel:
+            raise Exception("No features found in threshold layer.")
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+thr_geom = threshold_sel[0].geometry().asPoint()
+thr_point = QgsPoint(thr_geom)
+thr_point.addZValue(start_elevation_m)
+
+dist_to_start = hypot(thr_point.x() - start_point.x(), thr_point.y() - start_point.y())
+dist_to_end = hypot(thr_point.x() - end_point.x(), thr_point.y() - end_point.y())
+selected_end = 'start' if dist_to_start <= dist_to_end else 'end'
+outward_azimuth = base_azimuth_deg if selected_end == 'start' else (base_azimuth_deg + 180) % 360
+azimuth = (outward_azimuth + 180) % 360 if direction == 0 else outward_azimuth
+
+print(f"QOLS New OLS OES: azimuth={azimuth:.2f}°, selected_end={selected_end}")
+
+# ---------------------------------------------------------------------------
+# Transitional surface geometry — two triangular wings (ICAO Figure 4-1)
+#
+# At the near end (approach inner edge start):
+#   inner point: half_inner from centreline, Z = start_elevation_m
+#   outer point: half_inner + lateral_near from centreline, Z = cap_elevation
+#
+# At d_cap along the approach, the approach elevation = cap_elevation → wings
+# converge to a single point at approach-edge width from centreline, Z = cap_elevation.
+#
+# Each wing is a triangle: [near_inner, near_outer, far_vertex].
+# ---------------------------------------------------------------------------
+
+# Origin: start of approach inner edge
+pt_start = thr_point.project(distance_from_threshold_m, azimuth)
+pt_start.setZ(start_elevation_m)
+
+# Far convergence vertex (approach elevation = cap)
+pt_far_axis = pt_start.project(d_cap, azimuth)
+pt_far_axis.setZ(cap_elevation)
+
+# Left wing
+near_inner_l = pt_start.project(half_inner, azimuth + 90)
+near_inner_l.setZ(start_elevation_m)
+
+near_outer_l = pt_start.project(half_inner + lateral_near, azimuth + 90)
+near_outer_l.setZ(cap_elevation)
+
+far_l = pt_far_axis.project(far_half_width, azimuth + 90)
+far_l.setZ(cap_elevation)
+
+# Right wing
+near_inner_r = pt_start.project(half_inner, azimuth - 90)
+near_inner_r.setZ(start_elevation_m)
+
+near_outer_r = pt_start.project(half_inner + lateral_near, azimuth - 90)
+near_outer_r.setZ(cap_elevation)
+
+far_r = pt_far_axis.project(far_half_width, azimuth - 90)
+far_r.setZ(cap_elevation)
+
+# ---------------------------------------------------------------------------
+# Memory layer
+# ---------------------------------------------------------------------------
+layer_name = "NewOLS_OES_Transitional"
+oes_layer = QgsVectorLayer("PolygonZ?crs=" + map_srid, layer_name, "memory")
+oes_layer.dataProvider().addAttributes([
+    QgsField('ID', QVariant.Int),
+    QgsField('SurfaceName', QVariant.String),
+    QgsField('side', QVariant.String),
+    QgsField('slope_pct', QVariant.Double),
+    QgsField('cap_elevation_m', QVariant.Double),
+    QgsField('d_cap_m', QVariant.Double),
+    QgsField('lateral_near_m', QVariant.Double),
+])
+oes_layer.updateFields()
+
+feat_l = QgsFeature()
+feat_l.setGeometry(QgsPolygon(QgsLineString([near_inner_l, near_outer_l, far_l, near_inner_l])))
+feat_l.setAttributes([
+    1, 'New OLS OES Transitional', 'left',
+    slope_pct, round(cap_elevation, 3), round(d_cap, 1), round(lateral_near, 1),
+])
+
+feat_r = QgsFeature()
+feat_r.setGeometry(QgsPolygon(QgsLineString([near_inner_r, far_r, near_outer_r, near_inner_r])))
+feat_r.setAttributes([
+    2, 'New OLS OES Transitional', 'right',
+    slope_pct, round(cap_elevation, 3), round(d_cap, 1), round(lateral_near, 1),
+])
+
+oes_layer.dataProvider().addFeatures([feat_l, feat_r])
+
+QgsProject.instance().addMapLayers([oes_layer])
+oes_layer.renderer().symbol().setColor(QColor("#87CEEB"))  # sky blue
+oes_layer.renderer().symbol().setOpacity(0.4)
+oes_layer.triggerRepaint()
+
+oes_layer.selectAll()
+canvas = iface.mapCanvas()
+canvas.zoomToSelected(oes_layer)
+oes_layer.removeSelection()
+sc = canvas.scale()
+if sc < 20000:
+    sc = 20000
+canvas.zoomScale(sc)
+
+print(
+    f"QOLS New OLS OES: wings created — d_cap={d_cap:.1f}m, "
+    f"lateral_near={lateral_near:.1f}m, cap={cap_elevation:.1f}m"
+)
+iface.messageBar().pushMessage(
+    "QOLS Success",
+    f"New OLS OES Transitional (slope {slope_pct}%, cap +{cap_height_m}m, extent {d_cap:.0f}m) "
+    f"calculated successfully",
+    level=MSG_SUCCESS,
+)
+_script_success = True
+
+for _g in set(globals().keys()).difference(myglobals):
+    if _g not in ('myglobals', '_script_success'):
+        del globals()[_g]

--- a/qols/scripts/new-ols-ofs-approach-UTM.py
+++ b/qols/scripts/new-ols-ofs-approach-UTM.py
@@ -1,0 +1,276 @@
+"""
+New OLS Concept — OFS Approach Surface
+Single-section trapezoidal approach surface per ICAO New OLS concept.
+Uses ADG group classification instead of current OLS classification + code.
+Procedure to be used in Projected Coordinate System Only.
+"""
+myglobals = set(globals().keys())
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from math import sqrt, hypot
+import json
+
+_script_success = False
+
+
+def _normalize_polyline_points(geometry):
+    if geometry is None or geometry.isEmpty():
+        raise Exception("Empty geometry provided for runway centerline.")
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            raise Exception("Empty MultiLineString geometry.")
+
+        def part_len(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                dx = pts[i].x() - pts[i - 1].x()
+                dy = pts[i].y() - pts[i - 1].y()
+                total += sqrt(dx * dx + dy * dy)
+            return total
+
+        return [QgsPoint(p) for p in max(parts, key=part_len)]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [QgsPoint(p) for p in poly]
+    raise Exception("Line geometry cannot be converted to a polyline.")
+
+
+# ---------------------------------------------------------------------------
+# Parameter extraction
+# ---------------------------------------------------------------------------
+try:
+    rwy_type = globals().get('rwy_type', 'Instrument')
+    adg = globals().get('adg', 'III')
+    runway_width_m = globals().get('runway_width_m', 45.0)
+    distance_from_threshold_m = globals().get('distance_from_threshold_m', 60.0)
+    inner_edge_m = globals().get('inner_edge_m', 175.0)
+    divergence_ratio = globals().get('divergence_ratio', 0.10)
+    length_m = globals().get('length_m', 4500.0)
+    slope_pct = globals().get('slope_pct', 3.33)
+    start_elevation_m = globals().get('start_elevation_m', 0.0)
+    end_elevation_m = globals().get('end_elevation_m', 0.0)
+    arp_elevation_m = globals().get('arp_elevation_m', 0.0)
+    direction = globals().get('direction', 0)
+    runway_layer = globals().get('runway_layer', None)
+    threshold_layer = globals().get('threshold_layer', None)
+    use_selected_feature = globals().get('use_selected_feature', True)
+    contour_interval_m = int(globals().get('contour_interval_m', 0))
+
+    slope_ratio = slope_pct / 100.0
+
+    print(
+        f"QOLS New OLS OFS: rwy_type={rwy_type}, adg={adg}, "
+        f"inner_edge={inner_edge_m}m, length={length_m}m, "
+        f"slope={slope_pct}%, dist_thr={distance_from_threshold_m}m"
+    )
+except Exception as e:
+    print(f"QOLS New OLS OFS: Error getting parameters: {e}")
+    raise
+
+map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+
+# ---------------------------------------------------------------------------
+# Runway layer
+# ---------------------------------------------------------------------------
+try:
+    if runway_layer is None:
+        raise Exception("No Runway Layer Centerline provided.")
+    if use_selected_feature:
+        selection = runway_layer.selectedFeatures()
+        if not selection:
+            raise Exception("No runway features selected.")
+    else:
+        selection = runway_layer.selectedFeatures() or list(runway_layer.getFeatures())
+        if not selection:
+            raise Exception("No features found in Runway Layer.")
+    rwy_geom = selection[0].geometry()
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+for feat in selection:
+    line_pts = _normalize_polyline_points(feat.geometry())
+    break
+
+start_point = line_pts[0]
+end_point = line_pts[-1]
+base_azimuth_deg = start_point.azimuth(end_point)
+
+# ---------------------------------------------------------------------------
+# Threshold layer
+# ---------------------------------------------------------------------------
+try:
+    if threshold_layer is None:
+        raise Exception("No threshold layer provided.")
+    if use_selected_feature:
+        threshold_sel = threshold_layer.selectedFeatures()
+        if not threshold_sel:
+            raise Exception("No threshold features selected.")
+    else:
+        threshold_sel = threshold_layer.selectedFeatures() or list(threshold_layer.getFeatures())
+        if not threshold_sel:
+            raise Exception("No features found in threshold layer.")
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+thr_geom = threshold_sel[0].geometry().asPoint()
+new_geom = QgsPoint(thr_geom)
+new_geom.addZValue(start_elevation_m)
+
+dist_to_start = hypot(new_geom.x() - start_point.x(), new_geom.y() - start_point.y())
+dist_to_end = hypot(new_geom.x() - end_point.x(), new_geom.y() - end_point.y())
+selected_end = 'start' if dist_to_start <= dist_to_end else 'end'
+outward_azimuth = base_azimuth_deg if selected_end == 'start' else (base_azimuth_deg + 180) % 360
+azimuth = (outward_azimuth + 180) % 360 if direction == 0 else outward_azimuth
+
+print(f"QOLS New OLS OFS: azimuth={azimuth:.2f}°, selected_end={selected_end}")
+
+# ---------------------------------------------------------------------------
+# Surface geometry — single trapezoidal section
+# ---------------------------------------------------------------------------
+pt_thr = new_geom
+
+# Inner edge (at distance_from_threshold_m)
+pt_inner = pt_thr.project(distance_from_threshold_m, azimuth)
+pt_inner.setZ(start_elevation_m)
+half_inner = inner_edge_m / 2.0
+pt_inner_l = pt_inner.project(half_inner, azimuth + 90)
+pt_inner_r = pt_inner.project(half_inner, azimuth - 90)
+
+# Outer edge (at inner + length_m)
+height_outer = start_elevation_m + length_m * slope_ratio
+pt_outer = pt_inner.project(length_m, azimuth)
+pt_outer.setZ(height_outer)
+half_outer = half_inner + length_m * divergence_ratio
+pt_outer_l = pt_outer.project(half_outer, azimuth + 90)
+pt_outer_r = pt_outer.project(half_outer, azimuth - 90)
+
+# Assign Z to corners
+for pt, z in [
+    (pt_inner_l, start_elevation_m), (pt_inner_r, start_elevation_m),
+    (pt_outer_l, height_outer), (pt_outer_r, height_outer),
+]:
+    pt.addZValue(z) if not pt.is3D() else pt.setZ(z)
+
+# ---------------------------------------------------------------------------
+# Memory layer
+# ---------------------------------------------------------------------------
+layer_name = f"NewOLS_OFS_Approach_{rwy_type}_{adg}"
+approach_layer = QgsVectorLayer("PolygonZ?crs=" + map_srid, layer_name, "memory")
+approach_layer.dataProvider().addAttributes([
+    QgsField('ID', QVariant.String),
+    QgsField('SurfaceName', QVariant.String),
+    QgsField('rwy_type', QVariant.String),
+    QgsField('adg', QVariant.String),
+    QgsField('slope_pct', QVariant.Double),
+    QgsField('surface_start_elev', QVariant.Double),
+    QgsField('surface_end_elev', QVariant.Double),
+    QgsField('params_json', QVariant.String),
+])
+approach_layer.updateFields()
+
+_params_json = json.dumps({
+    'rwy_type': rwy_type,
+    'adg': adg,
+    'runway_width_m': runway_width_m,
+    'inner_edge_m': inner_edge_m,
+    'distance_from_threshold_m': distance_from_threshold_m,
+    'divergence_pct': round(divergence_ratio * 100, 3),
+    'length_m': length_m,
+    'slope_pct': slope_pct,
+    'start_elevation_m': round(start_elevation_m, 3),
+    'end_elevation_m': round(end_elevation_m, 3),
+})
+
+feat = QgsFeature()
+feat.setGeometry(QgsPolygon(QgsLineString([pt_inner_r, pt_inner_l, pt_outer_l, pt_outer_r, pt_inner_r])))
+feat.setAttributes([
+    '1', f'New OLS OFS Approach ({rwy_type} / ADG {adg})',
+    rwy_type, adg, slope_pct,
+    round(start_elevation_m, 3), round(height_outer, 3), _params_json,
+])
+approach_layer.dataProvider().addFeatures([feat])
+
+QgsProject.instance().addMapLayers([approach_layer])
+approach_layer.renderer().symbol().setColor(QColor("#FF69B4"))  # pink — matches diagram
+approach_layer.renderer().symbol().setOpacity(0.4)
+approach_layer.triggerRepaint()
+
+approach_layer.selectAll()
+canvas = iface.mapCanvas()
+canvas.zoomToSelected(approach_layer)
+approach_layer.removeSelection()
+sc = canvas.scale()
+if sc < 20000:
+    sc = 20000
+canvas.zoomScale(sc)
+
+# ---------------------------------------------------------------------------
+# Contour layer (optional)
+# ---------------------------------------------------------------------------
+if contour_interval_m > 0 and slope_ratio > 0:
+    import importlib.util as _ilu
+    import os as _os
+    import sys as _sys
+    _utils_path = _os.path.join(_os.path.dirname(__file__), '_contour_utils.py')
+    _cu_spec = _ilu.spec_from_file_location('_contour_utils', _utils_path)
+    _cu = _ilu.module_from_spec(_cu_spec)
+    _sys.modules['_contour_utils'] = _cu
+    _cu_spec.loader.exec_module(_cu)
+
+    _elevs = _cu.contour_elevations(start_elevation_m, height_outer, contour_interval_m)
+    _all_specs = _cu.contour_specs_for_linear_section(
+        z_section_start=start_elevation_m,
+        z_section_end=height_outer,
+        slope=slope_ratio,
+        d_offset=0.0,
+        near_half_width=half_inner,
+        divergence_ratio=divergence_ratio,
+        elevations=_elevs,
+    )
+    if _all_specs:
+        _clayer = QgsVectorLayer(
+            "LineStringZ?crs=" + map_srid,
+            f"NewOLS_OFS_Approach_Contours_{adg}",
+            "memory",
+        )
+        _clayer.dataProvider().addAttributes([
+            QgsField('ID', QVariant.Int),
+            QgsField('surface_elevation', QVariant.Double),
+        ])
+        _clayer.updateFields()
+        _cfeats = []
+        for _i, _spec in enumerate(_all_specs):
+            _ctr = pt_inner.project(_spec.distance_from_origin, azimuth)
+            _l2d = _ctr.project(_spec.half_width, azimuth + 90)
+            _r2d = _ctr.project(_spec.half_width, azimuth - 90)
+            _lpt = QgsPoint(_l2d.x(), _l2d.y(), _spec.elevation)
+            _rpt = QgsPoint(_r2d.x(), _r2d.y(), _spec.elevation)
+            _cf = QgsFeature()
+            _cf.setGeometry(QgsGeometry(QgsLineString([_lpt, _rpt])))
+            _cf.setAttributes([_i + 1, _spec.elevation])
+            _cfeats.append(_cf)
+        _clayer.dataProvider().addFeatures(_cfeats)
+        _cu.apply_contour_style(_clayer, __file__)
+        QgsProject.instance().addMapLayers([_clayer])
+        _clayer.triggerRepaint()
+        print(f"QOLS New OLS OFS: {len(_cfeats)} contour lines at {contour_interval_m} m")
+
+print(f"QOLS New OLS OFS: Approach surface created — {layer_name}")
+iface.messageBar().pushMessage(
+    "QOLS Success",
+    f"New OLS OFS Approach ({rwy_type} / ADG {adg}) calculated successfully",
+    level=MSG_SUCCESS,
+)
+_script_success = True
+
+# Clean up globals
+for _g in set(globals().keys()).difference(myglobals):
+    if _g not in ('myglobals', '_script_success'):
+        del globals()[_g]

--- a/qols/surface_types.py
+++ b/qols/surface_types.py
@@ -30,6 +30,9 @@ class SurfaceType(str, Enum):
     OUTER_HORIZONTAL = "Outer Horizontal"
     TAKEOFF = "Take-Off Surface"
     TRANSITIONAL = "Transitional Surface"
+    # New OLS concept (ICAO approved) — dispatched by concept-tab index, not tab text
+    NEW_OLS_OFS_APPROACH = "New OLS - Approach"
+    NEW_OLS_OES_TRANSITIONAL = "New OLS - Transitional"
 
     @classmethod
     def from_tab_text(cls, text: str) -> "SurfaceType":

--- a/qols/surfaces/new_ols_approach.py
+++ b/qols/surfaces/new_ols_approach.py
@@ -1,0 +1,207 @@
+"""New OLS concept — Approach Surface ICAO defaults.
+
+Tables 4-1 (Non-instrument runways) and 4-2 (Instrument runways) keyed by
+Aeroplane Design Group (ADG: I, IIA-IIB, IIC, III, IV, V) instead of the
+current OLS classification + code scheme.
+
+Inner edge lengths have width-conditional adjustments per ICAO footnotes.
+``slope_pct`` is returned as a percentage (e.g. 3.33), NOT as a ratio, so the
+UI can display it directly as an editable field — the geometry script divides
+by 100 before use.
+"""
+from typing import Dict
+
+# ---------------------------------------------------------------------------
+# ADG group constants
+# ---------------------------------------------------------------------------
+ADG_I = "I"
+ADG_IIA_IIB = "IIA-IIB"
+ADG_IIC = "IIC"
+ADG_III = "III"
+ADG_IV = "IV"
+ADG_V = "V"
+
+ADG_GROUPS = [ADG_I, ADG_IIA_IIB, ADG_IIC, ADG_III, ADG_IV, ADG_V]
+
+RWY_NON_INSTRUMENT = "Non-instrument"
+RWY_INSTRUMENT = "Instrument"
+
+RWY_TYPES = [RWY_NON_INSTRUMENT, RWY_INSTRUMENT]
+
+# ---------------------------------------------------------------------------
+# Table 4-1  Non-instrument runways
+# ---------------------------------------------------------------------------
+_DIST_THR_NI: Dict[str, float] = {
+    ADG_I:       30.0,
+    ADG_IIA_IIB: 60.0,
+    ADG_IIC:     60.0,
+    ADG_III:     60.0,
+    ADG_IV:      60.0,
+    ADG_V:       60.0,
+}
+
+_INNER_EDGE_BASE_NI: Dict[str, float] = {
+    ADG_I:        60.0,
+    ADG_IIA_IIB:  80.0,
+    ADG_IIC:     100.0,
+    ADG_III:     125.0,
+    ADG_IV:      135.0,
+    ADG_V:       150.0,
+}
+
+_LENGTH_NI: Dict[str, float] = {
+    ADG_I:       1600.0,
+    ADG_IIA_IIB: 2500.0,
+    ADG_IIC:     2500.0,
+    ADG_III:     2500.0,
+    ADG_IV:      2500.0,
+    ADG_V:       2500.0,
+}
+
+_SLOPE_PCT_NI: Dict[str, float] = {
+    ADG_I:       5.0,
+    ADG_IIA_IIB: 4.0,
+    ADG_IIC:     3.33,
+    ADG_III:     3.33,
+    ADG_IV:      3.33,
+    ADG_V:       3.33,
+}
+
+# ---------------------------------------------------------------------------
+# Table 4-2  Instrument runways
+# ---------------------------------------------------------------------------
+_DIST_THR_I: Dict[str, float] = {
+    ADG_I:       60.0,
+    ADG_IIA_IIB: 60.0,
+    ADG_IIC:     60.0,
+    ADG_III:     60.0,
+    ADG_IV:      60.0,
+    ADG_V:       60.0,
+}
+
+_INNER_EDGE_BASE_I: Dict[str, float] = {
+    ADG_I:       110.0,
+    ADG_IIA_IIB: 125.0,
+    ADG_IIC:     155.0,
+    ADG_III:     175.0,
+    ADG_IV:      185.0,
+    ADG_V:       200.0,
+}
+
+_LENGTH_I: Dict[str, float] = {
+    ADG_I:       4500.0,
+    ADG_IIA_IIB: 4500.0,
+    ADG_IIC:     4500.0,
+    ADG_III:     4500.0,
+    ADG_IV:      4500.0,
+    ADG_V:       4500.0,
+}
+
+_SLOPE_PCT_I: Dict[str, float] = {
+    ADG_I:       3.33,
+    ADG_IIA_IIB: 3.33,
+    ADG_IIC:     3.33,
+    ADG_III:     3.33,
+    ADG_IV:      3.33,
+    ADG_V:       3.33,
+}
+
+# Divergence is 10 % for all groups and both runway types
+_DIVERGENCE_PCT = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Width-based inner edge footnote adjustments
+# ---------------------------------------------------------------------------
+
+def get_inner_edge_adjusted(adg: str, rwy_type: str, runway_width_m: float) -> float:
+    """Return the inner edge length after applying ICAO width-based footnote adjustments.
+
+    Args:
+        adg: Aeroplane Design Group string (e.g. ``"I"``, ``"IIA-IIB"``).
+        rwy_type: ``RWY_NON_INSTRUMENT`` or ``RWY_INSTRUMENT``.
+        runway_width_m: Runway pavement width in metres.
+
+    Returns:
+        Adjusted inner edge length in metres.
+    """
+    w = float(runway_width_m)
+    if rwy_type == RWY_NON_INSTRUMENT:
+        base = _INNER_EDGE_BASE_NI.get(adg, 125.0)
+        if adg == ADG_I:
+            if w > 30.0:
+                return 100.0
+            if w > 23.0:
+                return 80.0
+        elif adg == ADG_IIA_IIB:
+            if w > 45.0:
+                return 110.0
+            if w > 30.0:
+                return 100.0
+        elif adg == ADG_IIC:
+            if w > 45.0:
+                return 110.0
+        return base
+    else:  # RWY_INSTRUMENT
+        base = _INNER_EDGE_BASE_I.get(adg, 175.0)
+        if adg == ADG_I:
+            if w > 30.0:
+                return 125.0
+        elif adg == ADG_IIA_IIB:
+            if w > 30.0 and w <= 45.0:
+                return 140.0
+        elif adg == ADG_IIC:
+            if w <= 30.0:
+                return 140.0
+        return base
+
+
+def get_new_ols_approach_defaults(
+    rwy_type: str,
+    adg: str,
+    runway_width_m: float,
+) -> Dict[str, float]:
+    """Return New OLS Approach Surface defaults for the given ADG group and runway type.
+
+    Args:
+        rwy_type: ``"Non-instrument"`` or ``"Instrument"``.
+        adg: Aeroplane Design Group (``"I"``, ``"IIA-IIB"``, ``"IIC"``,
+             ``"III"``, ``"IV"``, ``"V"``).
+        runway_width_m: Runway width in metres — used for inner edge footnote adjustments.
+
+    Returns:
+        Dict with keys:
+
+        * ``distance_from_threshold_m`` — float
+        * ``inner_edge_m``              — float (footnote-adjusted)
+        * ``divergence_pct``            — float (always 10.0)
+        * ``length_m``                  — float
+        * ``slope_pct``                 — float (as %, e.g. 3.33 — divide by 100 in scripts)
+    """
+    if rwy_type == RWY_NON_INSTRUMENT:
+        dist = _DIST_THR_NI.get(adg, 60.0)
+        length = _LENGTH_NI.get(adg, 2500.0)
+        slope = _SLOPE_PCT_NI.get(adg, 3.33)
+    else:
+        dist = _DIST_THR_I.get(adg, 60.0)
+        length = _LENGTH_I.get(adg, 4500.0)
+        slope = _SLOPE_PCT_I.get(adg, 3.33)
+
+    inner_edge = get_inner_edge_adjusted(adg, rwy_type, runway_width_m)
+
+    return {
+        'distance_from_threshold_m': dist,
+        'inner_edge_m': inner_edge,
+        'divergence_pct': _DIVERGENCE_PCT,
+        'length_m': length,
+        'slope_pct': slope,
+    }
+
+
+__all__ = [
+    'ADG_I', 'ADG_IIA_IIB', 'ADG_IIC', 'ADG_III', 'ADG_IV', 'ADG_V',
+    'ADG_GROUPS',
+    'RWY_NON_INSTRUMENT', 'RWY_INSTRUMENT', 'RWY_TYPES',
+    'get_inner_edge_adjusted',
+    'get_new_ols_approach_defaults',
+]

--- a/qols/surfaces/new_ols_transitional.py
+++ b/qols/surfaces/new_ols_transitional.py
@@ -1,0 +1,33 @@
+"""New OLS concept — OES Transitional Surface defaults.
+
+Per ICAO New OLS concept:
+- Slope: 20 % default, user-editable.
+- Upper edge: 60 m above the elevation of the highest threshold.
+- Width: derived from the OFS Approach inner edge.
+"""
+from typing import Dict
+
+DEFAULT_SLOPE_PCT: float = 20.0
+DEFAULT_CAP_HEIGHT_M: float = 60.0
+
+
+def get_new_ols_transitional_defaults() -> Dict[str, float]:
+    """Return New OLS OES Transitional Surface defaults.
+
+    Returns:
+        Dict with keys:
+
+        * ``slope_pct``     — float (as %, e.g. 20.0 — divide by 100 in scripts)
+        * ``cap_height_m``  — float (upper edge above highest THR, always 60 m)
+    """
+    return {
+        'slope_pct': DEFAULT_SLOPE_PCT,
+        'cap_height_m': DEFAULT_CAP_HEIGHT_M,
+    }
+
+
+__all__ = [
+    'DEFAULT_SLOPE_PCT',
+    'DEFAULT_CAP_HEIGHT_M',
+    'get_new_ols_transitional_defaults',
+]

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -22,12 +22,17 @@ from ..surfaces.icao import (
 )
 from ..rules import manager as rule_mgr
 from ..surfaces.approach import get_approach_defaults as icao_get_approach_defaults
+from ..surfaces.new_ols_approach import get_new_ols_approach_defaults
+from ..surfaces.new_ols_transitional import get_new_ols_transitional_defaults
 from ..surface_types import SurfaceType
 from .. import logger  # CR-01
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
-from qgis.PyQt.QtWidgets import QApplication, QCheckBox, QComboBox, QDockWidget, QLabel, QLineEdit, QToolTip
+from qgis.PyQt.QtWidgets import (
+    QApplication, QCheckBox, QComboBox, QDialog, QDockWidget,
+    QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
+)
 from ..compat import TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL, EVENT_MOUSE_MOVE
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
 
@@ -89,6 +94,23 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         'spin_ZE_transitional':      2546.5,
         'spin_ARPH_transitional':    2548.0,
         'spin_Tslope_transitional':    14.3,
+        # New OLS OFS Approach (#108)
+        'spin_rwyWidth_ofs':          45.0,
+        'spin_distThr_ofs':           60.0,
+        'spin_innerEdge_ofs':        155.0,
+        'spin_divergence_ofs':        10.0,
+        'spin_length_ofs':          4500.0,
+        'spin_slope_ofs':             3.33,
+        'spin_Z0_ofs':             2548.0,
+        'spin_ZE_ofs':             2546.5,
+        'spin_ARPH_ofs':           2548.0,
+        'spin_contour_interval_ofs':  10.0,
+        # New OLS OES Transitional (#109)
+        'spin_widthApp_oes':         155.0,
+        'spin_Z0_oes':             2548.0,
+        'spin_ZE_oes':             2546.5,
+        'spin_ARPH_oes':           2548.0,
+        'spin_slope_oes':             20.0,
     }
 
     # Widgets declared in qols_panel_base.ui, guaranteed available after setupUi() (R-04)
@@ -112,6 +134,23 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
     spin_maxWidthDep_takeoff: QLineEdit
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
+    # New OLS concept widgets (issues #107-#109)
+    combo_rwyType_ofs: QComboBox
+    combo_adg_ofs: QComboBox
+    spin_rwyWidth_ofs: QLineEdit
+    spin_distThr_ofs: QLineEdit
+    spin_innerEdge_ofs: QLineEdit
+    spin_divergence_ofs: QLineEdit
+    spin_length_ofs: QLineEdit
+    spin_slope_ofs: QLineEdit
+    spin_Z0_ofs: QLineEdit
+    spin_ZE_ofs: QLineEdit
+    spin_ARPH_ofs: QLineEdit
+    spin_widthApp_oes: QLineEdit
+    spin_Z0_oes: QLineEdit
+    spin_ZE_oes: QLineEdit
+    spin_ARPH_oes: QLineEdit
+    spin_slope_oes: QLineEdit
 
     def __init__(self, iface, parent=None):
         """Constructor with enhanced error handling and layer management."""
@@ -221,6 +260,18 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(self.runwayLayerCombo.layerChanged, self.validate_layer_change)
             self._connect(self.thresholdLayerCombo.layerChanged, self.validate_layer_change)
 
+            # New OLS concept tab signals (#107-#109)
+            try:
+                self._connect(self.combo_rwyType_ofs.currentIndexChanged,
+                              self.apply_ofs_approach_defaults)
+                self._connect(self.combo_adg_ofs.currentIndexChanged,
+                              self.apply_ofs_approach_defaults)
+                self._connect(self.spin_rwyWidth_ofs.editingFinished,
+                              self.apply_ofs_approach_defaults)
+                self._connect(self.btn_adg_help.clicked, self._show_adg_help_dialog)
+            except Exception as e:
+                logger.warning(f"Could not connect New OLS OFS defaults handlers: {e}")
+
             # Connect signals
             self._connect(self.calculateButton.clicked, self.on_calculate_clicked)
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
@@ -284,7 +335,13 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 'spin_widthDep_takeoff', 'spin_maxWidthDep_takeoff',
                 'spin_CWYLength_takeoff', 'spin_Z0_takeoff',
                 'spin_widthApp_transitional', 'spin_Z0_transitional', 'spin_ZE_transitional',
-                'spin_ARPH_transitional', 'spin_Tslope_transitional'
+                'spin_ARPH_transitional', 'spin_Tslope_transitional',
+                # New OLS OFS
+                'spin_rwyWidth_ofs', 'spin_distThr_ofs', 'spin_innerEdge_ofs',
+                'spin_divergence_ofs', 'spin_length_ofs', 'spin_slope_ofs',
+                'spin_Z0_ofs', 'spin_ZE_ofs', 'spin_ARPH_ofs', 'spin_contour_interval_ofs',
+                # New OLS OES
+                'spin_widthApp_oes', 'spin_Z0_oes', 'spin_ZE_oes', 'spin_ARPH_oes', 'spin_slope_oes',
             ]
 
             # Allow unlimited decimals; optional sign and decimal part
@@ -393,6 +450,8 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         self.apply_ofz_defaults_from_selection()
         self.apply_transitional_defaults_from_selection()
         self.apply_combined_inner_conical_defaults_from_selection()
+        self.apply_ofs_approach_defaults()
+        self.apply_oes_transitional_defaults()
 
     def _wire_combined_inner_conical_defaults(self):
         """Connect change signals to apply defaults when RWY/Code change in combined tab."""
@@ -611,6 +670,93 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             rd = rule_mgr.get_transitional_defaults(rwy, code)
             if rd and 'slope_pct' in rd:
                 self.set_numeric_value('spin_Tslope_transitional', rd['slope_pct'])
+        except Exception as e:
+            logger.warning(f"Unhandled error: {e}")
+
+    # ------------------------------------------------------------------
+    # New OLS concept defaults (#107-#109)
+    # ------------------------------------------------------------------
+
+    @pyqtSlot()
+    def apply_ofs_approach_defaults(self):
+        """Populate OFS Approach fields from ICAO Tables 4-1/4-2 (New OLS #108)."""
+        try:
+            rwy_type = self.combo_rwyType_ofs.currentText()
+            adg = self.combo_adg_ofs.currentText()
+            try:
+                rwy_width = float(self.spin_rwyWidth_ofs.text() or "45")
+            except ValueError:
+                rwy_width = 45.0
+            d = get_new_ols_approach_defaults(rwy_type, adg, rwy_width)
+            self.set_numeric_value('spin_distThr_ofs', d['distance_from_threshold_m'])
+            self.set_numeric_value('spin_innerEdge_ofs', d['inner_edge_m'])
+            self.set_numeric_value('spin_divergence_ofs', d['divergence_pct'])
+            self.set_numeric_value('spin_length_ofs', d['length_m'])
+            self.set_numeric_value('spin_slope_ofs', d['slope_pct'])
+            self.apply_oes_transitional_defaults()
+        except Exception as e:
+            logger.warning(f"Unhandled error: {e}")
+
+    @pyqtSlot()
+    def apply_oes_transitional_defaults(self):
+        """Populate OES Transitional fields (New OLS #109).
+
+        The OES width tracks the OFS Approach inner edge.
+        """
+        try:
+            d = get_new_ols_transitional_defaults()
+            self.set_numeric_value('spin_slope_oes', d['slope_pct'])
+            inner_edge_text = getattr(self, 'spin_innerEdge_ofs', None)
+            if inner_edge_text and hasattr(inner_edge_text, 'text'):
+                try:
+                    inner_val = float(inner_edge_text.text() or "155")
+                    self.set_numeric_value('spin_widthApp_oes', inner_val)
+                except ValueError:
+                    pass
+        except Exception as e:
+            logger.warning(f"Unhandled error: {e}")
+
+    @pyqtSlot()
+    def _show_adg_help_dialog(self):
+        """Show ADG reference table (ICAO Table 1-2) in an HTML dialog."""
+        try:
+            html = """
+<html><body>
+<h3 style="margin-bottom:8px">Table 1-2 — Aeroplane Design Group (ADG)</h3>
+<p style="font-size:11px">(see 1.8.2) &nbsp; Applicable as of 21 November 2030</p>
+<table border="1" cellspacing="0" cellpadding="4" style="border-collapse:collapse;font-size:12px">
+ <tr style="background:#444;color:#fff">
+  <th>ADG</th>
+  <th>Indicated airspeed at threshold</th>
+  <th>and</th>
+  <th>Wingspan</th>
+ </tr>
+ <tr><td>I</td><td>Less than 169 km/h (91 kt)</td><td>and</td><td>Up to but not including 24 m</td></tr>
+ <tr><td>IIA</td><td>Less than 169 km/h (91 kt)</td><td>and</td><td>24 m up to but not including 36 m</td></tr>
+ <tr><td>IIB</td>
+ <td>169 km/h (91 kt) up to but not including 224 km/h (121 kt)</td>
+ <td>and</td><td>Up to but not including 36 m</td></tr>
+ <tr><td>IIC</td>
+ <td>224 km/h (121 kt) up to but not including 307 km/h (166 kt)</td>
+ <td>and</td><td>Up to but not including 36 m</td></tr>
+ <tr><td>III</td><td>Less than 307 km/h (166 kt)</td><td>and</td><td>36 m up to but not including 52 m</td></tr>
+ <tr><td>IV</td><td>Less than 307 km/h (166 kt)</td><td>and</td><td>52 m up to but not including 65 m</td></tr>
+ <tr><td>V</td><td>Less than 307 km/h (166 kt)</td><td>and</td><td>65 m up to but not including 80 m</td></tr>
+</table>
+<p style="font-size:11px;margin-top:8px">
+<b>Note 1.</b> Detailed specifications on ADG are given in the Airport Services Manual, Part 6.<br>
+<b>Note 2.</b> Examples: 161 km/h (87 kt) and wingspan 20 m → ADG I; 307 km/h (166 kt) and wingspan 72 m → ADG IV.
+</p>
+</body></html>"""
+            dlg = QDialog(self)
+            dlg.setWindowTitle("ADG Reference Table — ICAO Table 1-2")
+            dlg.resize(700, 320)
+            browser = QTextBrowser(dlg)
+            browser.setHtml(html)
+            layout = QVBoxLayout(dlg)
+            layout.addWidget(browser)
+            dlg.setLayout(layout)
+            dlg.exec_()
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
@@ -1329,6 +1475,23 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
+    def _validate_project_crs(self) -> bool:
+        """Return True only when the project CRS is projected (not geographic).
+
+        Shows QMessageBox.critical and returns False when the CRS is geographic,
+        because all OLS geometry scripts require a projected (metric) CRS.
+        """
+        crs = QgsProject.instance().crs()
+        if crs.isGeographic():
+            QMessageBox.critical(
+                None,
+                "Projected CRS Required",
+                f"The project CRS ({crs.authid()} — {crs.description()}) is geographic. "
+                "All OLS calculations require a projected (metric) coordinate system.",
+            )
+            return False
+        return True
+
     @pyqtSlot()
     def on_calculate_clicked(self):
         """Handle calculate button click with validation."""
@@ -1557,15 +1720,37 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # Get direction
             direction = 0 if self.direction_start_to_end else -1
 
-            # Get current tab to determine surface type
-            current_tab_index = self.scriptTabWidget.currentIndex()
-            _tab_text = self.scriptTabWidget.tabText(current_tab_index)
-
-            # Normalise to SurfaceType enum (R-03) — raises ValueError for unknown tabs
-            try:
-                surface_type = SurfaceType.from_tab_text(_tab_text)
-            except ValueError:
-                raise Exception(f"Unknown surface type tab: {_tab_text!r}")
+            # Determine surface type from concept tab and surface tab
+            concept_index = getattr(self, 'conceptTabWidget', None)
+            if concept_index is not None and hasattr(concept_index, 'currentIndex'):
+                if concept_index.currentIndex() == 1:
+                    # New OLS concept — dispatch by OFS/OES sub-tab
+                    new_ols_widget = getattr(self, 'newOlsTabWidget', None)
+                    ofs_oes_index = (
+                        new_ols_widget.currentIndex()
+                        if new_ols_widget and hasattr(new_ols_widget, 'currentIndex')
+                        else 0
+                    )
+                    surface_type = (
+                        SurfaceType.NEW_OLS_OFS_APPROACH
+                        if ofs_oes_index == 0
+                        else SurfaceType.NEW_OLS_OES_TRANSITIONAL
+                    )
+                else:
+                    current_tab_index = self.scriptTabWidget.currentIndex()
+                    _tab_text = self.scriptTabWidget.tabText(current_tab_index)
+                    try:
+                        surface_type = SurfaceType.from_tab_text(_tab_text)
+                    except ValueError:
+                        raise Exception(f"Unknown surface type tab: {_tab_text!r}")
+            else:
+                # Fallback: no conceptTabWidget (tests / legacy)
+                current_tab_index = self.scriptTabWidget.currentIndex()
+                _tab_text = self.scriptTabWidget.tabText(current_tab_index)
+                try:
+                    surface_type = SurfaceType.from_tab_text(_tab_text)
+                except ValueError:
+                    raise Exception(f"Unknown surface type tab: {_tab_text!r}")
 
             # Get parameters based on current tab
             if surface_type == SurfaceType.APPROACH:
@@ -1708,6 +1893,39 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'ARPH': float(self.spin_ARPH_transitional.text() or "0"),          # QLineEdit
                     'Tslope': float(self.spin_Tslope_transitional.text() or "0") / 100.0,  # % → decimal
                     's': s_value  # Special parameter for transitional runway direction
+                }
+            elif surface_type == SurfaceType.NEW_OLS_OFS_APPROACH:
+                s_value = 0 if self.direction_start_to_end else -1
+                z0_ui = self.get_numeric_value('spin_Z0_ofs')
+                ze_ui = self.get_numeric_value('spin_ZE_ofs')
+                z0_calc, ze_calc = (z0_ui, ze_ui) if s_value == 0 else (ze_ui, z0_ui)
+                specific_params = {
+                    'rwy_type': self.combo_rwyType_ofs.currentText(),
+                    'adg': self.combo_adg_ofs.currentText(),
+                    'runway_width_m': self.get_numeric_value('spin_rwyWidth_ofs'),
+                    'distance_from_threshold_m': self.get_numeric_value('spin_distThr_ofs'),
+                    'inner_edge_m': self.get_numeric_value('spin_innerEdge_ofs'),
+                    'divergence_ratio': self.get_numeric_value('spin_divergence_ofs') / 100.0,
+                    'length_m': self.get_numeric_value('spin_length_ofs'),
+                    'slope_pct': self.get_numeric_value('spin_slope_ofs'),
+                    'start_elevation_m': z0_calc,
+                    'end_elevation_m': ze_calc,
+                    'arp_elevation_m': self.get_numeric_value('spin_ARPH_ofs'),
+                    'direction': s_value,
+                    'contour_interval_m': int(round(self.get_numeric_value('spin_contour_interval_ofs'))),
+                }
+            elif surface_type == SurfaceType.NEW_OLS_OES_TRANSITIONAL:
+                s_value = 0 if self.direction_start_to_end else -1
+                specific_params = {
+                    'width_m': self.get_numeric_value('spin_widthApp_oes'),
+                    'start_elevation_m': self.get_numeric_value('spin_Z0_oes'),
+                    'highest_thr_elev_m': self.get_numeric_value('spin_ARPH_oes'),
+                    'slope_pct': self.get_numeric_value('spin_slope_oes'),
+                    'cap_height_m': 60.0,
+                    'approach_slope_pct': self.get_numeric_value('spin_slope_ofs'),
+                    'divergence_ratio': self.get_numeric_value('spin_divergence_ofs') / 100.0,
+                    'distance_from_threshold_m': self.get_numeric_value('spin_distThr_ofs'),
+                    'direction': s_value,
                 }
             elif surface_type == SurfaceType.OFZ:
                 specific_params = {

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -306,10 +306,24 @@
     </item>
     
     <item>
-     <widget class="QTabWidget" name="scriptTabWidget">
+     <widget class="QTabWidget" name="conceptTabWidget">
       <property name="tabPosition">
        <enum>QTabWidget::North</enum>
       </property>
+
+      <!-- TAB 0: Current OLS — wraps the existing 6-tab scriptTabWidget unchanged -->
+      <widget class="QWidget" name="tab_current_ols">
+       <attribute name="title">
+        <string>Current OLS</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="layout_current_ols">
+        <property name="spacing"><number>0</number></property>
+        <property name="margin"><number>0</number></property>
+        <item>
+         <widget class="QTabWidget" name="scriptTabWidget">
+          <property name="tabPosition">
+           <enum>QTabWidget::North</enum>
+          </property>
       
       <!-- APPROACH SURFACE TAB -->
       <widget class="QWidget" name="tab_approach">
@@ -1410,13 +1424,323 @@ QPushButton:checked:hover {
          </layout>
         </widget>
       
+         </widget>
+        </item>
+       </layout>
+      </widget>
+
+      <!-- TAB 1: New OLS — OFS + OES sub-tabs -->
+      <widget class="QWidget" name="tab_new_ols">
+       <attribute name="title">
+        <string>New OLS</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="layout_new_ols">
+        <property name="spacing"><number>0</number></property>
+        <property name="margin"><number>0</number></property>
+        <item>
+         <widget class="QTabWidget" name="newOlsTabWidget">
+          <property name="tabPosition">
+           <enum>QTabWidget::North</enum>
+          </property>
+
+          <!-- OFS TAB — Obstacle Free Surface: Approach -->
+          <widget class="QWidget" name="tab_ofs">
+           <attribute name="title">
+            <string>OFS</string>
+           </attribute>
+           <layout class="QFormLayout" name="formLayout_ofs">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+            </property>
+            <property name="labelAlignment">
+             <set>Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="horizontalSpacing"><number>15</number></property>
+            <property name="verticalSpacing"><number>6</number></property>
+
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_rwyType_ofs">
+              <property name="text"><string>Runway Type:</string></property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="combo_rwyType_ofs">
+              <property name="minimumHeight"><number>22</number></property>
+              <item><property name="text"><string>Non-instrument</string></property></item>
+              <item><property name="text"><string>Instrument</string></property></item>
+             </widget>
+            </item>
+
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_adg_ofs">
+              <property name="text"><string>ADG Group:</string></property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="combo_adg_ofs">
+              <property name="minimumHeight"><number>22</number></property>
+              <property name="currentIndex"><number>2</number></property>
+              <item><property name="text"><string>I</string></property></item>
+              <item><property name="text"><string>IIA-IIB</string></property></item>
+              <item><property name="text"><string>IIC</string></property></item>
+              <item><property name="text"><string>III</string></property></item>
+              <item><property name="text"><string>IV</string></property></item>
+              <item><property name="text"><string>V</string></property></item>
+             </widget>
+            </item>
+
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_rwyWidth_ofs">
+              <property name="text"><string>Runway Width (m):</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="spin_rwyWidth_ofs">
+              <property name="text"><string>45.00</string></property>
+              <property name="toolTip">
+               <string>Runway pavement width in metres. Used to apply inner edge length adjustments per ICAO footnotes.</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_distThr_ofs">
+              <property name="text"><string>Distance from THR (m):</string></property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="spin_distThr_ofs">
+              <property name="text"><string>60.00</string></property>
+             </widget>
+            </item>
+
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_innerEdge_ofs">
+              <property name="text"><string>Inner Edge Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="spin_innerEdge_ofs">
+              <property name="text"><string>155.00</string></property>
+              <property name="toolTip">
+               <string>Width of the inner edge at the threshold end. Auto-computed from ADG group and runway width; editable.</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_divergence_ofs">
+              <property name="text"><string>Divergence (%):</string></property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="spin_divergence_ofs">
+              <property name="text"><string>10.00</string></property>
+             </widget>
+            </item>
+
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_length_ofs">
+              <property name="text"><string>Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="spin_length_ofs">
+              <property name="text"><string>4500.00</string></property>
+             </widget>
+            </item>
+
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_slope_ofs">
+              <property name="text"><string>Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QLineEdit" name="spin_slope_ofs">
+              <property name="text"><string>3.33</string></property>
+              <property name="toolTip">
+               <string>Approach surface slope in percent. Default from ICAO table; editable.</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="8" column="0">
+             <widget class="QLabel" name="label_Z0_ofs">
+              <property name="text"><string>Start Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item row="8" column="1">
+             <widget class="QLineEdit" name="spin_Z0_ofs">
+              <property name="text"><string>2548.00</string></property>
+             </widget>
+            </item>
+
+            <item row="9" column="0">
+             <widget class="QLabel" name="label_ZE_ofs">
+              <property name="text"><string>End Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <widget class="QLineEdit" name="spin_ZE_ofs">
+              <property name="text"><string>2546.50</string></property>
+             </widget>
+            </item>
+
+            <item row="10" column="0">
+             <widget class="QLabel" name="label_ARPH_ofs">
+              <property name="text"><string>ARPH (m):</string></property>
+             </widget>
+            </item>
+            <item row="10" column="1">
+             <widget class="QLineEdit" name="spin_ARPH_ofs">
+              <property name="text"><string>2548.00</string></property>
+             </widget>
+            </item>
+
+            <item row="11" column="0">
+             <widget class="QLabel" name="label_contour_interval_ofs">
+              <property name="text"><string>Contour Interval (m):</string></property>
+             </widget>
+            </item>
+            <item row="11" column="1">
+             <widget class="QLineEdit" name="spin_contour_interval_ofs">
+              <property name="text"><string>10</string></property>
+              <property name="toolTip">
+               <string>Elevation interval for contour lines in metres. Set to 0 to disable.</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="12" column="0" colspan="2">
+             <widget class="QPushButton" name="btn_adg_help">
+              <property name="text"><string>ADG Reference Table</string></property>
+              <property name="toolTip">
+               <string>Show the Aeroplane Design Group (ADG) reference table (ICAO Table 1-2)</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="13" column="0" colspan="2">
+             <widget class="QLabel" name="label_approach_note_ofs">
+              <property name="text">
+               <string>Note: The purpose of the approach surface is to establish the airspace to be maintained free from obstacles to protect an aeroplane in the visual phase of the approach-to-land manoeuvres following a standard 3.0° approach.</string>
+              </property>
+              <property name="wordWrap"><bool>true</bool></property>
+              <property name="styleSheet">
+               <string>QLabel { font-size: 11px; padding: 4px; }</string>
+              </property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+
+          <!-- OES TAB — Obstacle Evaluation Surface: Transitional -->
+          <widget class="QWidget" name="tab_oes">
+           <attribute name="title">
+            <string>OES</string>
+           </attribute>
+           <layout class="QFormLayout" name="formLayout_oes">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+            </property>
+            <property name="labelAlignment">
+             <set>Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="horizontalSpacing"><number>15</number></property>
+            <property name="verticalSpacing"><number>6</number></property>
+
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_widthApp_oes">
+              <property name="text"><string>Width App (m):</string></property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="spin_widthApp_oes">
+              <property name="text"><string>155.00</string></property>
+              <property name="toolTip">
+               <string>Approach inner edge width from OFS tab. Auto-populated; editable.</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_Z0_oes">
+              <property name="text"><string>Start Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="spin_Z0_oes">
+              <property name="text"><string>2548.00</string></property>
+             </widget>
+            </item>
+
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_ZE_oes">
+              <property name="text"><string>End Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="spin_ZE_oes">
+              <property name="text"><string>2546.50</string></property>
+             </widget>
+            </item>
+
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_ARPH_oes">
+              <property name="text"><string>Highest THR Elev (m):</string></property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="spin_ARPH_oes">
+              <property name="text"><string>2548.00</string></property>
+              <property name="toolTip">
+               <string>Elevation of the highest threshold of the runway. Upper edge = this value + 60 m.</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_slope_oes">
+              <property name="text"><string>Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="spin_slope_oes">
+              <property name="text"><string>20.00</string></property>
+              <property name="toolTip">
+               <string>Transitional surface slope in percent. Default 20 %; editable.</string>
+              </property>
+             </widget>
+            </item>
+
+            <item row="5" column="0" colspan="2">
+             <widget class="QLabel" name="label_oes_note">
+              <property name="text">
+               <string>Upper edge at 60 m above the highest threshold elevation. Lateral extent = 60 / (slope/100) from approach edge.</string>
+              </property>
+              <property name="wordWrap"><bool>true</bool></property>
+              <property name="styleSheet">
+               <string>QLabel { font-size: 11px; padding: 4px; }</string>
+              </property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+
+         </widget>
+        </item>
+       </layout>
+      </widget>
+
      </widget>
     </item>
         </layout>
        </widget>
       </widget>
      </item>
-     
+
      <!-- IMPROVED BUTTONS ALWAYS VISIBLE -->
      <item>
       <widget class="QFrame" name="buttonFrame">


### PR DESCRIPTION
# feat(#107,#108,#109): New OLS concept — Current/New selector, OFS Approach, OES Transitional

## Summary
<img width="1366" height="854" alt="{B85A3732-7195-4145-BE5D-51C9BDDD0FE6}" src="https://github.com/user-attachments/assets/d4a3bca1-c50b-4208-a92c-55fcea662f7d" />

Closes #107, #108, #109.

ICAO has introduced a **New OLS concept** that replaces the traditional Annex 14 approach with two
new surface families — **OFS** (Obstacle Free Surface) and **OES** (Obstacle Evaluation Surface).
This PR introduces both the UI selector (#107) and the first two New OLS surfaces:

- **#107** — A top-level `conceptTabWidget` wraps the existing "Current OLS" tab (fully unchanged)
  and adds a new "New OLS" tab with two sub-tabs: OFS and OES.
- **#108** — OFS > Approach surface using ICAO's **Aeroplane Design Group** classification
  (ADG I / IIA-IIB / IIC / III / IV / V) × runway type (Non-instrument / Instrument). Inner edge
  auto-adjusts from Table 4-1/4-2 footnote rules when runway width changes. Slope is editable.
- **#109** — OES > Transitional surface flanking the approach. Slope 20 % default (editable).
  Upper edge capped at `highest_THR_elevation + 60 m`. Width is linked to the OFS inner edge.

The New OLS concept uses **ADG keys** instead of the existing classification + code scheme, so
pure-Python ICAO tables are used (same pattern as `qols/surfaces/approach.py`) — no changes to
RuleManager JSON.

---

## Changes

### `qols/surface_types.py`

Two new enum members added at the end of `SurfaceType`:

```python
NEW_OLS_OFS_APPROACH      = "New OLS - Approach"
NEW_OLS_OES_TRANSITIONAL  = "New OLS - Transitional"
```

These are **not** dispatched via `from_tab_text()` — `get_parameters()` resolves them by
concept-tab index before the existing tab-text lookup.

---

### `qols/surfaces/new_ols_approach.py` *(new file)*

ICAO Tables 4-1 (Non-instrument) and 4-2 (Instrument) keyed by ADG group, plus footnote
width adjustments:

| ADG | NI dist (m) | NI inner (m) | NI slope | I inner (m) | I slope |
|---|---|---|---|---|---|
| I | 30 | 60 | 5.00 % | 110 | 3.33 % |
| IIA-IIB | 60 | 80 | 4.00 % | 125 | 3.33 % |
| IIC | 60 | 100 | 3.33 % | 155 | 3.33 % |
| III | 60 | 125 | 3.33 % | 175 | 3.33 % |
| IV | 60 | 135 | 3.33 % | 185 | 3.33 % |
| V | 60 | 150 | 3.33 % | 200 | 3.33 % |

Divergence is 10 % for all groups and runway types.

`get_inner_edge_adjusted(adg, rwy_type, runway_width_m)` applies footnote rules:

| Condition | Result |
|---|---|
| NI / ADG I / 23 < w ≤ 30 | inner edge → 80 m |
| NI / ADG I / w > 30 | inner edge → 100 m |
| NI / ADG IIA-IIB / 30 < w ≤ 45 | inner edge → 100 m |
| NI / ADG IIA-IIB / w > 45 | inner edge → 110 m |
| NI / ADG IIC / w > 45 | inner edge → 110 m |
| I / ADG I / w > 30 | inner edge → 125 m |
| I / ADG IIA-IIB / 30 < w ≤ 45 | inner edge → 140 m |
| I / ADG IIC / w ≤ 30 | inner edge → 140 m |

Public API:
```python
get_new_ols_approach_defaults(rwy_type, adg, runway_width_m) -> Dict[str, float]
# returns: distance_from_threshold_m, inner_edge_m, divergence_pct, length_m, slope_pct
```

---

### `qols/surfaces/new_ols_transitional.py` *(new file)*

```python
DEFAULT_SLOPE_PCT   = 20.0   # editable in UI
DEFAULT_CAP_HEIGHT_M = 60.0  # upper edge above highest THR — fixed per ICAO

def get_new_ols_transitional_defaults() -> Dict[str, float]:
    return {'slope_pct': DEFAULT_SLOPE_PCT, 'cap_height_m': DEFAULT_CAP_HEIGHT_M}
```

---

### `qols/ui/qols_panel_base.ui`

**Structural change** inside the scroll area:

```
Before:
  layersGroup
  scriptTabWidget  (6 tabs — Approach, Conical, …)

After:
  layersGroup
  conceptTabWidget
    ├─ Tab "Current OLS"
    │    └─ QVBoxLayout → scriptTabWidget  ← existing 6 tabs, UNCHANGED
    └─ Tab "New OLS"
         └─ QVBoxLayout → newOlsTabWidget
              ├─ Tab "OFS"  (tab_ofs)
              │    combo_rwyType_ofs, combo_adg_ofs
              │    spin_rwyWidth_ofs, spin_distThr_ofs, spin_innerEdge_ofs
              │    spin_divergence_ofs, spin_length_ofs, spin_slope_ofs
              │    spin_Z0_ofs, spin_ZE_ofs, spin_ARPH_ofs
              │    spin_contour_interval_ofs, btn_adg_help
              │    label_approach_note_ofs
              └─ Tab "OES"  (tab_oes)
                   spin_widthApp_oes, spin_Z0_oes, spin_ZE_oes
                   spin_ARPH_oes, spin_slope_oes, label_oes_note
```

The existing `scriptTabWidget` and all its children are untouched — they are only moved
one level deeper inside a wrapper widget.

---

### `qols/ui/dockwidget.py`

**Imports:**
```python
from qgis.PyQt.QtWidgets import (
    QApplication, QCheckBox, QComboBox, QDialog, QDockWidget,
    QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
)
from ..surfaces.new_ols_approach import get_new_ols_approach_defaults
from ..surfaces.new_ols_transitional import get_new_ols_transitional_defaults
```

**`_WIDGET_DEFAULTS`** — new OFS/OES entries:
```python
'spin_rwyWidth_ofs': 45.0, 'spin_distThr_ofs': 60.0, 'spin_innerEdge_ofs': 155.0,
'spin_divergence_ofs': 10.0, 'spin_length_ofs': 4500.0, 'spin_slope_ofs': 3.33,
'spin_Z0_ofs': 2548.0, 'spin_ZE_ofs': 2546.5, 'spin_ARPH_ofs': 2548.0,
'spin_contour_interval_ofs': 10.0,
'spin_widthApp_oes': 155.0, 'spin_Z0_oes': 2548.0, 'spin_ZE_oes': 2546.5,
'spin_ARPH_oes': 2548.0, 'spin_slope_oes': 20.0,
```

**Signal connections** (via `_connect()` helper):
```python
self._connect(self.combo_rwyType_ofs.currentIndexChanged, self.apply_ofs_approach_defaults)
self._connect(self.combo_adg_ofs.currentIndexChanged,     self.apply_ofs_approach_defaults)
self._connect(self.spin_rwyWidth_ofs.editingFinished,     self.apply_ofs_approach_defaults)
self._connect(self.btn_adg_help.clicked,                  self._show_adg_help_dialog)
```

**New method `apply_ofs_approach_defaults()`** — reads rwy_type, ADG, and width; calls
`get_new_ols_approach_defaults()`; populates all OFS fields; then calls
`apply_oes_transitional_defaults()` to keep OES width in sync.

**New method `apply_oes_transitional_defaults()`** — sets OES slope to 20 % and copies
the current OFS inner edge value to `spin_widthApp_oes`.

**New method `_show_adg_help_dialog()`** — connected to `btn_adg_help`. Opens a `QDialog`
with a `QTextBrowser` showing ICAO Table 1-2 (ADG reference) as fully inline HTML. No
external URLs.

**New method `_validate_project_crs() -> bool`** — returns `False` and shows
`QMessageBox.critical` when the project CRS is geographic. Standalone method; also resolves
the pre-existing gap needed by the #103 test suite.

**`get_parameters()`** — concept-tab index check before existing tab-text dispatch:
```python
concept_index = getattr(self, 'conceptTabWidget', None)
if concept_index is not None and hasattr(concept_index, 'currentIndex'):
    if concept_index.currentIndex() == 1:  # New OLS
        ofs_oes_index = self.newOlsTabWidget.currentIndex()
        surface_type = (SurfaceType.NEW_OLS_OFS_APPROACH if ofs_oes_index == 0
                        else SurfaceType.NEW_OLS_OES_TRANSITIONAL)
    else:
        # existing scriptTabWidget path — unchanged
```

New parameter blocks collect all OFS and OES fields and pass them to the scripts.

---

### `qols/plugin.py`

New dispatch branches in `on_calculate()`:
```python
elif st == SurfaceType.NEW_OLS_OFS_APPROACH:
    self.execute_new_ols_ofs_approach(params)
elif st == SurfaceType.NEW_OLS_OES_TRANSITIONAL:
    self.execute_new_ols_oes_transitional(params)
```

New execute methods:
```python
def execute_new_ols_ofs_approach(self, params):
    script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-ofs-approach-UTM.py')
    self.execute_script(script_path, params)

def execute_new_ols_oes_transitional(self, params):
    script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-transitional-UTM.py')
    self.execute_script(script_path, params)
```

---

### `qols/scripts/new-ols-ofs-approach-UTM.py` *(new file)*

Single-section trapezoidal approach surface:

1. Reads all params from `globals()`.
2. Determines runway direction from the centerline layer; resolves outward azimuth from the
   selected threshold.
3. Projects inner edge (`inner_edge_m` wide) at `distance_from_threshold_m` from THR.
4. Projects outer edge at `length_m` further out; width = `inner_edge_m + 2 × length_m × divergence_ratio`.
5. Elevation rises at `slope_pct / 100` per metre.
6. Creates a `PolygonZ` memory layer with ADG, rwy_type, slope, and params stored as attributes.
7. Optional contour lines at `contour_interval_m` via `_contour_utils.py` (same pattern as
   existing surfaces).

---

### `qols/scripts/new-ols-oes-transitional-UTM.py` *(new file)*

Two **triangular wings** flanking the OFS approach per ICAO Figure 4-1 (plan view):

Key derivations:
- `d_cap = cap_height / approach_slope` — longitudinal extent until approach reaches cap
  (e.g. 60 m ÷ 3.33 % ≈ 1 802 m)
- `lateral_near = cap_height / trans_slope` — outer width at inner-edge start
  (e.g. 60 m ÷ 20 % = 300 m)

Each wing is a triangle (PolygonZ):

| Vertex | Position | Z |
|---|---|---|
| `near_inner` | approach inner edge at `distance_from_threshold_m` | `start_elevation_m` |
| `near_outer` | `near_inner + lateral_near` outward | `cap_elevation` |
| `far_vertex` | approach inner edge at `d_cap` (widens with divergence) | `cap_elevation` |

The wings are widest near the threshold and converge to the approach edge where the approach
surface elevation reaches the cap — exactly matching ICAO Figure 4-1.

Parameters `approach_slope_pct`, `divergence_ratio`, and `distance_from_threshold_m` are
read silently from the OFS UI fields inside `get_parameters()` — no additional OES UI fields
required.

Styled in sky-blue at 40 % opacity.

---

### `tests/test_dockwidget_logic.py`

Section `# 9. New OLS concept — issues #107-#109` — 18 new test cases:

**`TestNewOlsApproachDefaults`** (15 tests):

| Test | What it verifies |
|---|---|
| `test_non_instrument_adg_i_base` | ADG I NI w≤23 → slope 5%, inner 60 m, length 1600 m |
| `test_non_instrument_adg_i_width_above_23` | 23 < w ≤ 30 → inner 80 m (footnote) |
| `test_non_instrument_adg_i_width_above_30` | w > 30 → inner 100 m (footnote) |
| `test_non_instrument_adg_iia_iib_base` | ADG IIA-IIB NI w≤30 → slope 4%, inner 80 m |
| `test_non_instrument_adg_iia_iib_width_above_30` | 30 < w ≤ 45 → inner 100 m |
| `test_non_instrument_adg_iia_iib_width_above_45` | w > 45 → inner 110 m |
| `test_non_instrument_adg_iic_base` | ADG IIC NI w≤45 → slope 3.33%, inner 100 m |
| `test_non_instrument_adg_iic_width_above_45` | w > 45 → inner 110 m |
| `test_instrument_adg_i_base` | ADG I I w≤30 → slope 3.33%, inner 110 m, length 4500 m |
| `test_instrument_adg_i_width_above_30` | w > 30 → inner 125 m |
| `test_instrument_adg_iia_iib_width_above_30_to_45` | 30 < w ≤ 45 → inner 140 m |
| `test_instrument_adg_iic_width_le_30` | w ≤ 30 → inner 140 m (footnote c) |
| `test_instrument_adg_iic_base` | w > 30 → inner 155 m |
| `test_instrument_adg_v` | ADG V I → slope 3.33%, inner 200 m |
| `test_divergence_always_10_pct` | 10% for all 12 ADG × rwy_type combinations |

**`TestNewOlsTransitionalDefaults`** (2 tests): slope 20%, cap 60 m, correct key set.

**`TestApplyOfsDefaultsPopulatesFields`** (4 tests): dockwidget method integration —
fields populated correctly, OES width syncs with OFS inner edge.

---

## Commits

| Hash | Message |
|---|---|
| `TBD` | feat(#107-109): add New OLS concept selector, OFS Approach, and OES Transitional |
