### PR TITLE
eat(#117): live direction-preview marker for Approach/Transitional (and OFS/OES)

### DIFF
--- a/qols/compat.py
+++ b/qols/compat.py
@@ -9,7 +9,7 @@ branching on the Qt version inline.
 from qgis.PyQt.QtCore import Qt, QEvent
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtWidgets import QDialogButtonBox
-from qgis.core import Qgis
+from qgis.core import Qgis, QgsWkbTypes
 
 # ---------------------------------------------------------------------------
 # Dock-widget area constants
@@ -93,6 +93,16 @@ try:
 except AttributeError:
     EVENT_MOUSE_MOVE = QEvent.MouseMove  # type: ignore[attr-defined]
 
+# ---------------------------------------------------------------------------
+# Geometry-type constant for QgsRubberBand
+# QGIS 3:  QgsWkbTypes.PolygonGeometry
+# QGIS 4:  Qgis.GeometryType.Polygon
+# ---------------------------------------------------------------------------
+try:
+    GEOM_TYPE_POLYGON = Qgis.GeometryType.Polygon
+except AttributeError:
+    GEOM_TYPE_POLYGON = QgsWkbTypes.PolygonGeometry  # type: ignore[attr-defined]
+
 __all__ = [
     "DOCK_RIGHT", "DOCK_LEFT",
     "BTN_SAVE", "BTN_CANCEL",
@@ -101,4 +111,5 @@ __all__ = [
     "RENDER_ANTIALIAS",
     "MSG_INFO", "MSG_WARNING", "MSG_CRITICAL", "MSG_SUCCESS",
     "EVENT_MOUSE_MOVE",
+    "GEOM_TYPE_POLYGON",
 ]

--- a/qols/direction_marker.py
+++ b/qols/direction_marker.py
@@ -1,0 +1,160 @@
+"""qols/direction_marker.py — live direction-preview triangle for the
+Approach/Transitional (and OFS/OES) dockwidget tabs (#117).
+
+Mirrors qpansopy's OMNI SID DER marker: a small triangle, tip pointing the
+way the surface will extend, sized in screen pixels so it stays visible at
+any zoom. The triangle/azimuth math is pure Python (no QGIS dependency) so
+it can be unit tested directly; ``build_marker_geometry`` is the thin
+QGIS-aware wrapper the dockwidgets call.
+
+The direction formula mirrors the ``s``-index convention ported from the
+legacy ``TransitionalSurface_UTM.py`` into the New OLS scripts (see #113):
+``s = direction; near_end_pt = line_pts[s]; far_end_pt = line_pts[-1 - s]``.
+"""
+from __future__ import annotations
+
+import math
+
+__all__ = [
+    "resolve_direction_azimuth",
+    "triangle_marker_vertices",
+    "build_marker_geometry",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure geometry helpers (no QGIS dependency — operate on plain (x, y) tuples)
+# ---------------------------------------------------------------------------
+
+def _azimuth_deg(p1: tuple[float, float], p2: tuple[float, float]) -> float:
+    """Bearing from p1 to p2, degrees clockwise from north (matches QgsPoint.azimuth)."""
+    dx = p2[0] - p1[0]
+    dy = p2[1] - p1[1]
+    return math.degrees(math.atan2(dx, dy)) % 360
+
+
+def _project(pt: tuple[float, float], distance: float, azimuth_deg: float) -> tuple[float, float]:
+    """Mirrors QgsPoint.project(distance, azimuth): 0° = north (+y), 90° = east (+x)."""
+    rad = math.radians(azimuth_deg)
+    return (pt[0] + distance * math.sin(rad), pt[1] + distance * math.cos(rad))
+
+
+def resolve_direction_azimuth(
+    line_pts: list[tuple[float, float]], direction: int,
+) -> tuple[tuple[float, float], tuple[float, float], float]:
+    """Given the runway centerline's endpoints and ``direction`` (0 = Start
+    to End, -1 = End to Start), returns (near_end_pt, far_end_pt, azimuth_deg).
+
+    Mirrors: s = direction; near_end_pt = line_pts[s]; far_end_pt = line_pts[-1-s];
+    azimuth = far_end_pt.azimuth(near_end_pt).
+    """
+    s = direction
+    near_end_pt = line_pts[s]
+    far_end_pt = line_pts[-1 - s]
+    azimuth_deg = _azimuth_deg(far_end_pt, near_end_pt)
+    return near_end_pt, far_end_pt, azimuth_deg
+
+
+def triangle_marker_vertices(
+    tip: tuple[float, float], azimuth_deg: float, length: float, half_width: float,
+) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
+    """Returns (tip, base_left, base_right) — a triangle pointing along
+    azimuth_deg from tip, base trailing back. Mirrors qpansopy's DER marker:
+    back_azimuth = azimuth + 180; base_center = tip.project(length, back_azimuth);
+    base_left/right = base_center.project(half_width, azimuth -+ 90).
+    """
+    back_azimuth = (azimuth_deg + 180) % 360
+    base_center = _project(tip, length, back_azimuth)
+    base_left = _project(base_center, half_width, (azimuth_deg - 90) % 360)
+    base_right = _project(base_center, half_width, (azimuth_deg + 90) % 360)
+    return tip, base_left, base_right
+
+
+# ---------------------------------------------------------------------------
+# QGIS-aware wrapper
+# ---------------------------------------------------------------------------
+
+def _resolve_features(layer, use_selected_feature):
+    if use_selected_feature:
+        return list(layer.selectedFeatures())
+    return list(layer.selectedFeatures()) or list(layer.getFeatures())
+
+
+def _normalize_polyline_points(geometry) -> list[tuple[float, float]]:
+    """Returns the runway centerline as a list of (x, y) tuples, picking the
+    longest part for a MultiLineString. Returns [] on anything unusable —
+    this feeds a live preview, so it must never raise."""
+    if geometry is None or geometry.isEmpty():
+        return []
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            return []
+
+        def part_len(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                total += math.hypot(pts[i].x() - pts[i - 1].x(), pts[i].y() - pts[i - 1].y())
+            return total
+
+        longest = max(parts, key=part_len)
+        return [(p.x(), p.y()) for p in longest]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [(p.x(), p.y()) for p in poly]
+    return []
+
+
+def _closest_feature(features, pt: tuple[float, float]):
+    return min(
+        features,
+        key=lambda f: math.hypot(f.geometry().asPoint().x() - pt[0], f.geometry().asPoint().y() - pt[1]),
+    )
+
+
+def build_marker_geometry(
+    runway_layer,
+    threshold_layer,
+    direction: int,
+    use_selected_feature: bool,
+    length_px: float,
+    half_width_px: float,
+    map_units_per_pixel: float,
+):
+    """Returns a QgsGeometry triangle pointing the way an Approach/
+    Transitional surface would extend for the current runway/threshold
+    selection and direction, or None when inputs aren't ready yet (no
+    layer/feature selected, degenerate centerline, zero-size canvas, etc.)
+    — callers should treat None as "hide the marker", never as an error.
+    """
+    if runway_layer is None or threshold_layer is None or not map_units_per_pixel:
+        return None
+
+    from qgis.core import QgsGeometry, QgsLineString, QgsPoint, QgsPolygon
+
+    runway_sel = _resolve_features(runway_layer, use_selected_feature)
+    threshold_sel = _resolve_features(threshold_layer, use_selected_feature)
+    if not runway_sel or not threshold_sel:
+        return None
+
+    line_pts = _normalize_polyline_points(runway_sel[0].geometry())
+    if len(line_pts) < 2:
+        return None
+
+    try:
+        near_end_pt, _far_end_pt, azimuth_deg = resolve_direction_azimuth(line_pts, direction)
+    except IndexError:
+        return None
+
+    near_thr_feat = _closest_feature(threshold_sel, near_end_pt)
+    thr_pt = near_thr_feat.geometry().asPoint()
+    tip = (thr_pt.x(), thr_pt.y())
+
+    length_m = length_px * map_units_per_pixel
+    half_width_m = half_width_px * map_units_per_pixel
+    tip_xy, base_left, base_right = triangle_marker_vertices(tip, azimuth_deg, length_m, half_width_m)
+
+    ring = [QgsPoint(*tip_xy), QgsPoint(*base_left), QgsPoint(*base_right)]
+    return QgsGeometry(QgsPolygon(QgsLineString(ring)))

--- a/qols/scripts/approach-surface-UTM.py
+++ b/qols/scripts/approach-surface-UTM.py
@@ -167,22 +167,10 @@ print(f"QOLS: ZIH at start (m): {zih_at_start_m}")
 for feat in selection:
     line_pts = _normalize_polyline_points(feat.geometry(), iface)
     print(f"QOLS: Geometry points count (normalized): {len(line_pts)}")
+    break
 
-    # Always use the same points regardless of direction
-    # Direction change is handled by azimuth rotation only
-    start_point = line_pts[0]
-    end_point = line_pts[-1]
-    base_azimuth_deg = start_point.azimuth(end_point)
-
-    print(f"QOLS: Using consistent points regardless of direction")
-    print(f"QOLS: start_point = first vertex of normalized line")
-    print(f"QOLS: end_point = last vertex of normalized line")
-    print(f"QOLS: Start point: {start_point.x()}, {start_point.y()}")
-    print(f"QOLS: End point: {end_point.x()}, {end_point.y()}")
-    print(f"QOLS: Base azimuth (deg): {base_azimuth_deg}")
-
-# Defer final azimuth until we know which threshold end is selected
-print(f"QOLS: Base azimuth (start→end) will be adjusted based on selected threshold end and UI direction toggle")
+# Final azimuth is resolved below once the threshold layer is loaded,
+# via the direction-driven s-index convention (matches TransitionalSurface_UTM.py).
 
 # ENHANCED THRESHOLD SELECTION - Use threshold layer from UI
 try:
@@ -217,37 +205,37 @@ except Exception as e:
     iface.messageBar().pushMessage("QOLS Error", f"Threshold layer error: {str(e)}", level=MSG_CRITICAL)
     raise
 
-# Get x,y from threshold - ORIGINAL LOGIC RESTORED
-# Always use the selected threshold feature as-is, direction change is handled by azimuth only
-if len(threshold_selection) >= 1:
-    # Use the first (or only) threshold feature
-    selected_threshold = threshold_selection[0]
-    threshold_geom = selected_threshold.geometry().asPoint()
-    print(f"QOLS: Using threshold feature as-is (original logic)")
-else:
+# Get x,y from threshold - direction picks the runway-centerline endpoint
+# directly (0 = Start to End, -1 = End to Start), mirroring the legacy
+# TransitionalSurface_UTM.py line_pts[-1-s]/line_pts[s] convention (ported
+# here from the New OLS scripts fix in #113) — no threshold-distance
+# matching or post-hoc azimuth flip needed. The threshold anchor is
+# matched to the direction-selected endpoint within threshold_selection —
+# in "Selected Only" mode with one feature it stays pinned (re-selecting
+# to match direction is the user's call, same as legacy); with multiple
+# candidates it follows direction automatically.
+if not threshold_selection:
     raise Exception("No threshold features found")
 
+
+def _closest_feature(features, pt):
+    return min(
+        features,
+        key=lambda f: hypot(f.geometry().asPoint().x() - pt.x(), f.geometry().asPoint().y() - pt.y()),
+    )
+
+
+s = direction
+near_end_pt = line_pts[s]
+far_end_pt = line_pts[-1 - s]
+azimuth = far_end_pt.azimuth(near_end_pt)
+
+selected_threshold = _closest_feature(threshold_selection, near_end_pt)
+threshold_geom = selected_threshold.geometry().asPoint()
 new_geom = QgsPoint(threshold_geom)
 new_geom.addZValue(start_elevation_m)
 
-# Determine which runway end the selected threshold corresponds to
-dist_to_start = hypot(new_geom.x() - start_point.x(), new_geom.y() - start_point.y())
-dist_to_end = hypot(new_geom.x() - end_point.x(), new_geom.y() - end_point.y())
-selected_end = 'start' if dist_to_start <= dist_to_end else 'end'
-
-# Compute outward azimuth from the selected threshold end
-outward_azimuth = base_azimuth_deg if selected_end == 'start' else (base_azimuth_deg + 180) % 360
-
-# UI toggle: client wants Start→End to be the opposite of the outward azimuth; End→Start follows outward azimuth
-if direction == 0:  # Start → End
-    azimuth = (outward_azimuth + 180) % 360
-else:  # End → Start
-    azimuth = outward_azimuth
-
 print(f"QOLS: Threshold point: {new_geom.x()}, {new_geom.y()}, {new_geom.z()}")
-print(f"QOLS: Selected threshold end: {selected_end} (dist_start={dist_to_start:.2f}, dist_end={dist_to_end:.2f})")
-print(f"QOLS: Base azimuth (start→end): {base_azimuth_deg:.6f}°")
-print(f"QOLS: Outward azimuth from selected end: {outward_azimuth:.6f}°")
 print(f"QOLS: UI direction toggle: {'End to Start' if direction == -1 else 'Start to End'}")
 print(f"QOLS: Final azimuth used for projection: {azimuth:.6f}°")
 

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -24,15 +24,23 @@ from ..rules import manager as rule_mgr
 from ..surfaces.approach import get_approach_defaults as icao_get_approach_defaults
 from ..surface_types import SurfaceType
 from .. import logger  # CR-01
+from ..direction_marker import build_marker_geometry
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
-from qgis.PyQt.QtGui import QRegularExpressionValidator
+from qgis.PyQt.QtGui import QColor, QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
     QApplication, QCheckBox, QComboBox, QDialog, QDockWidget,
     QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
 )
-from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
+from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL, GEOM_TYPE_POLYGON
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
+from qgis.gui import QgsRubberBand
+
+# Direction-marker triangle dimensions in screen pixels (converted to map
+# units via mapUnitsPerPixel so it stays a constant, visible size at any
+# zoom level) — matches qpansopy's OMNI SID DER marker (#117).
+_DIRECTION_MARKER_LENGTH_PX = 24
+_DIRECTION_MARKER_HALF_WIDTH_PX = 12
 
 # Load the UI file
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -135,6 +143,12 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         # Cached approach defaults — always exists so get_parameters() never needs getattr fallback
         self._approach_state: _ApproachState = _ApproachState()
 
+        # Live direction-preview marker (Approach/Transitional tabs only, #117)
+        self._direction_marker_band = QgsRubberBand(iface.mapCanvas(), GEOM_TYPE_POLYGON)
+        self._direction_marker_band.setColor(QColor(0, 170, 0, 120))
+        self._direction_marker_band.setStrokeColor(QColor(0, 120, 0, 220))
+        self._direction_marker_band.setWidth(1)
+
         try:
             self.setupUi(self)
 
@@ -233,6 +247,11 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # Connect tab change to reinitialize defaults (helpful for widget visibility)
             self._connect(self.scriptTabWidget.currentChanged, self.on_tab_changed)
 
+            # Live direction-preview marker: update on layer change and zoom (#117)
+            self._connect(self.runwayLayerCombo.layerChanged, self._update_direction_marker)
+            self._connect(self.thresholdLayerCombo.layerChanged, self._update_direction_marker)
+            self._connect(self.iface.mapCanvas().scaleChanged, self._update_direction_marker)
+
             # Set initial direction
             self.direction_start_to_end = True
             self.transitional_direction_normal = True  # True = normal (s=0), False = rotated (s=-1)
@@ -241,6 +260,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             self.update_direction_button()
             self.update_transitional_direction_button()
             self.update_selection_info()
+            self._update_direction_marker()
 
             # Apply initial OFZ visibility state after UI setup
             try:
@@ -1358,6 +1378,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         """Toggle direction between Start to End and End to Start."""
         self.direction_start_to_end = not self.direction_start_to_end
         self.update_direction_button()
+        self._update_direction_marker()
 
     def update_direction_button(self):
         """Update the direction button text."""
@@ -1370,6 +1391,46 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         """Toggle transitional runway direction between normal and rotated."""
         self.transitional_direction_normal = not self.transitional_direction_normal
         self.update_transitional_direction_button()
+        self._update_direction_marker()
+
+    def _update_direction_marker(self):
+        """Refresh the live direction-preview triangle (#117) for the
+        currently active tab. Approach/Transitional only — hidden otherwise.
+        Never raises: this runs on every layer/direction/zoom change."""
+        try:
+            current_tab = self.scriptTabWidget.widget(self.scriptTabWidget.currentIndex())
+            tab_name = current_tab.objectName().lower() if current_tab else ''
+            if 'approach' in tab_name:
+                direction = 0 if self.direction_start_to_end else -1
+            elif 'transitional' in tab_name:
+                direction = 0 if self.transitional_direction_normal else -1
+            else:
+                self._clear_direction_marker()
+                return
+
+            runway_layer = self.runwayLayerCombo.currentLayer()
+            threshold_layer = self.thresholdLayerCombo.currentLayer()
+            use_selected_feature = self.useSelectedThresholdCheckBox.isChecked()
+            map_units_per_pixel = self.iface.mapCanvas().mapUnitsPerPixel()
+
+            geometry = build_marker_geometry(
+                runway_layer, threshold_layer, direction, use_selected_feature,
+                _DIRECTION_MARKER_LENGTH_PX, _DIRECTION_MARKER_HALF_WIDTH_PX,
+                map_units_per_pixel,
+            )
+            if geometry is None:
+                self._clear_direction_marker()
+                return
+            self._direction_marker_band.setToGeometry(geometry, None)
+        except Exception as e:
+            logger.warning(f"Could not update direction marker: {e}")
+            self._clear_direction_marker()
+
+    def _clear_direction_marker(self):
+        try:
+            self._direction_marker_band.reset(GEOM_TYPE_POLYGON)
+        except Exception:
+            pass
 
     def update_transitional_direction_button(self):
         """Update the transitional direction button text and style."""
@@ -1391,6 +1452,8 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
 
                 if 'transitional' in tab_name.lower():
                     self.apply_transitional_defaults_from_selection()
+
+            self._update_direction_marker()
 
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
@@ -1884,6 +1947,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     pass
             self._connections.clear()
             self.disconnect_layer_selection_signals()
+            self._clear_direction_marker()
 
             self.closingPlugin.emit()
             event.accept()

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -10,18 +10,26 @@ from ..surfaces.new_ols_approach import get_new_ols_approach_defaults
 from ..surfaces.new_ols_transitional import get_new_ols_transitional_defaults
 from ..surface_types import SurfaceType
 from .. import logger
+from ..direction_marker import build_marker_geometry
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
-from qgis.PyQt.QtGui import QRegularExpressionValidator
+from qgis.PyQt.QtGui import QColor, QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
     QApplication, QComboBox, QDialog, QDockWidget,
     QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
 )
-from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
+from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL, GEOM_TYPE_POLYGON
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
+from qgis.gui import QgsRubberBand
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'new_ols_panel.ui'))
+
+# Direction-marker triangle dimensions in screen pixels (converted to map
+# units via mapUnitsPerPixel so it stays a constant, visible size at any
+# zoom level) — matches qpansopy's OMNI SID DER marker (#117).
+_DIRECTION_MARKER_LENGTH_PX = 24
+_DIRECTION_MARKER_HALF_WIDTH_PX = 12
 
 
 class NewOlsDockWidget(QDockWidget, FORM_CLASS):
@@ -80,6 +88,12 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         self._last_threshold_count = 0
         self._connections: list = []
 
+        # Live direction-preview marker (OFS/OES tabs, #117)
+        self._direction_marker_band = QgsRubberBand(iface.mapCanvas(), GEOM_TYPE_POLYGON)
+        self._direction_marker_band.setColor(QColor(0, 170, 0, 120))
+        self._direction_marker_band.setStrokeColor(QColor(0, 120, 0, 220))
+        self._direction_marker_band.setWidth(1)
+
         try:
             self.setupUi(self)
             self.setup_numeric_lineedit_validation()
@@ -120,9 +134,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
             self._connect(self.directionButton.clicked, self.toggle_direction)
 
+            # Live direction-preview marker: update on layer change and zoom (#117)
+            self._connect(self.runwayLayerCombo.layerChanged, self._update_direction_marker)
+            self._connect(self.thresholdLayerCombo.layerChanged, self._update_direction_marker)
+            self._connect(self.iface.mapCanvas().scaleChanged, self._update_direction_marker)
+
             self.direction_start_to_end = True
             self.update_direction_button()
             self.update_selection_info()
+            self._update_direction_marker()
 
             try:
                 self.connect_layer_selection_signals()
@@ -659,12 +679,43 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     def toggle_direction(self):
         self.direction_start_to_end = not self.direction_start_to_end
         self.update_direction_button()
+        self._update_direction_marker()
 
     def update_direction_button(self):
         if self.direction_start_to_end:
             self.directionButton.setText("Direction: Start to End")
         else:
             self.directionButton.setText("Direction: End to Start")
+
+    def _update_direction_marker(self):
+        """Refresh the live direction-preview triangle (#117) for the
+        current runway/threshold selection and direction. Never raises:
+        this runs on every layer/direction/zoom change."""
+        try:
+            direction = 0 if self.direction_start_to_end else -1
+            runway_layer = self.runwayLayerCombo.currentLayer()
+            threshold_layer = self.thresholdLayerCombo.currentLayer()
+            use_selected_feature = self.useSelectedThresholdCheckBox.isChecked()
+            map_units_per_pixel = self.iface.mapCanvas().mapUnitsPerPixel()
+
+            geometry = build_marker_geometry(
+                runway_layer, threshold_layer, direction, use_selected_feature,
+                _DIRECTION_MARKER_LENGTH_PX, _DIRECTION_MARKER_HALF_WIDTH_PX,
+                map_units_per_pixel,
+            )
+            if geometry is None:
+                self._clear_direction_marker()
+                return
+            self._direction_marker_band.setToGeometry(geometry, None)
+        except Exception as e:
+            logger.warning(f"Could not update direction marker: {e}")
+            self._clear_direction_marker()
+
+    def _clear_direction_marker(self):
+        try:
+            self._direction_marker_band.reset(GEOM_TYPE_POLYGON)
+        except Exception:
+            pass
 
     @pyqtSlot()
     def update_selection_info(self):
@@ -815,6 +866,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                     pass
             self._connections.clear()
             self.disconnect_layer_selection_signals()
+            self._clear_direction_marker()
             self.closingPlugin.emit()
             event.accept()
         except Exception:


### PR DESCRIPTION
# feat(#117): live direction-preview marker for Approach/Transitional (and OFS/OES)

## Summary

Issue #117 (`@antoniolocandro`): Approach/Transitional surfaces gave no
visual indication of which way they'd point until after clicking
Calculate — the user had to draw the surface, look at it, and re-toggle
Direction if it came out backwards. Requested a marker "similar to OMNI
SID", pointing at the sibling plugin `qpansopy`'s Departure OMNI SID DER
marker as the reference: a small `QgsRubberBand` triangle, tip pointing
the direction of travel, sized in screen pixels so it stays visible at any
zoom, that live-updates as the user changes layers/direction — no output
layer, no persisted geometry. Given the choice between a live preview and
a persistent output feature, the user chose the live preview to match
qpansopy exactly.

Ported to both dockwidgets: the classic panel's Approach/Transitional tabs
(`qols/ui/dockwidget.py`) and the New OLS panel's OFS/OES tabs
(`qols/ui/new_ols_dockwidget.py`).

---

## Changes

### `qols/direction_marker.py` (new)

Pure-Python triangle/azimuth math, no QGIS dependency, plus a thin
QGIS-aware wrapper:

- `resolve_direction_azimuth(line_pts, direction)` — the same `s`-index
  convention ported from legacy `TransitionalSurface_UTM.py` during #113
  (`near_end_pt = line_pts[s]`, `far_end_pt = line_pts[-1-s]`,
  `azimuth = far_end_pt.azimuth(near_end_pt)`), so the marker always
  predicts exactly what the surface scripts will build for the current
  Direction toggle.
- `triangle_marker_vertices(tip, azimuth_deg, length, half_width)` — tip +
  base-left + base-right, mirroring qpansopy's DER marker projection
  (`base_center = tip.project(length, azimuth+180)`, base corners offset
  ±90° from azimuth).
- `build_marker_geometry(runway_layer, threshold_layer, direction,
  use_selected_feature, length_px, half_width_px, map_units_per_pixel)` —
  resolves the runway centerline and near-threshold anchor the same way
  the scripts do (`_closest_feature` nearest-match within the
  selected/all features), converts pixel sizing to map units, and returns
  a `QgsGeometry` triangle — or `None` when inputs aren't ready (no
  layer/feature selected, degenerate centerline, zero-size canvas). `None`
  means "hide the marker", never an error; the function is not allowed to
  raise into the dockwidget's paint/update path.

### `qols/compat.py`

- Added `GEOM_TYPE_POLYGON` (QGIS3 `QgsWkbTypes.PolygonGeometry` vs QGIS4
  `Qgis.GeometryType.Polygon`, same try/except shim pattern as the rest of
  the file) for `QgsRubberBand`'s geometry-type argument.

### `qols/scripts/approach-surface-UTM.py`

Classic Approach still used the old, fragile direction pattern — the same
one fixed in the New OLS scripts during #113 — which the marker would
otherwise either mismatch or silently carry forward as a new "trust me" UI
element:

- Removed `dist_to_start`/`dist_to_end`/`selected_end` matching plus the
  `direction == 0` post-hoc 180° azimuth flip.
- Replaced with the shared `s`-index convention: `near_end_pt =
  line_pts[s]`, `far_end_pt = line_pts[-1-s]`, `azimuth =
  far_end_pt.azimuth(near_end_pt)`, threshold anchor matched to
  `near_end_pt` via `_closest_feature` within `threshold_selection` — same
  behavior as the New OLS Approach/Transitional scripts post-#113.

### `qols/ui/dockwidget.py` (classic panel)

- New `self._direction_marker_band` (`QgsRubberBand`, green fill/stroke,
  matching qpansopy's color scheme), created once in `__init__`.
- `_update_direction_marker()` — reads the active tab's object name; shows
  the marker only on `tab_approach`/`tab_transitional` (direction sourced
  from `self.direction_start_to_end` / `self.transitional_direction_normal`
  respectively), calls `build_marker_geometry()`, hides the marker
  (`_clear_direction_marker()`) on any other tab or when the builder
  returns `None`.
- `_clear_direction_marker()` — `self._direction_marker_band.reset(GEOM_TYPE_POLYGON)`.
- Wired via the existing `_connect()` helper (CLAUDE.md Signal Connection
  Pattern) to `runwayLayerCombo.layerChanged`, `thresholdLayerCombo.layerChanged`,
  and `iface.mapCanvas().scaleChanged`; also called at the end of
  `toggle_direction()`, `toggle_transitional_direction()`, and
  `on_tab_changed()`. Torn down in `closeEvent()`.

### `qols/ui/new_ols_dockwidget.py` (New OLS panel)

Same wiring, simplified: OFS and OES tabs share one `directionButton` /
`toggle_direction()` and one runway/threshold combo pair, so no tab-name
gating is needed — `_update_direction_marker()` always sources direction
from `self.direction_start_to_end`. Same `_connect()` wiring to layer
change and canvas zoom, same call inside `toggle_direction()`, same
cleanup in `closeEvent()`.

---

## Bug found during manual QGIS verification

Loading the plugin after the first pass raised:

```
ImportError: cannot import name 'QgsRubberBand' from 'qgis.core'
```

`QgsRubberBand` lives in `qgis.gui`, not `qgis.core` (unlike `QgsGeometry`/
`QgsWkbTypes`/`QgsVectorLayer`, which are in `core`). Fixed in both
dockwidgets by splitting the import:

```python
from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
from qgis.gui import QgsRubberBand
```

`tests/conftest.py` already mocks `qgis.gui` as a generic `MagicMock()`, so
this was invisible to the test suite — only surfaced when actually loading
the plugin in QGIS. No test-suite gap to close; this class of error is
inherent to mocked-import unit tests and is exactly why the plan called
for manual QGIS verification before closing out the issue.

---

## Verification

```bash
py -m pytest -q                                                    # 482 passed
py -m flake8 --max-line-length=120 qols/ui/dockwidget.py qols/ui/new_ols_dockwidget.py
                                                                    # pre-existing F821 only
                                                                    # (get_new_ols_approach_defaults /
                                                                    #  get_new_ols_transitional_defaults,
                                                                    #  dead code — see doc/PR_113.md baseline)
```

New tests (local-only, `tests/` is gitignored per repo convention — see
`doc/FEATURE_PLAN_117.md`):

- `tests/test_direction_marker.py` — `resolve_direction_azimuth` (index-0
  vs index-(-1) near/far selection, 180° azimuth flip on direction
  toggle, azimuth points away from the far end) and
  `triangle_marker_vertices` (tip matches input, base trails back along
  azimuth, base corners symmetric/offset, nonzero triangle area, rotating
  azimuth rotates the triangle) plus an end-to-end check that toggling
  direction flips which side of the tip the base sits on.

Manual QGIS check (now unblocked by the `qgis.gui` import fix):

- Plugin loads without the `QgsRubberBand` `ImportError`.
- On Approach/Transitional (classic) and OFS/OES (New OLS) tabs: select a
  runway + threshold, confirm the triangle appears pointing the correct
  way.
- Toggling Direction flips the triangle 180°.
- Changing runway/threshold layer updates the triangle.
- Switching to an unrelated tab (e.g. Conical) hides the marker (classic
  panel only — New OLS panel has no unrelated tabs to gate against).
- Zooming the canvas keeps the triangle a constant screen size.
- Closing the panel removes the triangle from the canvas.
- Running Calculate afterwards produces a surface pointing the same way
  the marker predicted.
