### PR TITLE
Feature/121 merged transitional option

### DIFF
--- a/qols/compat.py
+++ b/qols/compat.py
@@ -9,7 +9,7 @@ branching on the Qt version inline.
 from qgis.PyQt.QtCore import Qt, QEvent
 from qgis.PyQt.QtGui import QPainter
 from qgis.PyQt.QtWidgets import QDialogButtonBox
-from qgis.core import Qgis, QgsWkbTypes
+from qgis.core import Qgis, QgsWkbTypes, QgsAction
 
 # ---------------------------------------------------------------------------
 # Dock-widget area constants
@@ -103,6 +103,16 @@ try:
 except AttributeError:
     GEOM_TYPE_POLYGON = QgsWkbTypes.PolygonGeometry  # type: ignore[attr-defined]
 
+# ---------------------------------------------------------------------------
+# QgsAction generic-Python action type (for register_parameters_action, #118)
+# QGIS 3 / Qt5:  QgsAction.GenericPython
+# QGIS 4 / Qt6:  QgsAction.ActionType.GenericPython
+# ---------------------------------------------------------------------------
+try:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.ActionType.GenericPython
+except AttributeError:
+    ACTION_TYPE_GENERIC_PYTHON = QgsAction.GenericPython  # type: ignore[attr-defined]
+
 __all__ = [
     "DOCK_RIGHT", "DOCK_LEFT",
     "BTN_SAVE", "BTN_CANCEL",
@@ -112,4 +122,5 @@ __all__ = [
     "MSG_INFO", "MSG_WARNING", "MSG_CRITICAL", "MSG_SUCCESS",
     "EVENT_MOUSE_MOVE",
     "GEOM_TYPE_POLYGON",
+    "ACTION_TYPE_GENERIC_PYTHON",
 ]

--- a/qols/geometry_merge.py
+++ b/qols/geometry_merge.py
@@ -1,0 +1,208 @@
+"""qols/geometry_merge.py — Z-preserving polygon merge for Transitional
+Surface runs (#121).
+
+``TransitionalSurface_UTM.py`` optionally merges this run's Left/Right
+pentagons into an already-existing "RWY_Transition Surface" layer instead
+of creating a new one. The two source shapes (normal vs. inverted
+direction) are typically two elongated wedges pointing opposite ways
+along the runway, not one overlapping blob — their 2D union is very often
+a genuine MultiPolygon (two disjoint/barely-touching lobes), so nothing
+may be discarded: every part of the union must be kept. QGIS/GEOS boolean
+geometry operations (``QgsGeometry.combine()``) are also 2D — they may
+drop or zero out the Z dimension of a ``PolygonZ``/``MultiPolygonZ``
+input. ``recover_ring_z`` is pure Python (no QGIS dependency) so it can be
+unit tested directly: given a merged part's 2D boundary and the original
+3D source rings (from every part of both inputs), it recovers a Z for
+every output vertex by exact-matching an original vertex where the merged
+boundary follows an untouched edge, else linearly interpolating along the
+nearest original edge from either source ring.
+``merge_polygonz_preserving_z`` is the thin QGIS-aware wrapper — it always
+returns a MultiPolygonZ geometry (via ``convertToMultiType()``) so the
+result's type stays consistent regardless of whether the union happened
+to be single- or multi-part.
+"""
+from __future__ import annotations
+
+from typing import Iterator
+
+Point2 = tuple[float, float]
+Point3 = tuple[float, float, float]
+Edge3 = tuple[Point3, Point3]
+
+__all__ = [
+    "recover_ring_z",
+    "merge_polygonz_preserving_z",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure geometry helpers (no QGIS dependency — operate on plain tuples)
+# ---------------------------------------------------------------------------
+
+def _match_exact_vertex_z(pt: Point2, vertices_xyz: list[Point3], tol: float) -> float | None:
+    """First original vertex within `tol` of `pt`, or None. Iteration order
+    of `vertices_xyz` decides ties (existing-layer ring first, by convention
+    of the caller)."""
+    tol2 = tol * tol
+    for x, y, z in vertices_xyz:
+        dx = x - pt[0]
+        dy = y - pt[1]
+        if dx * dx + dy * dy <= tol2:
+            return z
+    return None
+
+
+def _iter_edges(ring: list[Point3]) -> Iterator[Edge3]:
+    """Closed-ring edges, skipping zero-length (degenerate) segments."""
+    n = len(ring)
+    for i in range(n):
+        a = ring[i]
+        b = ring[(i + 1) % n]
+        if a[0] == b[0] and a[1] == b[1]:
+            continue
+        yield a, b
+
+
+def _project_point_on_segment(pt: Point2, a: Point3, b: Point3) -> tuple[float, float]:
+    """Clamped projection parameter t in [0, 1] and squared distance from
+    `pt` to the projected point on segment a->b (2D, ignoring Z)."""
+    dx = b[0] - a[0]
+    dy = b[1] - a[1]
+    len2 = dx * dx + dy * dy
+    if len2 == 0:
+        t = 0.0
+    else:
+        t = ((pt[0] - a[0]) * dx + (pt[1] - a[1]) * dy) / len2
+        t = max(0.0, min(1.0, t))
+    proj_x = a[0] + t * dx
+    proj_y = a[1] + t * dy
+    dist2 = (pt[0] - proj_x) ** 2 + (pt[1] - proj_y) ** 2
+    return t, dist2
+
+
+def _interpolate_nearest_edge_z(pt: Point2, edges: list[Edge3]) -> float:
+    """Z at `pt`, linearly interpolated along whichever edge (from either
+    source ring) is globally nearest to `pt`."""
+    if not edges:
+        raise ValueError("no edges to interpolate from")
+    best_t = 0.0
+    best_dist2 = None
+    best_edge = edges[0]
+    for a, b in edges:
+        t, dist2 = _project_point_on_segment(pt, a, b)
+        if best_dist2 is None or dist2 < best_dist2:
+            best_dist2 = dist2
+            best_t = t
+            best_edge = (a, b)
+    a, b = best_edge
+    return a[2] + best_t * (b[2] - a[2])
+
+
+def recover_ring_z(
+    merged_xy: list[Point2],
+    source_rings_xyz: list[list[Point3]],
+    exact_match_tol: float = 1e-6,
+) -> list[Point3]:
+    """For each 2D vertex of a unioned polygon boundary, recover a Z by
+    exact-matching an original 3D vertex from either source ring, else by
+    linear interpolation along the nearest original edge from either ring.
+    """
+    if not merged_xy:
+        return []
+    all_vertices = [v for ring in source_rings_xyz for v in ring]
+    all_edges = [e for ring in source_rings_xyz for e in _iter_edges(ring)]
+    result = []
+    for pt in merged_xy:
+        z = _match_exact_vertex_z(pt, all_vertices, exact_match_tol)
+        if z is None:
+            z = _interpolate_nearest_edge_z(pt, all_edges)
+        result.append((pt[0], pt[1], z))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# QGIS-aware wrapper
+# ---------------------------------------------------------------------------
+
+def _geometry_parts(geom) -> list:
+    """Every polygon part of `geom` — `[geom]` if single-part, else each
+    member of a multi-part geometry."""
+    if not geom.isMultipart():
+        return [geom]
+    parts = geom.asGeometryCollection()
+    return parts if parts else [geom]
+
+
+def _all_exterior_rings_xyz(geom) -> list[list[Point3]]:
+    """Exterior ring of every polygon part of `geom` (handles both a plain
+    Polygon and an already multi-part MultiPolygon — e.g. the existing
+    layer's feature may itself be the result of a previous merge)."""
+    rings = []
+    for part in _geometry_parts(geom):
+        ring = part.constGet().exteriorRing()
+        pts = [(ring.pointN(i).x(), ring.pointN(i).y(), ring.pointN(i).z()) for i in range(ring.numPoints())]
+        if len(pts) > 1 and pts[0][:2] == pts[-1][:2]:
+            pts = pts[:-1]
+        rings.append(pts)
+    return rings
+
+
+def _polygon_exterior_xy(geom) -> list[Point2]:
+    ring = geom.constGet().exteriorRing()
+    pts = [(ring.pointN(i).x(), ring.pointN(i).y()) for i in range(ring.numPoints())]
+    if len(pts) > 1 and pts[0] == pts[-1]:
+        pts = pts[:-1]
+    return pts
+
+
+def merge_polygonz_preserving_z(
+    existing_geom,
+    new_geom,
+    exact_match_tol: float = 1e-6,
+):
+    """2D-union `existing_geom` and `new_geom` (PolygonZ or MultiPolygonZ,
+    no holes), recover Z per output vertex via `recover_ring_z`, and
+    return a new MultiPolygonZ QgsGeometry. The two source shapes are
+    often two disjoint/barely-touching lobes (e.g. two Transitional runs
+    pointing opposite ways along the runway) rather than one overlapping
+    blob, so EVERY part of the union is kept — nothing is discarded, even
+    when the result is genuinely multi-part. Falls back to `new_geom`
+    unchanged if the union or Z-recovery cannot proceed — a failed merge
+    must not lose the run the user just calculated."""
+    from qgis.core import QgsGeometry, QgsLineString, QgsMultiPolygon, QgsPoint, QgsPolygon
+
+    try:
+        existing_rings = _all_exterior_rings_xyz(existing_geom)
+        new_rings = _all_exterior_rings_xyz(new_geom)
+        if not existing_rings or not new_rings:
+            return new_geom
+
+        unioned = existing_geom.combine(new_geom)
+        if unioned is None or unioned.isEmpty():
+            return new_geom
+
+        source_rings = existing_rings + new_rings
+        rebuilt_parts = []
+        for part in _geometry_parts(unioned):
+            part_xy = _polygon_exterior_xy(part)
+            if len(part_xy) < 3:
+                continue
+            part_xyz = recover_ring_z(part_xy, source_rings, exact_match_tol)
+            points = [QgsPoint(x, y, z) for x, y, z in part_xyz]
+            rebuilt_parts.append(QgsPolygon(QgsLineString(points), rings=[]))
+
+        if not rebuilt_parts:
+            return new_geom
+
+        if len(rebuilt_parts) == 1:
+            result = QgsGeometry(rebuilt_parts[0])
+        else:
+            multi = QgsMultiPolygon()
+            for poly in rebuilt_parts:
+                multi.addGeometry(poly)
+            result = QgsGeometry(multi)
+
+        result.convertToMultiType()
+        return result
+    except Exception:
+        return new_geom

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -58,6 +58,7 @@ try:
     LH = globals().get('LH', 8400)
     Tslope = globals().get('Tslope', 14.3/100)
     s = globals().get('s', 0)  # CRITICAL: Get runway direction from UI button
+    merge_transitional = globals().get('merge_transitional', False)  # #121
 
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
@@ -81,6 +82,7 @@ except Exception as e:
     LH = 8400
     Tslope = 14.3/100
     s = 0
+    merge_transitional = False
     runway_layer = None
     threshold_layer = None
     use_selected_feature = True
@@ -286,16 +288,7 @@ list_pts.extend((pt_0,pt_01,pt_01AL,pt_01AR,pt_01TL,pt_01TR,pt_08,pt_08L,pt_08R,
 # QgsProject.instance().addMapLayers([p_layer])
 
 # Creation of the Transitional Surfaces
-# Create memory layer
-
-v_layer = QgsVectorLayer("PolygonZ?crs="+map_srid, "RWY_Transition Surface", "memory")
-IDField = QgsField( 'ID', QVariant.String)
-NameField = QgsField( 'SurfaceName', QVariant.String)
-RuleField = QgsField( 'rule_set', QVariant.String)
-v_layer.dataProvider().addAttributes([IDField])
-v_layer.dataProvider().addAttributes([NameField])
-v_layer.dataProvider().addAttributes([RuleField])
-v_layer.updateFields()
+# Create memory layer (or merge into an existing one - #121)
 
 # Store the full input parameter set as HTML-inspectable JSON (#118)
 from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
@@ -312,27 +305,97 @@ _params_json = build_parameters_json('Transitional Surface', {
     'direction': s,
     'rule_set': _active_rule_set,
 })
-add_parameters_field(v_layer)
 
-# Left Transition Surface
-SurfaceArea = [pt_08L,pt_01TL,pt_02TL,pt_02L,pt_01AL]
-pr = v_layer.dataProvider()
-seg = QgsFeature()
-seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([10,'Left Transitional Surface', _active_rule_set, _params_json])
-pr.addFeatures( [ seg ] )
+new_left_geom = QgsGeometry(QgsPolygon(QgsLineString([pt_08L,pt_01TL,pt_02TL,pt_02L,pt_01AL]), rings=[]))
+new_right_geom = QgsGeometry(QgsPolygon(QgsLineString([pt_08R,pt_01TR,pt_02TR,pt_02R,pt_01AR]), rings=[]))
+# Layer is MultiPolygonZ (#121 - a merge can produce two disjoint lobes),
+# so every feature geometry, including a fresh single-run one, must match.
+new_left_geom.convertToMultiType()
+new_right_geom.convertToMultiType()
 
-# Right Transition Surface
-SurfaceArea = [pt_08R,pt_01TR,pt_02TR,pt_02R,pt_01AR]
-pr = v_layer.dataProvider()
-seg = QgsFeature()
-seg.setGeometry(QgsPolygon(QgsLineString(SurfaceArea), rings=[]))
-seg.setAttributes([11,'Right Transitional Surface', _active_rule_set, _params_json])
-pr.addFeatures( [ seg ] )
+# #121: if requested, look for an already-existing Transitional layer to
+# merge into instead of creating a new one. 0 matches = first click with
+# the box checked, behaves like unchecked. >1 matches = can't tell which
+# one is meant, warn and fall back to creating a new layer rather than
+# silently merging into the wrong one.
+existing_layer = None
+if merge_transitional:
+    matches = QgsProject.instance().mapLayersByName('RWY_Transition Surface')
+    if len(matches) == 1:
+        existing_layer = matches[0]
+    elif len(matches) > 1:
+        iface.messageBar().pushMessage(
+            "TransitionalSurface Warning",
+            "Multiple 'RWY_Transition Surface' layers found; cannot tell which to merge into. "
+            "Created a new layer instead - keep only one such layer for merging to work.",
+            level=MSG_WARNING)
 
-register_parameters_action(v_layer)
+if existing_layer is not None:
+    from qols.geometry_merge import merge_polygonz_preserving_z
 
-QgsProject.instance().addMapLayers([v_layer])
+    add_parameters_field(existing_layer)  # idempotent, defensive
+    pr = existing_layer.dataProvider()
+    parameters_idx = existing_layer.fields().indexOf('parameters')
+    rule_set_idx = existing_layer.fields().indexOf('rule_set')
+    features_by_name = {f.attribute('SurfaceName'): f for f in existing_layer.getFeatures()}
+
+    geometry_changes = {}
+    attribute_changes = {}
+    for side_id, side_name, new_geom in (
+        (10, 'Left Transitional Surface', new_left_geom),
+        (11, 'Right Transitional Surface', new_right_geom),
+    ):
+        existing_feat = features_by_name.get(side_name)
+        if existing_feat is None:
+            # Shouldn't normally happen (the layer was created by this same
+            # script) - fall back to adding it as a new feature.
+            seg = QgsFeature(existing_layer.fields())
+            seg.setGeometry(new_geom)
+            seg.setAttributes([side_id, side_name, _active_rule_set, _params_json])
+            pr.addFeatures([seg])
+            continue
+        # Merge, conserving Z (#121) - last-run-wins for the parameters JSON,
+        # same semantics a brand-new layer already has.
+        merged_geom = merge_polygonz_preserving_z(existing_feat.geometry(), new_geom)
+        geometry_changes[existing_feat.id()] = merged_geom
+        attribute_changes[existing_feat.id()] = {
+            parameters_idx: _params_json,
+            rule_set_idx: _active_rule_set,
+        }
+
+    if geometry_changes:
+        pr.changeGeometryValues(geometry_changes)
+    if attribute_changes:
+        pr.changeAttributeValues(attribute_changes)
+    existing_layer.updateExtents()
+    existing_layer.triggerRepaint()
+    v_layer = existing_layer
+else:
+    v_layer = QgsVectorLayer("MultiPolygonZ?crs="+map_srid, "RWY_Transition Surface", "memory")
+    IDField = QgsField( 'ID', QVariant.String)
+    NameField = QgsField( 'SurfaceName', QVariant.String)
+    RuleField = QgsField( 'rule_set', QVariant.String)
+    v_layer.dataProvider().addAttributes([IDField])
+    v_layer.dataProvider().addAttributes([NameField])
+    v_layer.dataProvider().addAttributes([RuleField])
+    v_layer.updateFields()
+    add_parameters_field(v_layer)
+
+    # Left Transition Surface
+    pr = v_layer.dataProvider()
+    seg = QgsFeature()
+    seg.setGeometry(new_left_geom)
+    seg.setAttributes([10,'Left Transitional Surface', _active_rule_set, _params_json])
+    pr.addFeatures( [ seg ] )
+
+    # Right Transition Surface
+    seg = QgsFeature()
+    seg.setGeometry(new_right_geom)
+    seg.setAttributes([11,'Right Transitional Surface', _active_rule_set, _params_json])
+    pr.addFeatures( [ seg ] )
+
+    register_parameters_action(v_layer)
+    QgsProject.instance().addMapLayers([v_layer])
 
 # Change style of layer
 v_layer.renderer().symbol().setColor(QColor("magenta"))

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -1888,12 +1888,22 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 # IMPORTANT: For transitional, use the specific rotation button instead of general direction
                 s_value = 0 if self.transitional_direction_normal else -1  # s = 0 for normal, s = -1 for rotated
 
+                # Swap Start/End elevation on inversion, same as the APPROACH
+                # branch above (#119) — Z0 must always be the datum at the
+                # computation start point, ZE at the far point (see #119).
+                z0_ui = float(self.spin_Z0_transitional.text() or "0")  # UI-labeled Start Elevation (m)
+                ze_ui = float(self.spin_ZE_transitional.text() or "0")  # UI-labeled End Elevation (m)
+                if s_value == 0:  # Normal direction
+                    Z0_calc, ZE_calc = z0_ui, ze_ui
+                else:  # Inverted direction
+                    Z0_calc, ZE_calc = ze_ui, z0_ui
+
                 specific_params = {
                     'code': self.get_code_value('spin_code_transitional'),  # QComboBox
                     'rwyClassification': self.combo_rwyClassification_transitional.currentText(),
                     'widthApp': float(self.spin_widthApp_transitional.text() or "0"),  # QLineEdit
-                    'Z0': float(self.spin_Z0_transitional.text() or "0"),              # QLineEdit
-                    'ZE': float(self.spin_ZE_transitional.text() or "0"),              # QLineEdit
+                    'Z0': Z0_calc,
+                    'ZE': ZE_calc,
                     'ARPH': float(self.spin_ARPH_transitional.text() or "0"),          # QLineEdit
                     'Tslope': float(self.spin_Tslope_transitional.text() or "0") / 100.0,  # % → decimal
                     's': s_value  # Special parameter for transitional runway direction

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -117,6 +117,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
     spin_L_conical: QLineEdit
     combo_rwyClassification_transitional: QComboBox
     spin_code_transitional: QComboBox
+    check_merge_transitional: QCheckBox
     # Additional widgets guaranteed by setupUi() (R-04)
     label_not_applicable_ofz: QLabel
     spin_IHSlope_ofz: QLineEdit
@@ -1906,7 +1907,8 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'ZE': ZE_calc,
                     'ARPH': float(self.spin_ARPH_transitional.text() or "0"),          # QLineEdit
                     'Tslope': float(self.spin_Tslope_transitional.text() or "0") / 100.0,  # % → decimal
-                    's': s_value  # Special parameter for transitional runway direction
+                    's': s_value,  # Special parameter for transitional runway direction
+                    'merge_transitional': self.check_merge_transitional.isChecked(),  # #121
                 }
             elif surface_type == SurfaceType.OFZ:
                 specific_params = {

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -1210,6 +1210,19 @@ QPushButton:checked:hover {
           </property>
          </widget>
         </item>
+        <item row="8" column="0" colspan="2">
+         <widget class="QCheckBox" name="check_merge_transitional">
+          <property name="text">
+           <string>Merge with existing Transitional Surface layer</string>
+          </property>
+          <property name="toolTip">
+           <string>When checked, the next Calculate updates the existing 'RWY_Transition Surface' layer in place — combining this run's Left/Right geometries with what's already there (geometric union, elevation preserved) instead of creating a new layer. If no such layer exists yet, behaves like unchecked.</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
 


### PR DESCRIPTION
# feat(#121): option to merge Transitional Surface runs, conserving Z

## Summary

Closes #121.

Issue #121  `TransitionalSurface_UTM.py` computes, in
one run, a single Left/Right pentagon spanning the entire runway length
using one near-threshold elevation and one shared width/ARPH/slope/code —
so a single run is only dimensionally correct near whichever threshold is
currently selected. Users today run Calculate twice (once per direction,
re-entering that end's own params each time) and end up with two separate
overlapping `"RWY_Transition Surface"` layers they'd otherwise merge by
hand in QGIS. This adds an option to automate that merge — combining both
runs into one layer/geometry in place — while explicitly conserving Z
(elevation), per the issue's requirement.

**UX** (confirmed with `@andures`): the existing 2-click manual workflow
is unchanged (edit params + toggle direction between each Calculate). A
new "Merge with existing Transitional Surface layer" checkbox makes the
*second* Calculate merge into the already-existing layer in place instead
of creating a new one. If checked but no such layer exists yet (first
click), behavior is unchanged.

**Dependency folded in**: this branch cherry-picks `be413c1` (#119's
`Z0`/`ZE` swap-on-inverted-direction fix, still unmerged into `main` as of
this branch) — without it, both runs being merged would have their
far-end elevation wrong, undermining this feature's "conserve Z" premise.
Whoever later merges #119 into `main` will hit a trivial,
easily-resolved duplicate-content conflict on that same ~10-line block.

---

## Changes

### `qols/geometry_merge.py` (new)

Pure-Python Z-recovery/interpolation math, no QGIS dependency, plus a
thin QGIS-aware wrapper — mirrors the split already used in
`qols/direction_marker.py` (#117):

- `recover_ring_z(merged_xy, source_rings_xyz, exact_match_tol=1e-6)` —
  for each 2D vertex of a unioned polygon boundary, recovers a Z by
  exact-matching an original 3D vertex from either source ring (first
  match wins ties, existing-layer ring checked before the new run's), else
  by linear interpolation along the globally nearest original edge from
  either ring.
- `merge_polygonz_preserving_z(existing_geom, new_geom)` — 2D-unions two
  `PolygonZ` `QgsGeometry` objects via `.combine()` (QGIS/GEOS boolean ops
  are 2D and may drop/zero Z — this wrapper always re-derives Z rather
  than trusting the union's own Z), picks the largest part if the result
  is multipart, and rebuilds a `PolygonZ` with recovered elevations. Falls
  back to `new_geom` unchanged on any failure — a failed merge must not
  lose the run the user just calculated.

### `qols/scripts/TransitionalSurface_UTM.py`

- New `merge_transitional` flag read from `globals()`.
- Builds this run's Left/Right pentagons as `QgsGeometry`, then
  `.convertToMultiType()`s each (see below).
- If `merge_transitional` is set: looks up `"RWY_Transition Surface"` via
  `QgsProject.instance().mapLayersByName(...)`. Exactly one match → merges
  each side's new geometry into that layer's matching feature via
  `merge_polygonz_preserving_z()`, writes back with
  `dataProvider().changeGeometryValues()`/`changeAttributeValues()`
  (last-run-wins for the `parameters` JSON/`rule_set` fields — same
  semantics a brand-new layer already has). Zero matches → falls through
  to creating a new layer, unchanged (first click with the box checked).
  More than one match → warns via `messageBar()` and falls through to
  creating a new layer rather than guessing which one to merge into.
- Styling/zoom/cleanup tail is unchanged and shared by both branches.
- **Layer type is now `MultiPolygonZ`** (was `PolygonZ`) — see live-QGIS
  fix below.

### Live-QGIS testing fix: both lobes were disappearing, not merging

First live test (`@andures`) found that after checking the box and
calculating the second (inverted-direction) run, only one of the two
wedges survived — the other visually disappeared instead of the two
fusing like the issue's reference screenshot (two wedges meeting in the
middle, each still pointing its own way). Root cause: the two Transitional
runs are typically two elongated wedges pointing in *opposite* directions
along the runway, not one overlapping blob — their 2D union
(`QgsGeometry.combine()`) is very often a genuine **MultiPolygon** (two
disjoint/barely-touching lobes). The original `merge_polygonz_preserving_z()`
picked only the largest lobe (`_largest_polygon_part()`) and silently
discarded the other.

Fixed by no longer assuming single-part output:

- `qols/geometry_merge.py` — replaced `_largest_polygon_part()` with
  `_geometry_parts()`/`_all_exterior_rings_xyz()`, which enumerate *every*
  polygon part of a geometry (also needed on the *input* side now, since
  `existing_geom` itself may already be a multi-lobe result from a
  previous merge). `merge_polygonz_preserving_z()` now rebuilds every part
  of the union — single part → one `QgsPolygon`; multipart → a
  `QgsMultiPolygon` with all parts Z-recovered — nothing is discarded, and
  the result always ends with `.convertToMultiType()` for a consistent
  return type.
- Because the merge result can now be genuinely multi-part, the
  `"RWY_Transition Surface"` layer is created as `MultiPolygonZ` (not
  `PolygonZ`) from the very first Calculate, and the initial single-run
  pentagons are also `.convertToMultiType()`-ed before being stored — a
  memory-provider layer declared as single-type `PolygonZ` could otherwise
  reject/mishandle a multi-part geometry written back on a later merge.

**Note for re-testing**: any `"RWY_Transition Surface"` layer created
*before* this fix is still typed `PolygonZ` in your QGIS session — delete
it and start fresh (first Calculate, then check the box, then second
Calculate) rather than merging into a pre-fix layer.

### `qols/ui/qols_panel_base.ui`

Added `check_merge_transitional` (`QCheckBox`) as row 8 of
`formLayout_transitional`, following the existing
`check_finalWidth1800_takeoff` QFormLayout-checkbox pattern.

### `qols/ui/dockwidget.py`

- Cherry-picked #119's `Z0`/`ZE` swap-on-inverted-direction fix into
  `get_parameters()`'s `SurfaceType.TRANSITIONAL` branch (see `doc/PR_119.md`
  for that fix's own writeup).
- Added `'merge_transitional': self.check_merge_transitional.isChecked()`
  to `specific_params`. Read passively at Calculate time, no signal
  wiring needed.

No `qols/plugin.py` changes: `execute_script()` already flows
`specific_params` into the exec namespace, and the merge-target lookup is
entirely self-contained in the script (name-based, not session-tracked).

### Tests

- `tests/test_geometry_merge.py` (new, 18 tests) — exact-match, tie-
  breaking, edge interpolation, a hand-built two-overlapping-squares
  end-to-end scenario, and degenerate/empty-input cases.
- `tests/test_dockwidget_logic.py` — new `TestGetParametersTransitionalMergeFlag`
  (2 tests); `_make_wgt`/`_transitional_params_subject` now default/accept
  `check_merge_transitional`.

---

## Verification

```bash
pytest -q -p no:pytest-qt
# 504 passed, 28 failed — all 28 pre-existing on this branch's base (main
# without #117's compat.py ACTION_TYPE_GENERIC_PYTHON fix merged yet);
# none touch geometry_merge.py or the transitional merge flag.

flake8 qols/geometry_merge.py qols/ui/dockwidget.py
# geometry_merge.py: 0 issues
# dockwidget.py: 3 pre-existing F821 findings, unrelated (documented
# dead-code baseline, see doc/PR_113.md)
```

Manual QGIS check (pending, cannot be automated — `tests/conftest.py`
mocks every `qgis.*` import):

1. Whether `QgsGeometry.combine()` actually drops/zeroes Z on `PolygonZ`
   input in the installed QGIS/GEOS version.
2. `changeGeometryValues()`/`changeAttributeValues()` persist correctly
   on a `"memory"`-provider layer without an explicit edit session.
3. Full end-to-end: Calculate normal direction → toggle direction + edit
   that end's params → Calculate again with "Merge with existing
   Transitional Surface layer" checked → confirm exactly one
   `"RWY_Transition Surface"` layer with 2 features (not 4), envelope
   shape looks right, spot-check a few vertices' Z via the attribute
   table/3D view.
4. `mapLayersByName` 0/1/>1 handling if the user duplicates/renames the
   layer between clicks.

---

## Risk / notes

- `qols/scripts/*.py` stays flake8-exempt (TD-03); `geometry_merge.py` is
  a normal module and is flake8-clean.
- The `parameters` JSON field on a merged feature only reflects the most
  recent contributing run — the "view as HTML" action on a merged feature
  does not show a merge history. Documented limitation, acceptable for an
  interim convenience feature per the issue's own framing.
