### PR TITLE
feat(#118): store surface parameters in a field + show as HTML

### DIFF
--- a/qols/compat.py
+++ b/qols/compat.py
@@ -9,7 +9,7 @@ branching on the Qt version inline.
 from qgis.PyQt.QtCore import Qt, QEvent
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtWidgets import QDialogButtonBox
-from qgis.core import Qgis
+from qgis.core import Qgis, QgsAction
 
 # ---------------------------------------------------------------------------
 # Dock-widget area constants
@@ -93,6 +93,16 @@ try:
 except AttributeError:
     EVENT_MOUSE_MOVE = QEvent.MouseMove  # type: ignore[attr-defined]
 
+# ---------------------------------------------------------------------------
+# QgsAction generic-Python action type (for register_parameters_action, #118)
+# QGIS 3 / Qt5:  QgsAction.GenericPython
+# QGIS 4 / Qt6:  QgsAction.ActionType.GenericPython
+# ---------------------------------------------------------------------------
+try:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.ActionType.GenericPython
+except AttributeError:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.GenericPython  # type: ignore[attr-defined]
+
 __all__ = [
     "DOCK_RIGHT", "DOCK_LEFT",
     "BTN_SAVE", "BTN_CANCEL",
@@ -101,4 +111,5 @@ __all__ = [
     "RENDER_ANTIALIAS",
     "MSG_INFO", "MSG_WARNING", "MSG_CRITICAL", "MSG_SUCCESS",
     "EVENT_MOUSE_MOVE",
+    "ACTION_TYPE_GENERIC_PYTHON",
 ]

--- a/qols/parameters_inspector.py
+++ b/qols/parameters_inspector.py
@@ -1,0 +1,627 @@
+# -*- coding: utf-8 -*-
+"""
+qols/parameters_inspector.py — store/inspect a surface's input parameters (#118).
+
+Extends what qpansopy already ships (`Q_Pansopy/parameters_inspector_dialog.py`
++ `Q_Pansopy/utils.py`): every surface-generation script stores the full set
+of inputs that produced a feature as a JSON string in a `parameters` field,
+and registers a QGIS layer action ("view parameters as HTML Table") so a
+user can right-click a feature — in the attribute table or a canvas
+Identify Features result — and see a themeable HTML table of exactly what
+produced it, without redoing the calculation. Renders via QWebEngineView
+when available, falling back to a QTextBrowser popup otherwise (QtWebEngine
+is an optional, heavy Qt add-on not bundled with every QGIS install).
+
+Two helpers not present in qpansopy (which leaves this per-script) centralize
+what every qOLS script needs:
+    build_parameters_json('Approach Surface', {...})   -> JSON string
+    add_parameters_field(layer)                        -> idempotent QgsField add
+
+Usage inside a surface-generation script (exec()-dispatched, but this is a
+normal importable module — absolute imports resolve independently of the
+exec() globals dict):
+    from qols.parameters_inspector import (
+        build_parameters_json, add_parameters_field, register_parameters_action,
+    )
+    params_json = build_parameters_json('Approach Surface', {...})
+    add_parameters_field(v_layer)
+    # ...set feature.setAttributes([..., params_json]) for every feature...
+    register_parameters_action(v_layer)
+    QgsProject.instance().addMapLayers([v_layer])
+"""
+from __future__ import annotations
+
+import datetime
+import html
+import json
+import re
+
+from qgis.core import QgsAction, QgsField, QgsProject, QgsVectorLayer
+from qgis.PyQt.QtCore import QMimeData, QObject, QVariant, pyqtSlot
+from qgis.PyQt.QtWidgets import (
+    QApplication, QDialog, QHBoxLayout, QLabel, QMessageBox, QPushButton, QTextBrowser, QVBoxLayout,
+)
+
+from .compat import ACTION_TYPE_GENERIC_PYTHON
+
+# QtWebEngineWidgets/QtWebChannel are optional, heavy Qt components (bundled
+# separately from base PyQt -- e.g. `python-pyqt6-webengine` on Arch/CachyOS)
+# that aren't guaranteed to be installed alongside QGIS. Fall back to a
+# QTextBrowser-based popup (no live JS theme toggle, but still dark by
+# default) rather than crashing every "view parameters as HTML Table" action
+# for users who lack them.
+try:
+    from qgis.PyQt.QtWebChannel import QWebChannel
+    from qgis.PyQt.QtWebEngineWidgets import QWebEngineView
+    _WEBENGINE_AVAILABLE = True
+except ImportError:
+    QWebChannel = None
+    QWebEngineView = None
+    _WEBENGINE_AVAILABLE = False
+
+__all__ = [
+    "build_parameters_json",
+    "add_parameters_field",
+    "register_parameters_action",
+    "show_parameters_inspector",
+    "show_web_popup",
+    "resolve_inspector_title",
+    "format_parameters_table",
+    "collect_project_parameter_sections",
+    "show_project_parameters_table",
+]
+
+
+# ---------------------------------------------------------------------------
+# Storing parameters on a layer/feature
+# ---------------------------------------------------------------------------
+
+def build_parameters_json(calculation_type: str, params: dict) -> str:
+    """Build the JSON string stored in every feature's 'parameters' field.
+
+    Merges *calculation_type* and a 'generated_at' ISO timestamp into
+    *params* so every stored blob is self-describing (used by
+    resolve_inspector_title() to pick a popup title, and useful when
+    reviewing a project long after the surface was calculated).
+    """
+    payload = dict(params)
+    payload['calculation_type'] = calculation_type
+    payload['generated_at'] = datetime.datetime.now().isoformat(timespec='seconds')
+    return json.dumps(payload)
+
+
+def add_parameters_field(layer) -> None:
+    """Add a 'parameters' (String) field to *layer* if it doesn't already
+    have one. Idempotent — safe to call from scripts that build a layer's
+    fields incrementally or in a loop."""
+    if layer.fields().indexOf('parameters') != -1:
+        return
+    layer.dataProvider().addAttributes([QgsField('parameters', QVariant.String)])
+    layer.updateFields()
+
+
+# ---------------------------------------------------------------------------
+# "Copy to Word" plain-text/HTML table (ported from qpansopy's utils.py)
+# ---------------------------------------------------------------------------
+
+_PARAM_LABEL_ACRONYMS = {
+    'IAS', 'ISA', 'PDG', 'TNA', 'MSA', 'CWY', 'DER', 'THR', 'OAS', 'FAP',
+    'MOC', 'VPA', 'OCH', 'RDH', 'ILS', 'KML', 'CRS', 'W', 'ARPH', 'ADG',
+}
+
+_PARAM_LABEL_OVERRIDES: dict = {}
+
+
+def _humanize_param_label(key):
+    """Turn a raw parameters-dict key (snake_case or camelCase, sometimes
+    with aviation acronyms) into a readable label, e.g. 'widthApp' ->
+    'Width App', 'ARPH' -> 'ARPH', 'rule_set' -> 'Rule Set'."""
+    override = _PARAM_LABEL_OVERRIDES.get(key)
+    if override:
+        return override
+
+    spaced = re.sub(r'(?<=[a-z])(?=[A-Z])', ' ', str(key)).replace('_', ' ')
+    words = []
+    for word in spaced.split():
+        words.append(word.upper() if word.upper() in _PARAM_LABEL_ACRONYMS else word.capitalize())
+    return ' '.join(words)
+
+
+def format_parameters_table(title, params_dict, as_html=False):
+    """Format a flat parameters dict as a standalone table — plain text by
+    default, an HTML `<table>` (Word-pasteable) when as_html=True."""
+    entries = [(key, value) for key, value in params_dict.items()]
+
+    if as_html:
+        parts = [
+            '<table border="1" cellpadding="4" cellspacing="0"'
+            ' style="border-collapse: collapse; font-family: Calibri, Arial, sans-serif; font-size: 11pt;">',
+            f'<tr style="background-color:#000000;color:#FFFFFF;font-weight:bold;text-align:center;">'
+            f'<th colspan="2">{html.escape(str(title))}</th></tr>',
+            '<tr style="background-color:#FFFFFF;font-weight:bold;">'
+            '<td>Parameter</td><td>Value</td></tr>',
+        ]
+        for key, value in entries:
+            parts.append(
+                '<tr style="background-color:#FFFFFF;">'
+                f'<td>{html.escape(_humanize_param_label(key))}</td>'
+                f'<td style="text-align:right;">{html.escape(str(value))}</td></tr>'
+            )
+        parts.append('</table>')
+        return ''.join(parts)
+
+    table = f"{title}\n{'=' * 50}\n\n"
+    table += "PARAMETER                    VALUE\n"
+    table += "-" * 50 + "\n"
+    for key, value in entries:
+        table += f"{_humanize_param_label(key):<28} {value}\n"
+    return table
+
+
+# ---------------------------------------------------------------------------
+# HTML popup page (ported from qpansopy's parameters_inspector_dialog.py)
+# ---------------------------------------------------------------------------
+
+# Reached from a QGIS layer action, which is triggered per-click rather than
+# tracked by any caller -- keep open QWebEngineView popups alive here (keyed
+# by id(view)), otherwise PyQt garbage-collects them the moment
+# show_parameters_inspector()/show_web_popup() returns.
+_open_views: dict = {}
+
+_PAGE_TEMPLATE = """<html>
+<head>
+<style>
+    html, body {
+        font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, sans-serif;
+        margin: 0; padding: 0; height: 100vh;
+        overflow-x: hidden; overflow-y: auto; box-sizing: border-box;
+        transition: background-color 0.2s, color 0.2s;
+    }
+    ::-webkit-scrollbar { width: 14px; background-color: rgba(0, 0, 0, 0.05); }
+    ::-webkit-scrollbar-track { background-color: rgba(0, 0, 0, 0.1); border-radius: 4px; }
+    .light-theme ::-webkit-scrollbar-thumb { background-color: #64748b; border: 2px solid #f4f6f9; border-radius: 6px; }
+    .dark-theme ::-webkit-scrollbar-thumb { background-color: #38bdf8; border: 2px solid #0f172a; border-radius: 6px; }
+    ::-webkit-scrollbar-thumb:hover { background-color: #0076a3 !important; }
+    .dark-theme ::-webkit-scrollbar-thumb:hover { background-color: #f8fafc !important; }
+
+    body.light-theme { background-color: #f4f6f9; color: #333333; }
+    .light-theme .layer-title { color: #1e293b; }
+    .light-theme h3 { color: #1e293b; border-bottom: 2px solid #e2e8f0; }
+    .light-theme .section-title { color: #475569; }
+    .light-theme .table-card { background: #ffffff; border: 1px solid #e2e8f0; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1); }
+    .light-theme th { background-color: #0f172a; color: #ffffff; border-bottom: 2px solid #1e293b; }
+    .light-theme td { border-bottom: 1px solid #f1f5f9; color: #475569; }
+    .light-theme tr:nth-child(even) td { background-color: #f8fafc; }
+    .light-theme tr:hover td { background-color: #f1f5f9; color: #0f172a; }
+    .light-theme td b { color: #1e293b; }
+    .light-theme .word-btn { background-color: #ffffff; border: 1px solid #cbd5e1; color: #1e293b; }
+    .light-theme .word-btn:hover { background-color: #f1f5f9; }
+
+    body.dark-theme { background-color: #0f172a; color: #cbd5e1; }
+    .dark-theme .layer-title { color: #f8fafc; }
+    .dark-theme h3 { color: #f8fafc; border-bottom: 2px solid #1e293b; }
+    .dark-theme .section-title { color: #94a3b8; }
+    .dark-theme .table-card { background: #1e293b; border: 1px solid #334155; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.3); }
+    .dark-theme th { background-color: #020617; color: #38bdf8; border-bottom: 2px solid #334155; }
+    .dark-theme td { border-bottom: 1px solid #334155; color: #94a3b8; }
+    .dark-theme tr:nth-child(even) td { background-color: #1e293b; }
+    .dark-theme tr:nth-child(odd) td { background-color: #111827; }
+    .dark-theme tr:hover td { background-color: #334155; color: #f8fafc; }
+    .dark-theme td b { color: #f1f5f9; }
+    .dark-theme .word-btn { background-color: #1e293b; border: 1px solid #475569; color: #f8fafc; }
+    .dark-theme .word-btn:hover { background-color: #334155; }
+
+    #main-container { padding: 24px; display: flex; flex-direction: column; position: relative; }
+    .layer-title { font-size: 20px; font-weight: 600; margin-bottom: 2px; padding-right: 180px; }
+    h3 { margin: 0 0 16px 0; font-size: 20px; font-weight: 600; padding-bottom: 8px; }
+    .section-title { margin: 20px 0 8px 0; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+    .table-card { border-radius: 8px; overflow: hidden; transition: background 0.2s, border 0.2s; }
+    table { width: 100%; border-collapse: collapse; text-align: left; }
+    th, td { padding: 14px 18px; font-size: 14px; line-height: 1.5; word-break: break-all; }
+    th { font-weight: 600; text-transform: uppercase; font-size: 12px; letter-spacing: 0.05em; width: 35%; }
+    td b { font-weight: 500; }
+    .controls-wrapper { position: absolute; top: 22px; right: 24px; display: flex; align-items: center; gap: 16px; }
+    .word-btn { padding: 4px 10px; font-size: 12px; font-weight: 500; border-radius: 4px; cursor: pointer; display: flex; align-items: center; gap: 6px; transition: background-color 0.2s; }
+    .theme-switch-wrapper { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 500; }
+    .theme-switch { display: inline-block; height: 20px; position: relative; width: 36px; }
+    .theme-switch input { display:none; }
+    .slider { background-color: #cbd5e1; bottom: 0; cursor: pointer; left: 0; position: absolute; right: 0; top: 0; transition: .2s; border-radius: 20px; }
+    .slider:before { background-color: white; bottom: 3px; content: ""; height: 14px; left: 3px; position: absolute; transition: .2s; width: 14px; border-radius: 50%; }
+    input:checked + .slider { background-color: #38bdf8; }
+    input:checked + .slider:before { transform: translateX(16px); }
+</style>
+<!-- Include the internal Qt WebChannel Script framework to link JS with Python Backend -->
+<script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-theme">
+    <div id="main-container">
+        <div class="layer-title">__QOLS_TITLE__</div>
+        <h3>Feature Parameters</h3>
+
+        <div class="controls-wrapper">
+            <button class="word-btn" onclick="triggerNativeCopy()">Copy to Word</button>
+            <div class="theme-switch-wrapper">
+                <span id="theme-label">Dark Mode</span>
+                <label class="theme-switch" for="checkbox">
+                    <input type="checkbox" id="checkbox" checked />
+                    <div class="slider"></div>
+                </label>
+            </div>
+        </div>
+
+__QOLS_SECTIONS__
+    </div>
+
+    <script>
+        let backendBridge;
+        // Establish runtime links with the PyQt backend bridge container channels
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            backendBridge = channel.objects.pyBridge;
+        });
+
+        const toggleSwitch = document.querySelector('#checkbox');
+        const themeLabel = document.querySelector('#theme-label');
+
+        toggleSwitch.addEventListener('change', (e) => {
+            if (e.target.checked) {
+                document.body.className = 'dark-theme';
+                themeLabel.textContent = 'Dark Mode';
+            } else {
+                document.body.className = 'light-theme';
+                themeLabel.textContent = 'Light Mode';
+            }
+        }, false);
+
+        function triggerNativeCopy() {
+            if (backendBridge) {
+                backendBridge.copyToClipboard();
+                const btn = document.querySelector('.word-btn');
+                const originalText = btn.innerHTML;
+                btn.innerHTML = '✔ Copied!';
+                setTimeout(() => { btn.innerHTML = originalText; }, 1500);
+            }
+        }
+    </script>
+</body>
+</html>
+"""
+
+
+def _format_value(value):
+    return json.dumps(value) if isinstance(value, (dict, list)) else str(value)
+
+
+def _build_rows_html(flat_params):
+    rows = []
+    for key, value in flat_params.items():
+        rows.append(
+            f"<tr><td><b>{html.escape(str(key))}</b></td>"
+            f"<td>{html.escape(_format_value(value))}</td></tr>"
+        )
+    return "".join(rows)
+
+
+def _build_section_html(section_title, flat_params, show_heading):
+    heading = f'<h4 class="section-title">{html.escape(section_title)}</h4>' if show_heading else ''
+    rows = _build_rows_html(flat_params)
+    return (
+        f'{heading}<div class="table-card"><table>'
+        f'<tr><th>Parameter</th><th>Value</th></tr>{rows}</table></div>'
+    )
+
+
+def _build_page_html(title, sections):
+    """sections: list of (section_title, flat_params_dict) pairs. A single
+    section renders with no sub-heading; multiple sections each get their
+    own labelled table-card."""
+    show_heading = len(sections) > 1
+    sections_html = "".join(
+        _build_section_html(section_title, flat_params, show_heading)
+        for section_title, flat_params in sections
+    )
+    page = _PAGE_TEMPLATE.replace("__QOLS_TITLE__", html.escape(title))
+    page = page.replace("__QOLS_SECTIONS__", sections_html)
+    return page
+
+
+class ClipboardBridge(QObject):
+    """JS-callable bridge (via QWebChannel) that copies a clean, Word-pasteable
+    HTML table to the native clipboard -- QWebEngineView content runs in a
+    separate process/sandbox, so JS can't touch the OS clipboard directly."""
+
+    def __init__(self, sections):
+        super().__init__()
+        self._sections = sections
+
+    @pyqtSlot()
+    def copyToClipboard(self):
+        multi = len(self._sections) > 1
+        html_parts = []
+        text_parts = []
+        for section_title, flat_params in self._sections:
+            html_parts.append(format_parameters_table(section_title, flat_params, as_html=True))
+            text_parts.append(format_parameters_table(section_title, flat_params, as_html=False))
+        mime = QMimeData()
+        mime.setHtml("<div>" + "<br>".join(html_parts) + "</div>" if multi else html_parts[0])
+        mime.setText("\n\n".join(text_parts))
+        QApplication.clipboard().setMimeData(mime)
+
+
+def show_web_popup(title, sections):
+    """Show a Parameters Inspector popup for one or more (section_title,
+    flat_params_dict) pairs. Non-modal; kept alive in _open_views until the
+    window is closed. Uses QWebEngineView when available (dark-mode-by-
+    default with a live toggle), falling back to a QTextBrowser popup
+    otherwise."""
+    if _WEBENGINE_AVAILABLE:
+        return _show_webengine_popup(title, sections)
+    return _show_textbrowser_popup(title, sections)
+
+
+def _show_webengine_popup(title, sections):
+    page_html = _build_page_html(title, sections)
+
+    view = QWebEngineView()
+    bridge = ClipboardBridge(sections)
+    channel = QWebChannel(view.page())
+    view.page().setWebChannel(channel)
+    channel.registerObject("pyBridge", bridge)
+
+    view.setHtml(page_html)
+    view.setWindowTitle(title)
+
+    screen = view.screen().geometry()
+    max_width = int(screen.width() / 3)
+    max_height = int(screen.height() * 0.75)
+    view.resize(max_width, max_height)
+
+    def _fit_to_content(_ok=None):
+        view.page().runJavaScript(
+            "document.getElementById('main-container').offsetHeight",
+            lambda rendered_height: view.resize(max_width, min(int(rendered_height) + 12, max_height))
+        )
+
+    view.loadFinished.connect(_fit_to_content)
+
+    key = id(view)
+    _open_views[key] = (view, bridge, channel)
+    view.destroyed.connect(lambda: _open_views.pop(key, None))
+
+    view.show()
+    return view
+
+
+# ---------------------------------------------------------------------------
+# QTextBrowser fallback (no QtWebEngine available): a static render of the
+# same data, dark-by-default. QTextBrowser can't run JavaScript, so the
+# light/dark toggle and "Copy to Word" are plain QPushButtons instead of the
+# JS/QWebChannel-driven controls in the WebEngine version.
+# ---------------------------------------------------------------------------
+
+_FALLBACK_PALETTES = {
+    'dark': {
+        'bg': '#0f172a', 'title_fg': '#f8fafc', 'h3_fg': '#f8fafc', 'h3_border': '#1e293b',
+        'section_fg': '#94a3b8', 'card_border': '#334155',
+        'th_bg': '#020617', 'th_fg': '#38bdf8',
+        'row_even': '#1e293b', 'row_odd': '#111827', 'td_border': '#334155',
+        'key_fg': '#f1f5f9', 'value_fg': '#94a3b8',
+    },
+    'light': {
+        'bg': '#f4f6f9', 'title_fg': '#1e293b', 'h3_fg': '#1e293b', 'h3_border': '#e2e8f0',
+        'section_fg': '#475569', 'card_border': '#e2e8f0',
+        'th_bg': '#0f172a', 'th_fg': '#ffffff',
+        'row_even': '#ffffff', 'row_odd': '#f8fafc', 'td_border': '#f1f5f9',
+        'key_fg': '#1e293b', 'value_fg': '#475569',
+    },
+}
+
+
+def _build_fallback_rows_html(flat_params, palette):
+    rows = []
+    for idx, (key, value) in enumerate(flat_params.items()):
+        bg = palette['row_even'] if idx % 2 == 0 else palette['row_odd']
+        rows.append(
+            f'<tr>'
+            f'<td style="background-color:{bg}; color:{palette["key_fg"]}; padding:10px; '
+            f'border-bottom:1px solid {palette["td_border"]};"><b>{html.escape(str(key))}</b></td>'
+            f'<td style="background-color:{bg}; color:{palette["value_fg"]}; padding:10px; '
+            f'border-bottom:1px solid {palette["td_border"]};">{html.escape(_format_value(value))}</td></tr>'
+        )
+    return "".join(rows)
+
+
+def _build_fallback_section_html(section_title, flat_params, show_heading, palette):
+    heading = (
+        f'<h4 style="color:{palette["section_fg"]}; text-transform:uppercase; font-size:12px; '
+        f'letter-spacing:0.05em; margin:20px 0 8px 0;">{html.escape(section_title)}</h4>'
+    ) if show_heading else ''
+    rows = _build_fallback_rows_html(flat_params, palette)
+    header_style = (
+        f'background-color:{palette["th_bg"]}; color:{palette["th_fg"]}; padding:12px; text-align:left; '
+        'text-transform:uppercase; font-size:12px;'
+    )
+    return (
+        f'{heading}<table style="width:100%; border-collapse:collapse; '
+        f'border:1px solid {palette["card_border"]}; border-radius:8px;">'
+        f'<tr><th style="{header_style}">Parameter</th><th style="{header_style}">Value</th></tr>'
+        f'{rows}</table>'
+    )
+
+
+def _build_fallback_page_html(title, sections, theme='dark'):
+    palette = _FALLBACK_PALETTES[theme]
+    show_heading = len(sections) > 1
+    sections_html = "".join(
+        _build_fallback_section_html(section_title, flat_params, show_heading, palette)
+        for section_title, flat_params in sections
+    )
+    return (
+        f'<body style="background-color:{palette["bg"]}; color:{palette["value_fg"]}; '
+        'font-family:\'Segoe UI\',Arial,sans-serif; padding:4px;">'
+        f'<h3 style="color:{palette["h3_fg"]}; border-bottom:2px solid {palette["h3_border"]}; '
+        'padding-bottom:8px; margin-top:0;">Feature Parameters</h3>'
+        f'{sections_html}</body>'
+    )
+
+
+class _FallbackParametersDialog(QDialog):
+    """Static QTextBrowser popup used when QtWebEngine isn't installed.
+    Ships its own native (non-JS) light/dark toggle button."""
+
+    def __init__(self, title, sections, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setMinimumSize(520, 360)
+        self._sections = sections
+        self._title = title
+        self._theme = 'dark'
+
+        layout = QVBoxLayout(self)
+
+        header_row = QHBoxLayout()
+        title_label = QLabel(title)
+        title_label.setStyleSheet("font-size: 16px; font-weight: 600; color: #f8fafc;")
+        header_row.addWidget(title_label)
+        header_row.addStretch()
+        copy_btn = QPushButton("Copy to Word")
+        copy_btn.clicked.connect(self._copy_to_word)
+        header_row.addWidget(copy_btn)
+        self._theme_btn = QPushButton()
+        self._theme_btn.clicked.connect(self._toggle_theme)
+        header_row.addWidget(self._theme_btn)
+        layout.addLayout(header_row)
+
+        self._browser = QTextBrowser(self)
+        layout.addWidget(self._browser)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        button_row.addWidget(close_btn)
+        layout.addLayout(button_row)
+
+        self._render()
+
+    def _render(self):
+        palette = _FALLBACK_PALETTES[self._theme]
+        self._theme_btn.setText("🌙 Dark Mode" if self._theme == 'dark' else "☀ Light Mode")
+        self._browser.setStyleSheet(
+            f"QTextBrowser {{ background-color: {palette['bg']}; border: 1px solid {palette['card_border']}; }}"
+        )
+        self._browser.setHtml(_build_fallback_page_html(self._title, self._sections, self._theme))
+
+    def _toggle_theme(self):
+        self._theme = 'light' if self._theme == 'dark' else 'dark'
+        self._render()
+
+    def _copy_to_word(self):
+        ClipboardBridge(self._sections).copyToClipboard()
+
+
+def _show_textbrowser_popup(title, sections):
+    dialog = _FallbackParametersDialog(title, sections)
+    key = id(dialog)
+    _open_views[key] = dialog
+    dialog.finished.connect(lambda _result: _open_views.pop(key, None))
+    dialog.show()
+    return dialog
+
+
+# ---------------------------------------------------------------------------
+# QGIS layer action wiring
+# ---------------------------------------------------------------------------
+
+def resolve_inspector_title(parameters_dict, fallback):
+    """Pick a readable popup title: the stored 'calculation_type' if
+    present, else *fallback* (e.g. the layer name)."""
+    calculation_type = parameters_dict.get('calculation_type') if isinstance(parameters_dict, dict) else None
+    subject = calculation_type or fallback
+    return f"{subject} — Feature Parameters"
+
+
+def show_parameters_inspector(layer_id, feature_id):
+    """Entry point for the QGIS layer action registered by
+    register_parameters_action(). Resolves the feature's stored
+    'parameters' JSON and shows it in a Parameters Inspector popup."""
+    layer = QgsProject.instance().mapLayer(layer_id)
+    if layer is None:
+        QMessageBox.warning(None, "Parameters Inspector", "Could not find the source layer.")
+        return
+
+    feature = layer.getFeature(feature_id)
+    if not feature.isValid():
+        QMessageBox.warning(None, "Parameters Inspector", "Could not find the selected feature.")
+        return
+
+    raw = feature.attribute('parameters')
+    if not raw:
+        QMessageBox.information(None, "Parameters Inspector", "This feature has no stored parameters.")
+        return
+
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        QMessageBox.warning(None, "Parameters Inspector", "The stored parameters could not be parsed as JSON.")
+        return
+
+    title = resolve_inspector_title(parsed, layer.name())
+    show_web_popup(title, [(layer.name(), parsed)])
+
+
+def register_parameters_action(layer):
+    """Register the 'view parameters as HTML Table' QGIS layer action on
+    *layer*, so any feature with a 'parameters' attribute can be inspected
+    as a rendered HTML table from the Attribute Table / canvas Identify
+    results. Action scopes are set explicitly to Feature and Canvas --
+    without this the action is registered but invisible until a user
+    manually enables those scopes in Layer Properties > Actions."""
+    action_code = (
+        "from qols.parameters_inspector import show_parameters_inspector\n"
+        "show_parameters_inspector('[% @layer_id %]', [% $id %])"
+    )
+    action = QgsAction(ACTION_TYPE_GENERIC_PYTHON, "view parameters as HTML Table", action_code)
+    action.setActionScopes({'Feature', 'Canvas'})
+    layer.actions().addAction(action)
+
+
+# ---------------------------------------------------------------------------
+# Dockwidget "Show Table" button (#118 follow-up)
+# ---------------------------------------------------------------------------
+
+def collect_project_parameter_sections():
+    """Scan every vector layer in the current project for a 'parameters'
+    field and return [(layer_name, params_dict), ...] — one entry per
+    layer, using its first feature's stored JSON as representative (every
+    feature qOLS writes to a given surface layer shares the same params
+    blob). Layers without the field, or with unparsable JSON, are skipped."""
+    sections = []
+    for layer in QgsProject.instance().mapLayers().values():
+        if not isinstance(layer, QgsVectorLayer):
+            continue
+        if layer.fields().indexOf('parameters') == -1:
+            continue
+        for feature in layer.getFeatures():
+            raw = feature.attribute('parameters')
+            if not raw:
+                continue
+            try:
+                sections.append((layer.name(), json.loads(raw)))
+            except (TypeError, ValueError):
+                pass
+            break
+    return sections
+
+
+def show_project_parameters_table():
+    """Entry point for the dockwidgets' 'Show Table' button: show every
+    calculated surface currently in the project (that has stored
+    parameters) as a multi-section HTML table, so a user can review what
+    inputs produced them without re-running Calculate."""
+    sections = collect_project_parameter_sections()
+    if not sections:
+        sections = [(
+            "No data",
+            {'message': 'No calculated surfaces with stored parameters found. Run Calculate first.'},
+        )]
+    return show_web_popup("qOLS Surfaces — Feature Parameters", sections)

--- a/qols/scripts/OFZ_UTM.py
+++ b/qols/scripts/OFZ_UTM.py
@@ -299,12 +299,36 @@ v_layer.dataProvider().addAttributes([NameField])
 v_layer.dataProvider().addAttributes([RuleField])
 v_layer.updateFields()
 
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('Obstacle Free Zone', {
+    'code': code,
+    'rwy_classification': rwyClassification,
+    'width': width,
+    'Z0': Z0,
+    'ZE': ZE,
+    'ARPH': ARPH,
+    'IHSlope': IHSlope,
+    'IA_width': IA_width,
+    'IA_distance_from_thr': IA_distance_from_thr,
+    'IA_length': IA_length,
+    'IA_slope': IA_slope,
+    'BL_width': BL_width,
+    'BL_distance_from_thr': BL_distance_from_thr,
+    'BL_divergence': BL_divergence,
+    'BL_slope': BL_slope,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
 # Runway Inner Strip Surface Polygon
 SurfaceArea = [pt_03,pt_03L,pt_0L,pt_01L,pt_01,pt_01R,pt_0R,pt_03R]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([1,'Runway Inner Strip', globals().get('active_rule_set', None)])
+seg.setAttributes([1,'Runway Inner Strip', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
 
 # Inner Approach Surface Polygon
@@ -312,7 +336,7 @@ SurfaceArea = [pt_01,pt_01L,pt_02L,pt_02,pt_02R,pt_01R]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([2,'Inner Approach Surface', globals().get('active_rule_set', None)])
+seg.setAttributes([2,'Inner Approach Surface', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
 
 # Balked Landing Surface Polygon
@@ -320,7 +344,7 @@ SurfaceArea = [pt_04,pt_04L,pt_03L,pt_03,pt_03R,pt_04R]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([3,'Balked Landing Surface', globals().get('active_rule_set', None)])
+seg.setAttributes([3,'Balked Landing Surface', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
 
 # Inner Transitional Right Surface Polygon
@@ -328,7 +352,7 @@ SurfaceArea = [pt_04R,pt_03R,pt_0R,pt_01R,pt_02R,pt_I02R,pt_I01R,pt_I0R,pt_I03R]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([4,'Inner Transitional Surface - Right Side', globals().get('active_rule_set', None)])
+seg.setAttributes([4,'Inner Transitional Surface - Right Side', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
 
 # Inner Transitional Left Surface Polygon
@@ -336,8 +360,10 @@ SurfaceArea = [pt_04L,pt_03L,pt_0L,pt_01L,pt_02L,pt_I02L,pt_I01L,pt_I0L,pt_I03L]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([5,'Inner Transitional Surface - Left Side', globals().get('active_rule_set', None)])
+seg.setAttributes([5,'Inner Transitional Surface - Left Side', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
+
+register_parameters_action(v_layer)
 
 QgsProject.instance().addMapLayers([v_layer])
 

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -297,12 +297,29 @@ v_layer.dataProvider().addAttributes([NameField])
 v_layer.dataProvider().addAttributes([RuleField])
 v_layer.updateFields()
 
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('Transitional Surface', {
+    'code': code,
+    'rwy_classification': rwyClassification,
+    'widthApp': widthApp,
+    'Z0': Z0,
+    'ZE': ZE,
+    'ARPH': ARPH,
+    'Tslope': Tslope,
+    'direction': s,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
 # Left Transition Surface
 SurfaceArea = [pt_08L,pt_01TL,pt_02TL,pt_02L,pt_01AL]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([10,'Left Transitional Surface', globals().get('active_rule_set', None)])
+seg.setAttributes([10,'Left Transitional Surface', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
 
 # Right Transition Surface
@@ -310,8 +327,10 @@ SurfaceArea = [pt_08R,pt_01TR,pt_02TR,pt_02R,pt_01AR]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([11,'Right Transitional Surface', globals().get('active_rule_set', None)])
+seg.setAttributes([11,'Right Transitional Surface', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
+
+register_parameters_action(v_layer)
 
 QgsProject.instance().addMapLayers([v_layer])
 

--- a/qols/scripts/approach-surface-UTM.py
+++ b/qols/scripts/approach-surface-UTM.py
@@ -361,11 +361,13 @@ code_field = QgsField('Code', QVariant.Int)
 rule_field = QgsField('rule_set', QVariant.String)
 start_elev_field = QgsField('surface_start_elev', QVariant.Double)
 end_elev_field = QgsField('surface_end_elev', QVariant.Double)
-params_json_field = QgsField('params_json', QVariant.String)
-approach_layer.dataProvider().addAttributes([id_field, name_field, type_field, code_field, rule_field, start_elev_field, end_elev_field, params_json_field])
+approach_layer.dataProvider().addAttributes([id_field, name_field, type_field, code_field, rule_field, start_elev_field, end_elev_field])
 approach_layer.updateFields()
 
-_params_json = json.dumps({
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+
+_params_json = build_parameters_json('Approach Surface', {
     'Z0': round(start_elevation_m, 3),
     'ZE': round(end_elevation_m, 3),
     'ARPH': round(arp_elevation_m, 3),
@@ -380,6 +382,7 @@ _params_json = json.dumps({
     'runway_code': runway_code,
     'rule_set': globals().get('active_rule_set', None),
 })
+add_parameters_field(approach_layer)
 
 provider = approach_layer.dataProvider()
 for fid, name, surface_area, sec_start_elev, sec_end_elev in features_to_create:
@@ -387,6 +390,8 @@ for fid, name, surface_area, sec_start_elev, sec_end_elev in features_to_create:
     feature.setGeometry(QgsPolygon(QgsLineString(surface_area), rings=[]))
     feature.setAttributes([fid, name, rwy_classification, runway_code, globals().get('active_rule_set', None), round(sec_start_elev, 3), round(sec_end_elev, 3), _params_json])
     provider.addFeatures([feature])
+
+register_parameters_action(approach_layer)
 
 # Load PolygonZ Layer to map canvas
 QgsProject.instance().addMapLayers([approach_layer])

--- a/qols/scripts/conical.py
+++ b/qols/scripts/conical.py
@@ -229,6 +229,20 @@ v_layer_provider.addAttributes([
 ])
 v_layer.updateFields()
 
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('Conical Surface', {
+    'radius_m': L,
+    'height_m': height,
+    'rule_set': _active_rule_set,
+    'azimuth': angle0,
+    'rwy_classification': rwy_classification,
+    'runway_code': int(runway_code),
+})
+add_parameters_field(v_layer)
+
 print(f"Conical: Creating unified 3D surface with radius {L}m at height {height}m")
 
 polygon_points = []
@@ -364,14 +378,15 @@ feature.setAttributes([
     "Conical",
     L,
     height,
-    globals().get('active_rule_set', None),
+    _active_rule_set,
     start_point.x(),
     start_point.y(),
     end_point.x(),
     end_point.y(),
     angle0,
     rwy_classification,
-    int(runway_code)
+    int(runway_code),
+    _params_json,
 ])
 
 # Add feature to layer
@@ -379,6 +394,8 @@ v_layer_provider.addFeatures([feature])
 
 v_layer.updateExtents()
 print(f"Conical: Created conical 3D surface")
+
+register_parameters_action(v_layer)
 
 # Add to map
 QgsProject.instance().addMapLayers([v_layer])

--- a/qols/scripts/inner-horizontal-racetrack.py
+++ b/qols/scripts/inner-horizontal-racetrack.py
@@ -133,6 +133,19 @@ v_layer_provider.addAttributes([
 ])
 v_layer.updateFields()
 
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('Inner Horizontal Surface', {
+    'radius_m': L,
+    'height_m': height,
+    'rule_set': _active_rule_set,
+    'rwy_classification': rwy_classification,
+    'runway_code': int(runway_code),
+})
+add_parameters_field(v_layer)
+
 features_created = 0
 
 # Process each runway feature
@@ -349,14 +362,15 @@ for feat in selection:
         "Inner Horizontal",
         L,
         height,
-        globals().get('active_rule_set', None),
+        _active_rule_set,
         start_point.x(),
         start_point.y(),
         end_point.x(),
         end_point.y(),
         azimuth,
         rwy_classification,
-        int(runway_code)
+        int(runway_code),
+        _params_json,
     ])
 
     # Add feature to layer
@@ -367,6 +381,8 @@ for feat in selection:
 
 v_layer.updateExtents()
 print(f"InnerHorizontal: Created {features_created} inner horizontal surface(s)")
+
+register_parameters_action(v_layer)
 
 # Add to map
 QgsProject.instance().addMapLayers([v_layer])

--- a/qols/scripts/new-ols-oes-transitional-UTM.py
+++ b/qols/scripts/new-ols-oes-transitional-UTM.py
@@ -30,6 +30,7 @@ from qgis.core import *
 from qgis.PyQt.QtCore import *
 from qgis.PyQt.QtGui import *
 from math import sqrt, hypot
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
 
 _script_success = False
 
@@ -284,14 +285,33 @@ oes_layer.dataProvider().addAttributes([
     QgsField('cap_elevation_m', QVariant.Double),
     QgsField('d_cap_m', QVariant.Double),
     QgsField('lateral_near_m', QVariant.Double),
+    QgsField('rule_set', QVariant.String),  # was missing vs. every other script (#118)
 ])
 oes_layer.updateFields()
+
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('New OLS OES Transitional', {
+    'width_m': width_m,
+    'start_elevation_m': round(start_elevation_m, 3),
+    'end_elevation_m': round(end_elevation_m, 3),
+    'highest_thr_elev_m': round(highest_thr_elev_m, 3),
+    'slope_pct': slope_pct,
+    'cap_height_m': cap_height_m,
+    'approach_slope_pct': approach_slope_pct,
+    'divergence_ratio': divergence_ratio,
+    'distance_from_threshold_m': distance_from_threshold_m,
+    'direction': direction,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(oes_layer)
 
 feat_l = QgsFeature()
 feat_l.setGeometry(QgsPolygon(QgsLineString(left_ring + [left_ring[0]])))
 feat_l.setAttributes([
     1, 'New OLS OES Transitional', 'left',
     slope_pct, round(cap_elevation, 3), round(d_cap, 1), round(lateral_near, 1),
+    _active_rule_set, _params_json,
 ])
 
 feat_r = QgsFeature()
@@ -299,9 +319,12 @@ feat_r.setGeometry(QgsPolygon(QgsLineString(right_ring + [right_ring[0]])))
 feat_r.setAttributes([
     2, 'New OLS OES Transitional', 'right',
     slope_pct, round(cap_elevation, 3), round(d_cap, 1), round(lateral_near, 1),
+    _active_rule_set, _params_json,
 ])
 
 oes_layer.dataProvider().addFeatures([feat_l, feat_r])
+
+register_parameters_action(oes_layer)
 
 QgsProject.instance().addMapLayers([oes_layer])
 oes_layer.renderer().symbol().setColor(QColor("#87CEEB"))  # sky blue

--- a/qols/scripts/new-ols-ofs-approach-UTM.py
+++ b/qols/scripts/new-ols-ofs-approach-UTM.py
@@ -10,7 +10,7 @@ from qgis.core import *
 from qgis.PyQt.QtCore import *
 from qgis.PyQt.QtGui import *
 from math import sqrt, hypot
-import json
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
 
 _script_success = False
 
@@ -186,11 +186,11 @@ approach_layer.dataProvider().addAttributes([
     QgsField('slope_pct', QVariant.Double),
     QgsField('surface_start_elev', QVariant.Double),
     QgsField('surface_end_elev', QVariant.Double),
-    QgsField('params_json', QVariant.String),
 ])
 approach_layer.updateFields()
 
-_params_json = json.dumps({
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+_params_json = build_parameters_json('New OLS OFS Approach', {
     'rwy_type': rwy_type,
     'adg': adg,
     'runway_width_m': runway_width_m,
@@ -202,6 +202,7 @@ _params_json = json.dumps({
     'start_elevation_m': round(start_elevation_m, 3),
     'end_elevation_m': round(end_elevation_m, 3),
 })
+add_parameters_field(approach_layer)
 
 feat = QgsFeature()
 feat.setGeometry(QgsPolygon(QgsLineString([pt_inner_r, pt_inner_l, pt_outer_l, pt_outer_r, pt_inner_r])))
@@ -211,6 +212,8 @@ feat.setAttributes([
     round(start_elevation_m, 3), round(height_outer, 3), _params_json,
 ])
 approach_layer.dataProvider().addFeatures([feat])
+
+register_parameters_action(approach_layer)
 
 QgsProject.instance().addMapLayers([approach_layer])
 approach_layer.renderer().symbol().setColor(QColor("#FF69B4"))  # pink — matches diagram

--- a/qols/scripts/outer-horizontal.py
+++ b/qols/scripts/outer-horizontal.py
@@ -66,6 +66,18 @@ v_layer_provider.addAttributes([
 ])
 v_layer.updateFields()
 
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('Outer Horizontal Surface', {
+    'code': code,
+    'radius_m': radius,
+    'height_m': height,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
 # Process each ARP point
 features_created = 0
 for feat in selection:
@@ -96,9 +108,10 @@ for feat in selection:
         code,
         radius,
         height,
-        globals().get('active_rule_set', None),
+        _active_rule_set,
         arp_x,
-        arp_y
+        arp_y,
+        _params_json,
     ])
 
     # Add feature to layer
@@ -109,6 +122,8 @@ for feat in selection:
 
 v_layer.updateExtents()
 print(f"OuterHorizontal: Created {features_created} outer horizontal surface(s)")
+
+register_parameters_action(v_layer)
 
 # Add to map
 QgsProject.instance().addMapLayers([v_layer])

--- a/qols/scripts/take-off-surface_UTM.py
+++ b/qols/scripts/take-off-surface_UTM.py
@@ -290,13 +290,37 @@ v_layer.dataProvider().addAttributes([NameField])
 v_layer.dataProvider().addAttributes([RuleField])
 v_layer.updateFields()
 
+# Store the full input parameter set as HTML-inspectable JSON (#118)
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('Take-Off Climb Surface', {
+    'code': code,
+    'widthApp': widthApp,
+    'widthDep': widthDep,
+    'maxWidthDep': maxWidthDep,
+    'CWYLength': CWYLength,
+    'Z0': Z0,
+    'ZE': ZE,
+    'ARPH': ARPH,
+    'divergencePct': divergencePct,
+    'startDistance': startDistance,
+    'surfaceLength': surfaceLength,
+    'slopePct': slopePct,
+    'direction': s,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
 # Take Off Climb Surface Creation - EXACTLY as original
 SurfaceArea = [pt_03DR,pt_03DL,pt_02DL,pt_01DL,pt_01DR,pt_02DR]
 pr = v_layer.dataProvider()
 seg = QgsFeature()
 seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([13,'TakeOff Climb Surface', globals().get('active_rule_set', None)])
+seg.setAttributes([13,'TakeOff Climb Surface', _active_rule_set, _params_json])
 pr.addFeatures( [ seg ] )
+
+register_parameters_action(v_layer)
 
 # Load PolygonZ Layer to map canvas - EXACTLY as original
 QgsProject.instance().addMapLayers([v_layer])

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -29,9 +29,10 @@ from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
     QApplication, QCheckBox, QComboBox, QDialog, QDockWidget,
-    QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
+    QLabel, QLineEdit, QMessageBox, QPushButton, QTextBrowser, QToolTip, QVBoxLayout,
 )
 from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
+from ..parameters_inspector import show_project_parameters_table
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
 
 # Load the UI file
@@ -229,6 +230,14 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
             self._connect(self.directionButton.clicked, self.toggle_direction)
             self._connect(self.button_rotate_transitional.clicked, self.toggle_transitional_direction)
+
+            # "Show Table" button — view stored surface parameters as HTML (#118)
+            self.showTableButton = QPushButton("Show Table")
+            self.showTableButton.setMinimumHeight(30)
+            self.showTableButton.setMaximumHeight(32)
+            self.showTableButton.setToolTip("View calculated surfaces' stored parameters as an HTML table")
+            self.buttonLayout.insertWidget(self.buttonLayout.indexOf(self.cancelButton), self.showTableButton)
+            self._connect(self.showTableButton.clicked, self.show_parameters_table)
 
             # Connect tab change to reinitialize defaults (helpful for widget visibility)
             self._connect(self.scriptTabWidget.currentChanged, self.on_tab_changed)
@@ -1353,6 +1362,15 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
 
         except Exception as e:
             return f"Error getting layer summary: {e}"
+
+    def show_parameters_table(self):
+        """Show every calculated surface's stored parameters as an HTML
+        table (#118) — lets a user review what inputs produced a surface
+        without re-running Calculate."""
+        try:
+            show_project_parameters_table()
+        except Exception as e:
+            logger.warning(f"Could not show parameters table: {e}")
 
     def toggle_direction(self):
         """Toggle direction between Start to End and End to Start."""

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -15,9 +15,10 @@ from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
     QApplication, QComboBox, QDialog, QDockWidget,
-    QLabel, QLineEdit, QMessageBox, QTextBrowser, QToolTip, QVBoxLayout,
+    QLabel, QLineEdit, QMessageBox, QPushButton, QTextBrowser, QToolTip, QVBoxLayout,
 )
 from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL
+from ..parameters_inspector import show_project_parameters_table
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -119,6 +120,14 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(self.calculateButton.clicked, self.on_calculate_clicked)
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
             self._connect(self.directionButton.clicked, self.toggle_direction)
+
+            # "Show Table" button — view stored surface parameters as HTML (#118)
+            self.showTableButton = QPushButton("Show Table")
+            self.showTableButton.setMinimumHeight(30)
+            self.showTableButton.setMaximumHeight(32)
+            self.showTableButton.setToolTip("View calculated surfaces' stored parameters as an HTML table")
+            self.buttonLayout.insertWidget(self.buttonLayout.indexOf(self.cancelButton), self.showTableButton)
+            self._connect(self.showTableButton.clicked, self.show_parameters_table)
 
             self.direction_start_to_end = True
             self.update_direction_button()
@@ -655,6 +664,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         except Exception as e:
             self.show_error_message(f"Error collecting parameters: {str(e)}")
             return None
+
+    def show_parameters_table(self):
+        """Show every calculated surface's stored parameters as an HTML
+        table (#118) — lets a user review what inputs produced a surface
+        without re-running Calculate."""
+        try:
+            show_project_parameters_table()
+        except Exception as e:
+            logger.warning(f"Could not show parameters table: {e}")
 
     def toggle_direction(self):
         self.direction_start_to_end = not self.direction_start_to_end

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,9 @@ exclude =
     __pycache__,
     .venv,
     tests
+
+per-file-ignores =
+    # parameters_inspector.py: embedded HTML/CSS/JS popup template kept as
+    # single-line CSS rules for easy visual scanning/diffing (matches the
+    # same convention in qpansopy's own parameters_inspector_dialog.py).
+    qols/parameters_inspector.py: E501


### PR DESCRIPTION
# feat(#118): store surface parameters in a field + show as HTML

## Summary

Closes #118.

Issue #118 "when a surface is created the
parameters are not stored in surface[s] to be reviewed in case something
has been changed. This needs to happen for all surfaces" — explicitly
extending what the sibling plugin `qpansopy` already does: every
calculated output feature stores a `parameters` JSON field, and a
`QgsAction` ("view parameters as HTML Table") lets a user right-click a
feature (attribute table or canvas Identify results) and pop up a
themeable HTML table of exactly what inputs produced it, with a
"Copy to Word" button.

Applies to all 8 classic surface types + both New OLS surfaces (primary
polygon output layer only, per the user's decision — contour/step-line
sub-layers are unchanged). `Combined Inner+Conical` needed no separate
work: it just runs `conical.py` + `inner-horizontal-racetrack.py`, so it
inherits both scripts' new field automatically.

On top of the original scope, the user asked for a second access path
beyond the per-feature `QgsAction`: a **"Show Table"** button in both
dockwidgets that aggregates every calculated surface's stored parameters
across the whole project into one popup, without needing to right-click
a specific feature first.

---

## Changes

### `qols/parameters_inspector.py` (new)

Ported near-verbatim from qpansopy's `Q_Pansopy/parameters_inspector_dialog.py`
plus `format_parameters_table`/`_humanize_param_label` from its `utils.py`:

- `_PAGE_TEMPLATE` / `_build_rows_html` / `_build_section_html` /
  `_build_page_html` — dark/light-theme HTML popup, JS theme toggle.
- `ClipboardBridge` (`QObject` + `QWebChannel`) — "Copy to Word" puts both
  HTML and plain-text table representations on the clipboard.
- `show_web_popup(title, sections)` — dispatches to `QWebEngineView` when
  available, falls back to a static `QTextBrowser` dialog
  (`_FallbackParametersDialog`) when `QtWebEngineWidgets`/`QtWebChannel`
  aren't installed (optional, heavy Qt add-ons not bundled with every
  QGIS).
- `resolve_inspector_title(parameters_dict, fallback)`,
  `show_parameters_inspector(layer_id, feature_id)` — looked up by the
  `QgsAction`'s expression-driven action code.
- `register_parameters_action(layer)` — adds a `GenericPython` action
  scoped to `{'Feature', 'Canvas'}`, named `"view parameters as HTML
  Table"`, whose code is
  `show_parameters_inspector('[% @layer_id %]', [% $id %])` (QGIS
  expression substitution — never interpolates raw JSON into the code
  string).

New helpers (not in qpansopy, needed because qOLS centralizes what
qpansopy left per-calculation-module):

- `build_parameters_json(calculation_type, params: dict) -> str` — merges
  `calculation_type` and a `generated_at` ISO timestamp into `params`,
  returns `json.dumps(...)`; does not mutate the input dict.
- `add_parameters_field(layer)` — idempotently appends
  `QgsField('parameters', QVariant.String)` if not already present.

Added for the "Show Table" button follow-up:

- `collect_project_parameter_sections()` — scans every `QgsVectorLayer`
  in the current `QgsProject` that has a `parameters` field, reads the
  first feature with a parsable JSON value from each, and returns
  `[(layer_name, parsed_dict), ...]`. Skips non-vector layers, layers
  without the field, and unparsable JSON rather than raising.
- `show_project_parameters_table()` — calls the above and opens one
  multi-section popup covering every calculated surface in the project
  (falls back to a "No calculated surfaces with stored parameters found"
  placeholder section when nothing qualifies yet).

### `qols/compat.py`

- Added `ACTION_TYPE_GENERIC_PYTHON` (QGIS3 `QgsAction.GenericPython` vs
  QGIS4 `QgsAction.ActionType.GenericPython`), same try/except shim
  pattern as the rest of the file.

### Nine `qols/scripts/*.py` files

Each primary-output-layer script now imports `build_parameters_json`,
`add_parameters_field`, `register_parameters_action` from
`qols.parameters_inspector`, builds a `calculation_type`-labelled params
dict from values already in the script's `exec()` scope, adds the
`parameters` field, appends its value as the last positional entry in
every `setAttributes([...])` call, and registers the viewer action right
before `QgsProject.instance().addMapLayer(s)`:

`approach-surface-UTM.py`, `conical.py`, `inner-horizontal-racetrack.py`,
`OFZ_UTM.py`, `outer-horizontal.py`, `take-off-surface_UTM.py`,
`TransitionalSurface_UTM.py`, `new-ols-ofs-approach-UTM.py`,
`new-ols-oes-transitional-UTM.py`.

- `approach-surface-UTM.py` and `new-ols-ofs-approach-UTM.py` already had
  an ad-hoc `params_json` field from #113/#117 — replaced with the shared
  `parameters` field (matching qpansopy's field name) instead of carrying
  a redundant second JSON field.
- `new-ols-oes-transitional-UTM.py` was also missing a `rule_set` field
  that every other script already had — fixed opportunistically in the
  same edit, not unrelated scope creep. Its `from qols.parameters_inspector
  import ...` line was placed in the top-of-file import block (this
  script, unlike the other 8, has no `# flake8: noqa`), which also fixed a
  new `F401 'json' imported but unused` left over from replacing
  `json.dumps` with `build_parameters_json`.

### `qols/ui/dockwidget.py` and `qols/ui/new_ols_dockwidget.py`

New **"Show Table"** button, added programmatically to each panel's
existing `buttonLayout` (no `.ui` file edits — mirrors qpansopy's own
`setup_copy_button()` precedent of building a button in Python and
appending it to an existing layout):

- `showTableButton = QPushButton("Show Table")`, inserted before the
  Cancel/Close button, wired via the repo's `_connect()` helper (CLAUDE.md
  Signal Connection Pattern) to a new `show_parameters_table()` method.
- `show_parameters_table()` calls `show_project_parameters_table()` inside
  a try/except, logging a warning on failure instead of raising into the
  UI event loop.

### `tests/conftest.py`

- Stubbed `qgis.PyQt.QtWebEngineWidgets` / `qgis.PyQt.QtWebChannel`
  (mirrors qpansopy's own conftest) so `qols.parameters_inspector` imports
  cleanly under test.
- Added `_FakeQDialog` / `_FakeQObject` real classes (wired as
  `QtWidgets.QDialog` / `QtCore.QObject`) — a bare `MagicMock()` used as a
  *single* base class doesn't raise on subclassing but silently produces a
  non-functional pseudo-class, which `_FallbackParametersDialog(QDialog)`
  and `ClipboardBridge(QObject)` need to avoid. `_FakeQDialog` defines
  `__getattr__` returning `MagicMock()` so calls like
  `self.setWindowTitle(...)` and `dialog.finished.connect(...)` both work
  under test.

### `setup.cfg`

- Added a `[flake8] per-file-ignores` entry silencing `E501` specifically
  on `qols/parameters_inspector.py`'s embedded HTML/CSS/JS template
  (kept as single-line CSS rules for easy visual diffing), replicating the
  identical convention already present in qpansopy's own `setup.cfg`.

---

## Verification

```bash
pytest -q --ignore=tests/test_direction_marker.py
# 500 passed
# (test_direction_marker.py is a stray local file left over from the
#  separate, unmerged feature/117-direction-marker branch; it imports a
#  module that doesn't exist on this branch and is unrelated to #118)

flake8 qols/parameters_inspector.py qols/ui/dockwidget.py qols/ui/new_ols_dockwidget.py
# only the two pre-existing, already-documented F821 findings in
# dockwidget.py (dead-code baseline, get_new_ols_approach_defaults /
# get_new_ols_transitional_defaults) — no new issues
```

Manual QGIS check (still pending — QgsAction wiring and Qt popups can't
be exercised by pytest):

- For at least 2-3 surface types (including Transitional, matching the
  issue's screenshot, and one New OLS surface): Calculate a surface,
  confirm the attribute table has a `parameters` field with valid JSON.
- Right-click a feature (or use canvas Identify) and confirm "view
  parameters as HTML Table" appears and opens a popup showing every input
  value.
- Toggle the popup's light/dark theme switch.
- Click "Copy to Word" and paste into a document to confirm a formatted
  table appears.
- Click the new "Show Table" button in each dockwidget and confirm it
  opens a popup with one section per calculated surface currently in the
  project.

---

## Risk / notes

- Mechanical risk: 9 near-identical script edits, each with its own
  attribute-list shape — care was needed to keep the new `parameters`
  field's position consistent with each script's existing positional
  `setAttributes([...])` calls.
- `QtWebEngineWidgets`/`QtWebChannel` are optional Qt add-ons not
  guaranteed to ship with every QGIS install — the ported `QTextBrowser`
  fallback popup is required, not a nice-to-have, for both the per-feature
  action and the new "Show Table" button.
- `collect_project_parameter_sections()` intentionally differs from
  qpansopy's single-calculation-type-filtered pattern: it scans *all*
  project layers with a `parameters` field, since qOLS's panel covers many
  surface types per session rather than one calculation module at a time.
