### PR TITLE
fix(#112): ADG Reference Table button does nothing

### DIFF
--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -30,10 +30,10 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
-    QApplication, QCheckBox, QComboBox, QDockWidget,
-    QLabel, QLineEdit, QMessageBox, QToolTip,
+    QApplication, QCheckBox, QComboBox, QDialog, QDockWidget,
+    QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
 )
-from ..compat import TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
+from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
 
 # Load the UI file
@@ -756,9 +756,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             layout = QVBoxLayout(dlg)
             layout.addWidget(browser)
             dlg.setLayout(layout)
-            dlg.exec_()
+            dlg.exec()  # exec() works in both PyQt5 and PyQt6
         except Exception as e:
-            logger.warning(f"Unhandled error: {e}")
+            logger.warning(f"Unhandled error in ADG help dialog: {e}")
 
     @pyqtSlot()
     def apply_ofz_defaults_from_selection(self):
@@ -1474,23 +1474,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
 
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
-
-    def _validate_project_crs(self) -> bool:
-        """Return True only when the project CRS is projected (not geographic).
-
-        Shows QMessageBox.critical and returns False when the CRS is geographic,
-        because all OLS geometry scripts require a projected (metric) CRS.
-        """
-        crs = QgsProject.instance().crs()
-        if crs.isGeographic():
-            QMessageBox.critical(
-                None,
-                "Projected CRS Required",
-                f"The project CRS ({crs.authid()} — {crs.description()}) is geographic. "
-                "All OLS calculations require a projected (metric) coordinate system.",
-            )
-            return False
-        return True
 
     @pyqtSlot()
     def on_calculate_clicked(self):


### PR DESCRIPTION
# fix(#112): ADG Reference Table button does nothing

## Summary

Closes #112.

Clicking **ADG Reference Table** in the New OLS > OFS tab did nothing. Two bugs combined
to produce this symptom:

1. **`NameError` on dialog creation** — `QDialog`, `QTextBrowser`, and `QVBoxLayout` were
   not imported from `QtWidgets`. The slot crashed immediately and the `try/except` block
   swallowed the error silently.

2. **`AttributeError` on dialog show** — even with the imports fixed, `dlg.exec_()` raises
   `AttributeError` in PyQt6 (QGIS 4.x) because PyQt6 renamed the method to `exec()`.
   The surrounding `try/except` swallowed this error too, so the dialog window was created
   but never shown.

The same inspection also revealed two pre-existing issues fixed in this PR:
- `EVENT_MOUSE_MOVE` was used in `eventFilter` but never imported from `compat.py` —
  every mouse event in the layer combo dropdowns would crash silently.
- `_validate_project_crs` was defined twice; the first (weaker) definition used `None` as
  the QMessageBox parent. Removed the duplicate; kept the complete #103 version.

---

## Changes

### `qols/ui/dockwidget.py`

**QtWidgets import** — add the three names used by `_show_adg_help_dialog`:

```python
# Before
from qgis.PyQt.QtWidgets import (
    QApplication, QCheckBox, QComboBox, QDockWidget,
    QLabel, QLineEdit, QMessageBox, QToolTip,
)

# After
from qgis.PyQt.QtWidgets import (
    QApplication, QCheckBox, QComboBox, QDialog, QDockWidget,
    QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
)
```

**`_show_adg_help_dialog`** — change `exec_()` to `exec()` for PyQt6 compatibility:

```python
# Before
dlg.exec_()   # AttributeError in PyQt6 — swallowed silently

# After
dlg.exec()    # works in both PyQt5 and PyQt6
```

**compat import** — add `EVENT_MOUSE_MOVE` (used in `eventFilter` at line 1106):

```python
# Before
from ..compat import TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL

# After
from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
```

**Duplicate `_validate_project_crs`** — removed the first (weaker) definition that used
`None` as the QMessageBox parent. Kept the second definition (added in #103) which correctly
passes `self` and shows the full user-facing guidance message.

---

## Verification

```bash
py -m flake8 qols/ui/dockwidget.py --isolated --max-line-length=119  # 0 issues
py -m pytest tests/test_dockwidget_logic.py -v                        # 65 passed
```

Manual check in QGIS: New OLS tab → OFS sub-tab → click **ADG Reference Table** → modal
dialog with ICAO Table 1-2 (ADG definitions) appears.

---

## Commits

| Hash | Message |
|---|---|
| `TBD` | fix(#112): add missing QDialog/QTextBrowser/QVBoxLayout imports; fix EVENT_MOUSE_MOVE import; remove duplicate _validate_project_crs |
