### PR TITLE
Feature/119 transitional inverted elevation swap

### DIFF
--- a/qols/compat.py
+++ b/qols/compat.py
@@ -9,7 +9,7 @@ branching on the Qt version inline.
 from qgis.PyQt.QtCore import Qt, QEvent
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtWidgets import QDialogButtonBox
-from qgis.core import Qgis, QgsWkbTypes
+from qgis.core import Qgis, QgsWkbTypes, QgsAction
 
 # ---------------------------------------------------------------------------
 # Dock-widget area constants
@@ -103,6 +103,16 @@ try:
 except AttributeError:
     GEOM_TYPE_POLYGON = QgsWkbTypes.PolygonGeometry  # type: ignore[attr-defined]
 
+# ---------------------------------------------------------------------------
+# QgsAction generic-Python action type (for register_parameters_action, #118)
+# QGIS 3 / Qt5:  QgsAction.GenericPython
+# QGIS 4 / Qt6:  QgsAction.ActionType.GenericPython
+# ---------------------------------------------------------------------------
+try:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.ActionType.GenericPython
+except AttributeError:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.GenericPython  # type: ignore[attr-defined]
+
 __all__ = [
     "DOCK_RIGHT", "DOCK_LEFT",
     "BTN_SAVE", "BTN_CANCEL",
@@ -112,4 +122,5 @@ __all__ = [
     "MSG_INFO", "MSG_WARNING", "MSG_CRITICAL", "MSG_SUCCESS",
     "EVENT_MOUSE_MOVE",
     "GEOM_TYPE_POLYGON",
+    "ACTION_TYPE_GENERIC_PYTHON",
 ]

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -1808,12 +1808,22 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 # IMPORTANT: For transitional, use the specific rotation button instead of general direction
                 s_value = 0 if self.transitional_direction_normal else -1  # s = 0 for normal, s = -1 for rotated
 
+                # Swap Start/End elevation on inversion, same as the APPROACH
+                # branch above (#119) — Z0 must always be the datum at the
+                # computation start point, ZE at the far point (see #119).
+                z0_ui = float(self.spin_Z0_transitional.text() or "0")  # UI-labeled Start Elevation (m)
+                ze_ui = float(self.spin_ZE_transitional.text() or "0")  # UI-labeled End Elevation (m)
+                if s_value == 0:  # Normal direction
+                    Z0_calc, ZE_calc = z0_ui, ze_ui
+                else:  # Inverted direction
+                    Z0_calc, ZE_calc = ze_ui, z0_ui
+
                 specific_params = {
                     'code': self.get_code_value('spin_code_transitional'),  # QComboBox
                     'rwyClassification': self.combo_rwyClassification_transitional.currentText(),
                     'widthApp': float(self.spin_widthApp_transitional.text() or "0"),  # QLineEdit
-                    'Z0': float(self.spin_Z0_transitional.text() or "0"),              # QLineEdit
-                    'ZE': float(self.spin_ZE_transitional.text() or "0"),              # QLineEdit
+                    'Z0': Z0_calc,
+                    'ZE': ZE_calc,
                     'ARPH': float(self.spin_ARPH_transitional.text() or "0"),          # QLineEdit
                     'Tslope': float(self.spin_Tslope_transitional.text() or "0") / 100.0,  # % → decimal
                     's': s_value  # Special parameter for transitional runway direction


### PR DESCRIPTION
# fix(#119): Transitional Inverted should swap Start/End elevation

## Summary

Closes #119.
Root cause: `TransitionalSurface_UTM.py`'s `Z0` is always the datum at
whichever threshold end is currently the computation start point (not a
fixed "start"), and `ZE` is always the datum at the far end. `Z0` is
applied to `new_geom`, built from the currently selected threshold
feature, independent of `s`; `ZE` is applied to `pt_02T`, derived from
`line_pts[-1-s]`. So the script's contract has always been "`Z0` = start
point, `ZE` = far point" — but `get_parameters()`'s `SurfaceType
.TRANSITIONAL` branch read `spin_Z0_transitional`/`spin_ZE_transitional`
raw and passed them straight through, regardless of
`self.transitional_direction_normal`.

The Approach tab already has the identical problem solved: its
`get_parameters()` branch swaps `Z0`/`ZE` based on
`self.direction_start_to_end` before handing them to the script. This fix
applies the same swap to the Transitional branch, keyed off
`self.transitional_direction_normal` (Transitional's own, independent
direction toggle).

**Scope**: classic Transitional tab only, per the issue title's
"(Current)" qualifier. New OLS OES Transitional has a separate,
pre-existing gap (`spin_ZE_oes` is declared but never read in
`get_parameters()`, so the far-end elevation isn't wired to the script at
all) — that's a missing-wiring bug, not a swap-direction bug, and was
explicitly left out of this issue's scope.
<img width="702" height="697" alt="swappy-20260804-211619" src="https://github.com/user-attachments/assets/6a9bda81-61da-46ab-b563-4d0d159ac105" />

---

## Changes

### `qols/ui/dockwidget.py`

`get_parameters()`, `SurfaceType.TRANSITIONAL` branch — swap `Z0`/`ZE`
when direction is inverted, mirroring the `SurfaceType.APPROACH` branch's
existing pattern:

```python
elif surface_type == SurfaceType.TRANSITIONAL:
    s_value = 0 if self.transitional_direction_normal else -1

    z0_ui = float(self.spin_Z0_transitional.text() or "0")
    ze_ui = float(self.spin_ZE_transitional.text() or "0")
    if s_value == 0:      # Normal direction
        Z0_calc, ZE_calc = z0_ui, ze_ui
    else:                  # Inverted direction
        Z0_calc, ZE_calc = ze_ui, z0_ui

    specific_params = {
        ...
        'Z0': Z0_calc,
        'ZE': ZE_calc,
        ...
    }
```

No script changes: `qols/scripts/TransitionalSurface_UTM.py` already
expects `Z0` = start-point datum, `ZE` = far-point datum — exactly what
the swapped UI values now supply for either direction.

No interaction with #118's `parameters` JSON field: that field's
`build_parameters_json(...)` call reads `Z0`/`ZE` from `globals()` *after*
this swap happens upstream in `get_parameters()`, so the stored JSON
automatically reflects the already-swapped, effective values once both
changes are merged.

### `tests/test_dockwidget_logic.py`

Added `TestGetParametersTransitionalDirectionSwap` (mirrors the existing
`TestGetParametersDirectionSwap` for Approach), plus a
`_transitional_params_subject()` helper:

- `test_normal_direction_no_swap` — `transitional_direction_normal=True`
  → `Z0`/`ZE` pass through unswapped, `s == 0`.
- `test_inverted_direction_swaps_elevations` —
  `transitional_direction_normal=False` → `Z0`/`ZE` swapped, `s == -1`.

---

## Verification

```bash
pytest -q --ignore=tests/test_direction_marker.py --ignore=tests/test_parameters_inspector.py
# 474 passed
# (both ignored files are stray local-only files left over from separate,
#  unmerged branches — feature/117-direction-marker and
#  feature/118-store-surface-parameters — unrelated to #119; tests/ is
#  gitignored so untracked files persist across branch checkouts)

flake8 --max-line-length=119 qols/ui/dockwidget.py
# only the two pre-existing, already-documented F821 findings
# (get_new_ols_approach_defaults / get_new_ols_transitional_defaults,
#  dead code — see doc/PR_113.md baseline)
```

Manual QGIS check (still pending — matches the issue's own repro):

- Select a runway + threshold, apply Transitional defaults, Calculate
  with normal direction; note the resulting surface's orientation and
  elevation gradient.
- Click "Inverted Runway Direction", Calculate again *without* editing
  Start/End Elevation by hand, and confirm the output now matches what
  previously required manually swapping the two fields.

---

## Risk / notes

- Small, isolated, single-branch fix.
- Only `self.transitional_direction_normal` is read — `self
  .direction_start_to_end` (Approach's separate toggle) is untouched, since
  the two tabs have independent direction state
  (`toggle_direction()` vs `toggle_transitional_direction()`).
