### PR TITLE
fix(#117): restore `ACTION_TYPE_GENERIC_PYTHON` 

### DIFF
--- a/qols/compat.py
+++ b/qols/compat.py
@@ -9,7 +9,7 @@ branching on the Qt version inline.
 from qgis.PyQt.QtCore import Qt, QEvent
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtWidgets import QDialogButtonBox
-from qgis.core import Qgis, QgsWkbTypes
+from qgis.core import Qgis, QgsWkbTypes, QgsAction
 
 # ---------------------------------------------------------------------------
 # Dock-widget area constants
@@ -103,6 +103,16 @@ try:
 except AttributeError:
     GEOM_TYPE_POLYGON = QgsWkbTypes.PolygonGeometry  # type: ignore[attr-defined]
 
+# ---------------------------------------------------------------------------
+# QgsAction generic-Python action type (for register_parameters_action, #118)
+# QGIS 3 / Qt5:  QgsAction.GenericPython
+# QGIS 4 / Qt6:  QgsAction.ActionType.GenericPython
+# ---------------------------------------------------------------------------
+try:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.ActionType.GenericPython
+except AttributeError:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.GenericPython  # type: ignore[attr-defined]
+
 __all__ = [
     "DOCK_RIGHT", "DOCK_LEFT",
     "BTN_SAVE", "BTN_CANCEL",
@@ -112,4 +122,5 @@ __all__ = [
     "MSG_INFO", "MSG_WARNING", "MSG_CRITICAL", "MSG_SUCCESS",
     "EVENT_MOUSE_MOVE",
     "GEOM_TYPE_POLYGON",
+    "ACTION_TYPE_GENERIC_PYTHON",
 ]


### PR DESCRIPTION
# fix(#117): restore `ACTION_TYPE_GENERIC_PYTHON` 

## Summary

Follow-up to #117 (closed via #139). After #139 and #140 were both merged
to `main`,  reported on the issue thread that installing
the plugin now throws:

```
QOLS Error: Error calculating surface: cannot import name 'ACTION_TYPE_GENERIC_PYTHON' from 'qols.compat'
```

Root cause: `qols/compat.py` was edited independently by two branches —
#139 (`feature/117-direction-marker`, commit `c3a6d86`) added
`GEOM_TYPE_POLYGON`; #140 (`feature/118-store-surface-parameters`, commit
`0a11502`) added `ACTION_TYPE_GENERIC_PYTHON` (used by the new
`qols/parameters_inspector.py` to register the "view parameters as HTML"
layer action). Merge commit `49787df` ("Merge branch 'main' into
feature/118-store-surface-parameters") resolved the resulting conflict by
taking #139's side of `compat.py` wholesale, silently discarding the
`QgsAction` import and the `ACTION_TYPE_GENERIC_PYTHON` block. That merge
went to `main` as `0e8e44c` (PR #140), while `parameters_inspector.py`
still imports the now-missing name — so any surface calculation that
registers the layer action crashes on import.

---

## Changes

### `qols/compat.py`

- Re-added `QgsAction` to the `qgis.core` import
  (`from qgis.core import Qgis, QgsWkbTypes, QgsAction`).
- Re-added the `ACTION_TYPE_GENERIC_PYTHON` try/except shim
  (`QgsAction.ActionType.GenericPython` on Qt6 /
  `QgsAction.GenericPython` fallback on Qt5), verbatim from the version
  originally added in `0a11502` before the conflicting merge dropped it.
- Re-added `"ACTION_TYPE_GENERIC_PYTHON"` to `__all__`.

No other files changed — `qols/parameters_inspector.py` already expected
this name and needed no modification.

---

## Verification

```bash
python -m pytest -q -p no:pytest-qt        # 511 passed, 1 failed (pre-existing, unrelated — see below)
flake8 qols/compat.py                       # 0 issues
flake8 qols/                                # 100 issues, all pre-existing (qols/scripts/*.py star-import
                                             #   F403/F405/E402, a few qols/ui/*.py F821/F401) — identical
                                             #   count on main before this change
```

Confirmed the bug reproduces exactly as reported: stashing this fix and
running `tests/test_parameters_inspector.py` against unmodified `main`
fails all 28 tests in that file with the exact `ImportError` from the
issue. With the fix applied, all 28 pass.

The one remaining failure,
`test_dockwidget_logic.py::TestGetParametersTransitionalDirectionSwap::test_inverted_direction_swaps_elevations`,
reproduces identically on unmodified `main` — pre-existing, unrelated to
this fix, out of scope here.

No manual QGIS check needed beyond re-running the reporter's original
repro (calculate an Approach or Transitional surface and confirm the
"view parameters as HTML" action registers without error) — the crash was
a pure import-time `ImportError`, fully covered by the existing mocked
test harness.
