### PR TITLE
feat(#121): option to merge Transitional Surface runs, conserving Z

### DIFF
--- a/qols/geometry_merge.py
+++ b/qols/geometry_merge.py
@@ -1,25 +1,30 @@
-"""qols/geometry_merge.py — Z-preserving polygon merge for Transitional
-Surface runs (#121).
+"""qols/geometry_merge.py — Z-preserving polygon dissolve for the
+"Merged Transitional Surface" layer (#121).
 
-``TransitionalSurface_UTM.py`` optionally merges this run's Left/Right
-pentagons into an already-existing "RWY_Transition Surface" layer instead
-of creating a new one. The two source shapes (normal vs. inverted
-direction) are typically two elongated wedges pointing opposite ways
-along the runway, not one overlapping blob — their 2D union is very often
-a genuine MultiPolygon (two disjoint/barely-touching lobes), so nothing
-may be discarded: every part of the union must be kept. QGIS/GEOS boolean
-geometry operations (``QgsGeometry.combine()``) are also 2D — they may
-drop or zero out the Z dimension of a ``PolygonZ``/``MultiPolygonZ``
-input. ``recover_ring_z`` is pure Python (no QGIS dependency) so it can be
-unit tested directly: given a merged part's 2D boundary and the original
-3D source rings (from every part of both inputs), it recovers a Z for
-every output vertex by exact-matching an original vertex where the merged
-boundary follows an untouched edge, else linearly interpolating along the
-nearest original edge from either source ring.
-``merge_polygonz_preserving_z`` is the thin QGIS-aware wrapper — it always
-returns a MultiPolygonZ geometry (via ``convertToMultiType()``) so the
-result's type stays consistent regardless of whether the union happened
-to be single- or multi-part.
+``TransitionalSurface_UTM.py`` optionally maintains a separate
+"Merged Transitional Surface" layer, accumulating every run's Left/Right
+pentagons into it via a full n-way geometric union — dissolving purely by
+spatial overlap, never by matching feature attributes/names (an earlier
+version paired features by their ``SurfaceName`` — "Left" with "Left",
+"Right" with "Right" — which silently glued together the wrong physical
+sides whenever a direction flip swapped which side ends up called "Left"
+vs. "Right"; see the #121 reopened discussion). QGIS/GEOS boolean geometry
+operations (``QgsGeometry.unaryUnion()``) are 2D — they may drop or zero
+out the Z dimension of a ``PolygonZ``/``MultiPolygonZ`` input, and the
+union of several wedge-shaped runs is very often a genuine MultiPolygon
+(disjoint/barely-touching lobes on each side of the runway), so nothing
+may be discarded: every part of the union must be kept. ``recover_ring_z``
+is pure Python (no QGIS dependency) so it can be unit tested directly:
+given a dissolved part's 2D boundary and the original 3D source rings
+(from every part of every input), it recovers a Z for every output vertex
+by exact-matching an original vertex where the dissolved boundary follows
+an untouched edge, else linearly interpolating along the nearest original
+edge from any source ring. ``dissolve_geometries_preserving_z`` is the
+thin QGIS-aware wrapper — it unions an arbitrary number of input
+geometries at once and returns one Z-recovered, ``.convertToMultiType()``-ed
+``QgsGeometry`` per disjoint/connected part, so each part can become its
+own feature (selecting one highlights one coherent side, not several
+unrelated pieces glued together).
 """
 from __future__ import annotations
 
@@ -31,7 +36,7 @@ Edge3 = tuple[Point3, Point3]
 
 __all__ = [
     "recover_ring_z",
-    "merge_polygonz_preserving_z",
+    "dissolve_geometries_preserving_z",
 ]
 
 
@@ -155,54 +160,60 @@ def _polygon_exterior_xy(geom) -> list[Point2]:
     return pts
 
 
-def merge_polygonz_preserving_z(
-    existing_geom,
-    new_geom,
+def dissolve_geometries_preserving_z(
+    geometries: list,
     exact_match_tol: float = 1e-6,
-):
-    """2D-union `existing_geom` and `new_geom` (PolygonZ or MultiPolygonZ,
-    no holes), recover Z per output vertex via `recover_ring_z`, and
-    return a new MultiPolygonZ QgsGeometry. The two source shapes are
-    often two disjoint/barely-touching lobes (e.g. two Transitional runs
-    pointing opposite ways along the runway) rather than one overlapping
-    blob, so EVERY part of the union is kept — nothing is discarded, even
-    when the result is genuinely multi-part. Falls back to `new_geom`
-    unchanged if the union or Z-recovery cannot proceed — a failed merge
-    must not lose the run the user just calculated."""
-    from qgis.core import QgsGeometry, QgsLineString, QgsMultiPolygon, QgsPoint, QgsPolygon
+) -> list:
+    """Union every geometry in `geometries` (each PolygonZ or
+    MultiPolygonZ, no holes) via `QgsGeometry.unaryUnion()`, recover Z per
+    output vertex via `recover_ring_z`, and return one Z-recovered,
+    `.convertToMultiType()`-ed QgsGeometry per disjoint/connected part of
+    the union — never a single combined multi-part geometry, so each part
+    can become its own feature (e.g. one per physical side of the
+    runway). Dissolving is purely by spatial overlap: this function takes
+    no names/attributes into account at all, so it can never mis-pair two
+    geometries that happen to share a label. Returns `[]` if fewer than 2
+    usable geometries are given or the union/Z-recovery cannot proceed —
+    the caller must keep its own inputs untouched on failure, since a
+    failed dissolve must not lose data."""
+    from qgis.core import QgsGeometry, QgsLineString, QgsPoint, QgsPolygon
 
     try:
-        existing_rings = _all_exterior_rings_xyz(existing_geom)
-        new_rings = _all_exterior_rings_xyz(new_geom)
-        if not existing_rings or not new_rings:
-            return new_geom
+        usable = [g for g in geometries if g is not None and not g.isEmpty()]
+        print(f"dissolve_geometries_preserving_z: {len(geometries)} input(s), {len(usable)} usable")
+        if len(usable) < 2:
+            return []
 
-        unioned = existing_geom.combine(new_geom)
+        source_rings = [ring for g in usable for ring in _all_exterior_rings_xyz(g)]
+        print(f"dissolve_geometries_preserving_z: {len(source_rings)} source ring(s), "
+              f"sizes={[len(r) for r in source_rings]}")
+        if not source_rings:
+            return []
+
+        unioned = QgsGeometry.unaryUnion(usable)
         if unioned is None or unioned.isEmpty():
-            return new_geom
+            print("dissolve_geometries_preserving_z: unaryUnion returned None/empty")
+            return []
 
-        source_rings = existing_rings + new_rings
-        rebuilt_parts = []
-        for part in _geometry_parts(unioned):
+        parts = _geometry_parts(unioned)
+        print(f"dissolve_geometries_preserving_z: union produced {len(parts)} part(s)")
+
+        results = []
+        for _pi, part in enumerate(parts):
             part_xy = _polygon_exterior_xy(part)
             if len(part_xy) < 3:
+                print(f"dissolve_geometries_preserving_z: part {_pi} has < 3 vertices ({len(part_xy)}), skipped")
                 continue
             part_xyz = recover_ring_z(part_xy, source_rings, exact_match_tol)
             points = [QgsPoint(x, y, z) for x, y, z in part_xyz]
-            rebuilt_parts.append(QgsPolygon(QgsLineString(points), rings=[]))
+            result = QgsGeometry(QgsPolygon(QgsLineString(points), rings=[]))
+            result.convertToMultiType()
+            results.append(result)
 
-        if not rebuilt_parts:
-            return new_geom
-
-        if len(rebuilt_parts) == 1:
-            result = QgsGeometry(rebuilt_parts[0])
-        else:
-            multi = QgsMultiPolygon()
-            for poly in rebuilt_parts:
-                multi.addGeometry(poly)
-            result = QgsGeometry(multi)
-
-        result.convertToMultiType()
-        return result
-    except Exception:
-        return new_geom
+        print(f"dissolve_geometries_preserving_z: returning {len(results)} result(s)")
+        return results
+    except Exception as e:
+        import traceback
+        print(f"dissolve_geometries_preserving_z: FAILED with {e!r}")
+        traceback.print_exc()
+        return []

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -288,7 +288,8 @@ list_pts.extend((pt_0,pt_01,pt_01AL,pt_01AR,pt_01TL,pt_01TR,pt_08,pt_08L,pt_08R,
 # QgsProject.instance().addMapLayers([p_layer])
 
 # Creation of the Transitional Surfaces
-# Create memory layer (or merge into an existing one - #121)
+# Create memory layer (always fresh - #121 individual layer is untouched
+# by merging; see the separate "Merged Transitional Surface" block below)
 
 # Store the full input parameter set as HTML-inspectable JSON (#118)
 from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
@@ -308,94 +309,110 @@ _params_json = build_parameters_json('Transitional Surface', {
 
 new_left_geom = QgsGeometry(QgsPolygon(QgsLineString([pt_08L,pt_01TL,pt_02TL,pt_02L,pt_01AL]), rings=[]))
 new_right_geom = QgsGeometry(QgsPolygon(QgsLineString([pt_08R,pt_01TR,pt_02TR,pt_02R,pt_01AR]), rings=[]))
-# Layer is MultiPolygonZ (#121 - a merge can produce two disjoint lobes),
-# so every feature geometry, including a fresh single-run one, must match.
-new_left_geom.convertToMultiType()
-new_right_geom.convertToMultiType()
 
-# #121: if requested, look for an already-existing Transitional layer to
-# merge into instead of creating a new one. 0 matches = first click with
-# the box checked, behaves like unchecked. >1 matches = can't tell which
-# one is meant, warn and fall back to creating a new layer rather than
-# silently merging into the wrong one.
-existing_layer = None
+v_layer = QgsVectorLayer("PolygonZ?crs="+map_srid, "RWY_Transition Surface", "memory")
+IDField = QgsField( 'ID', QVariant.String)
+NameField = QgsField( 'SurfaceName', QVariant.String)
+RuleField = QgsField( 'rule_set', QVariant.String)
+v_layer.dataProvider().addAttributes([IDField])
+v_layer.dataProvider().addAttributes([NameField])
+v_layer.dataProvider().addAttributes([RuleField])
+v_layer.updateFields()
+add_parameters_field(v_layer)
+
+# Left Transition Surface
+pr = v_layer.dataProvider()
+seg = QgsFeature()
+seg.setGeometry(new_left_geom)
+seg.setAttributes([10,'Left Transitional Surface', _active_rule_set, _params_json])
+pr.addFeatures( [ seg ] )
+
+# Right Transition Surface
+seg = QgsFeature()
+seg.setGeometry(new_right_geom)
+seg.setAttributes([11,'Right Transitional Surface', _active_rule_set, _params_json])
+pr.addFeatures( [ seg ] )
+
+register_parameters_action(v_layer)
+QgsProject.instance().addMapLayers([v_layer])
+
+# -----------------------------------------------------------------------
+# Merged Transitional Surface (#121) - a SEPARATE layer, maintained only
+# when requested. Dissolves purely by spatial overlap (never by matching
+# "Left"/"Right" names - a direction flip can swap which physical side
+# ends up called which, so name-based pairing glues the wrong sides
+# together). The individual layer above is never touched by this.
+# -----------------------------------------------------------------------
 if merge_transitional:
-    matches = QgsProject.instance().mapLayersByName('RWY_Transition Surface')
-    if len(matches) == 1:
-        existing_layer = matches[0]
-    elif len(matches) > 1:
+    from qols.geometry_merge import dissolve_geometries_preserving_z
+
+    merged_matches = QgsProject.instance().mapLayersByName('Merged Transitional Surface')
+    print(f"TransitionalSurface: merge_transitional=True, found {len(merged_matches)} "
+          f"existing 'Merged Transitional Surface' layer(s)")
+    merged_layer = None
+    skip_merge = False
+    if len(merged_matches) == 1:
+        merged_layer = merged_matches[0]
+    elif len(merged_matches) > 1:
+        skip_merge = True
         iface.messageBar().pushMessage(
             "TransitionalSurface Warning",
-            "Multiple 'RWY_Transition Surface' layers found; cannot tell which to merge into. "
-            "Created a new layer instead - keep only one such layer for merging to work.",
+            "Multiple 'Merged Transitional Surface' layers found; cannot tell which to "
+            "accumulate into. Keep only one such layer for merging to work.",
             level=MSG_WARNING)
 
-if existing_layer is not None:
-    from qols.geometry_merge import merge_polygonz_preserving_z
+    if not skip_merge:
+        existing_geoms = [f.geometry() for f in merged_layer.getFeatures()] if merged_layer else []
+        print(f"TransitionalSurface: {len(existing_geoms)} existing merged geometrie(s) "
+              f"carried into this dissolve")
+        # dissolve_geometries_preserving_z needs >= 2 geometries; this run's
+        # own Left+Right (which never overlap each other) always supplies
+        # that, so the first click (no existing_geoms yet) still works -
+        # it just dissolves this run's own two geometries against
+        # themselves, trivially recovering their own original Z.
+        dissolved_parts = dissolve_geometries_preserving_z(
+            existing_geoms + [new_left_geom, new_right_geom]
+        )
+    else:
+        dissolved_parts = []
 
-    add_parameters_field(existing_layer)  # idempotent, defensive
-    pr = existing_layer.dataProvider()
-    parameters_idx = existing_layer.fields().indexOf('parameters')
-    rule_set_idx = existing_layer.fields().indexOf('rule_set')
-    features_by_name = {f.attribute('SurfaceName'): f for f in existing_layer.getFeatures()}
+    if dissolved_parts:
+        if merged_layer is None:
+            merged_layer = QgsVectorLayer(
+                "MultiPolygonZ?crs=" + map_srid, "Merged Transitional Surface", "memory")
+            merged_layer.dataProvider().addAttributes([
+                QgsField('ID', QVariant.Int),
+                QgsField('SurfaceName', QVariant.String),
+                QgsField('rule_set', QVariant.String),
+            ])
+            merged_layer.updateFields()
+            add_parameters_field(merged_layer)
+            register_parameters_action(merged_layer)
+            QgsProject.instance().addMapLayers([merged_layer])
+            # #121: this is the first run contributing to the merge - remind
+            # the user the checkbox must stay checked for every OTHER run
+            # they still want folded in, not just this one.
+            iface.messageBar().pushMessage(
+                "Merged Transitional Surface",
+                "Layer created. Keep 'Create/update Merged Transitional Surface layer' "
+                "checked on every run (direction/params) you want included - it's not "
+                "enough to check it only on the last one.",
+                level=MSG_INFO, duration=8)
 
-    geometry_changes = {}
-    attribute_changes = {}
-    for side_id, side_name, new_geom in (
-        (10, 'Left Transitional Surface', new_left_geom),
-        (11, 'Right Transitional Surface', new_right_geom),
-    ):
-        existing_feat = features_by_name.get(side_name)
-        if existing_feat is None:
-            # Shouldn't normally happen (the layer was created by this same
-            # script) - fall back to adding it as a new feature.
-            seg = QgsFeature(existing_layer.fields())
-            seg.setGeometry(new_geom)
-            seg.setAttributes([side_id, side_name, _active_rule_set, _params_json])
-            pr.addFeatures([seg])
-            continue
-        # Merge, conserving Z (#121) - last-run-wins for the parameters JSON,
-        # same semantics a brand-new layer already has.
-        merged_geom = merge_polygonz_preserving_z(existing_feat.geometry(), new_geom)
-        geometry_changes[existing_feat.id()] = merged_geom
-        attribute_changes[existing_feat.id()] = {
-            parameters_idx: _params_json,
-            rule_set_idx: _active_rule_set,
-        }
+        mpr = merged_layer.dataProvider()
+        mpr.deleteFeatures([f.id() for f in merged_layer.getFeatures()])
+        merged_feats = []
+        for _i, _part in enumerate(dissolved_parts):
+            _feat = QgsFeature(merged_layer.fields())
+            _feat.setGeometry(_part)
+            _feat.setAttributes([_i + 1, 'Transitional Surfaces', _active_rule_set, _params_json])
+            merged_feats.append(_feat)
+        mpr.addFeatures(merged_feats)
+        merged_layer.updateExtents()
 
-    if geometry_changes:
-        pr.changeGeometryValues(geometry_changes)
-    if attribute_changes:
-        pr.changeAttributeValues(attribute_changes)
-    existing_layer.updateExtents()
-    existing_layer.triggerRepaint()
-    v_layer = existing_layer
-else:
-    v_layer = QgsVectorLayer("MultiPolygonZ?crs="+map_srid, "RWY_Transition Surface", "memory")
-    IDField = QgsField( 'ID', QVariant.String)
-    NameField = QgsField( 'SurfaceName', QVariant.String)
-    RuleField = QgsField( 'rule_set', QVariant.String)
-    v_layer.dataProvider().addAttributes([IDField])
-    v_layer.dataProvider().addAttributes([NameField])
-    v_layer.dataProvider().addAttributes([RuleField])
-    v_layer.updateFields()
-    add_parameters_field(v_layer)
-
-    # Left Transition Surface
-    pr = v_layer.dataProvider()
-    seg = QgsFeature()
-    seg.setGeometry(new_left_geom)
-    seg.setAttributes([10,'Left Transitional Surface', _active_rule_set, _params_json])
-    pr.addFeatures( [ seg ] )
-
-    # Right Transition Surface
-    seg = QgsFeature()
-    seg.setGeometry(new_right_geom)
-    seg.setAttributes([11,'Right Transitional Surface', _active_rule_set, _params_json])
-    pr.addFeatures( [ seg ] )
-
-    register_parameters_action(v_layer)
-    QgsProject.instance().addMapLayers([v_layer])
+        merged_layer.renderer().symbol().setColor(QColor("magenta"))
+        merged_layer.renderer().symbol().setOpacity(0.4)
+        merged_layer.triggerRepaint()
 
 # Change style of layer
 v_layer.renderer().symbol().setColor(QColor("magenta"))

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -59,6 +59,7 @@ try:
     Tslope = globals().get('Tslope', 14.3/100)
     s = globals().get('s', 0)  # CRITICAL: Get runway direction from UI button
     merge_transitional = globals().get('merge_transitional', False)  # #121
+    contour_interval_m = int(globals().get('contour_interval_m', 0))  # #122
 
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
@@ -83,6 +84,7 @@ except Exception as e:
     Tslope = 14.3/100
     s = 0
     merge_transitional = False
+    contour_interval_m = 0
     runway_layer = None
     threshold_layer = None
     use_selected_feature = True
@@ -442,6 +444,62 @@ canvas.zoomScale(sc)
 
 iface.messageBar().pushMessage("QPANSOPY:", "Transitional Surface Calculation Finished", level=MSG_SUCCESS)
 
+# -----------------------------------------------------------------------
+# Contour layer (#122 — stepped elevation bands for Transitional Surface)
+# Independent of merge_transitional: always computed fresh from this
+# run's own pentagon vertices, exactly like Approach/Take-off recompute
+# their own contours every run.
+# -----------------------------------------------------------------------
+if contour_interval_m > 0:
+    import importlib.util as _ilu
+    import os as _os
+    import sys as _sys
+    _utils_path = _os.path.join(_os.path.dirname(__file__), '_contour_utils.py')
+    _cu_spec = _ilu.spec_from_file_location('_contour_utils', _utils_path)
+    _cu = _ilu.module_from_spec(_cu_spec)
+    _sys.modules['_contour_utils'] = _cu
+    _cu_spec.loader.exec_module(_cu)
+
+    _z_bottom = min(Z0, ZE)
+    _elevs = _cu.contour_elevations(_z_bottom, ZIH, contour_interval_m)
+    # Exclude the plateau level itself - it's the flat 3-vertex boundary
+    # (pt_08*/pt_01T*/pt_02T*), not a straight chord between two points.
+    _elevs = [e for e in _elevs if e < ZIH - 1e-6]
+
+    _verts_left = [(p.x(), p.y(), p.z()) for p in (pt_08L, pt_01TL, pt_02TL, pt_02L, pt_01AL)]
+    _verts_right = [(p.x(), p.y(), p.z()) for p in (pt_08R, pt_01TR, pt_02TR, pt_02R, pt_01AR)]
+
+    _specs_left = _cu.contour_specs_for_polygon_slice(_verts_left, _elevs)
+    _specs_right = _cu.contour_specs_for_polygon_slice(_verts_right, _elevs)
+    _all_specs = _specs_left + _specs_right
+
+    if _all_specs:
+        _clayer = QgsVectorLayer(
+            "LineStringZ?crs=" + map_srid, "RWY_TransitionalSurface_Contours", "memory")
+        _clayer.dataProvider().addAttributes([
+            QgsField('ID', QVariant.Int),
+            QgsField('surface_elevation', QVariant.Double),
+        ])
+        _clayer.updateFields()
+
+        _cfeats = []
+        for _i, (_elev, (_x1, _y1), (_x2, _y2)) in enumerate(_all_specs):
+            _p1 = QgsPoint(_x1, _y1, _elev)
+            _p2 = QgsPoint(_x2, _y2, _elev)
+            _cfeat = QgsFeature()
+            _cfeat.setGeometry(QgsGeometry(QgsLineString([_p1, _p2])))
+            _cfeat.setAttributes([_i + 1, _elev])
+            _cfeats.append(_cfeat)
+        _clayer.dataProvider().addFeatures(_cfeats)
+
+        _cu.apply_contour_style(_clayer, __file__)
+        QgsProject.instance().addMapLayers([_clayer])
+        _clayer.triggerRepaint()
+        print(f"TransitionalSurface: Contour layer added - {len(_cfeats)} lines at "
+              f"{contour_interval_m} m interval")
+    else:
+        print(f"TransitionalSurface: No contour lines - no elevation levels in range "
+              f"for interval {contour_interval_m} m")
 
 set(globals().keys()).difference(myglobals)
 

--- a/qols/scripts/_contour_utils.py
+++ b/qols/scripts/_contour_utils.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import ceil, floor
-from typing import List
+from typing import List, Tuple
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +212,76 @@ def contour_specs_for_takeoff(
             distance_from_origin=d,
             half_width=half_w,
         ))
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# General polygon iso-elevation slicing (#122 — Transitional Surface)
+# ---------------------------------------------------------------------------
+
+def contour_specs_for_polygon_slice(
+    vertices: List[Tuple[float, float, float]],
+    elevations: List[float],
+) -> List[Tuple[float, Tuple[float, float], Tuple[float, float]]]:
+    """Slice a closed (x, y, z) polygon ring at each target elevation.
+
+    Unlike :func:`contour_specs_for_linear_section`/`_for_takeoff`, this
+    makes no assumption about a single axis driving both elevation and
+    width — it works directly from the ring's own per-vertex elevations,
+    which is required for Transitional Surface's 5-vertex pentagon (three
+    vertices share the max elevation, the other two sit at the two
+    threshold elevations — not a simple single-axis trapezoid). Returns
+    plain ``(elevation, (x1, y1), (x2, y2))`` tuples instead of
+    :class:`ContourSpec`, since there's no single "distance from origin"
+    or "half-width" axis to report here.
+
+    ``vertices`` is an ordered ring, NOT closed (no repeated first point);
+    edge ``(vertices[-1], vertices[0])`` is treated as the closing edge.
+
+    For each ``level`` in ``elevations``, every edge ``(za, zb)`` is kept
+    if ``min(za, zb) < level <= max(za, zb)`` — flat edges (``za == zb``)
+    never cross under this half-open convention, which is also what
+    avoids double-counting a level that lands exactly on a shared vertex
+    (the edge for which that vertex is the upper endpoint reports it, the
+    edge for which it's the lower endpoint does not).
+
+    Levels producing exactly 2 crossings become one contour segment.
+    Levels producing 0, 1, or more than 2 crossings are silently omitted
+    (0 = level outside this ring's range; 1 or >2 = a degenerate/non-simple
+    ring, which shouldn't occur for the standard pentagon under valid
+    input parameters — e.g. ``Tslope > 0`` and ``ZIH`` above both
+    threshold elevations). This mirrors the existing convention of
+    producing fewer contour lines than requested rather than guessing at
+    a possibly-wrong pairing.
+
+    Args:
+        vertices:   Ordered ring of (x, y, z) points, ring not closed.
+        elevations: Pre-computed target elevations (from
+                    :func:`contour_elevations`).
+
+    Returns:
+        List of ``(elevation, (x1, y1), (x2, y2))`` tuples, one per level
+        that yields exactly 2 crossings.
+    """
+    n = len(vertices)
+    if n < 3:
+        return []
+
+    specs: List[Tuple[float, Tuple[float, float], Tuple[float, float]]] = []
+    for level in elevations:
+        crossings: List[Tuple[float, float]] = []
+        for i in range(n):
+            x1, y1, z1 = vertices[i]
+            x2, y2, z2 = vertices[(i + 1) % n]
+            if z1 == z2:
+                continue
+            lo, hi = (z1, z2) if z1 < z2 else (z2, z1)
+            if not (lo < level <= hi):
+                continue
+            t = (level - z1) / (z2 - z1)
+            crossings.append((x1 + t * (x2 - x1), y1 + t * (y2 - y1)))
+        if len(crossings) == 2:
+            specs.append((level, crossings[0], crossings[1]))
     return specs
 
 

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -1909,6 +1909,8 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'Tslope': float(self.spin_Tslope_transitional.text() or "0") / 100.0,  # % → decimal
                     's': s_value,  # Special parameter for transitional runway direction
                     'merge_transitional': self.check_merge_transitional.isChecked(),  # #121
+                    'contour_interval_m': int(round(  # #122
+                        self.get_numeric_value('spin_contour_interval_transitional'))),
                 }
             elif surface_type == SurfaceType.OFZ:
                 specific_params = {

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -1225,6 +1225,23 @@ Must be checked on EVERY run you want included in the merge - including the firs
           </property>
          </widget>
         </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="label_contour_interval_transitional">
+          <property name="text">
+           <string>Contour Interval (m):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <widget class="QLineEdit" name="spin_contour_interval_transitional">
+          <property name="text">
+           <string>10</string>
+          </property>
+          <property name="toolTip">
+           <string>Elevation interval for contour lines in metres. Set to 0 to disable.</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
 

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -1213,10 +1213,12 @@ QPushButton:checked:hover {
         <item row="8" column="0" colspan="2">
          <widget class="QCheckBox" name="check_merge_transitional">
           <property name="text">
-           <string>Merge with existing Transitional Surface layer</string>
+           <string>Create/update Merged Transitional Surface layer</string>
           </property>
           <property name="toolTip">
-           <string>When checked, the next Calculate updates the existing 'RWY_Transition Surface' layer in place — combining this run's Left/Right geometries with what's already there (geometric union, elevation preserved) instead of creating a new layer. If no such layer exists yet, behaves like unchecked.</string>
+           <string>When checked, Calculate additionally maintains a separate 'Merged Transitional Surface' layer, dissolving this run's Left/Right geometries with whatever is already there by actual spatial overlap (elevation preserved). The individual 'RWY_Transition Surface' layer above is always created fresh and is never affected by this.
+
+Must be checked on EVERY run you want included in the merge - including the first one. If it's unchecked for a run, that run is only added to the individual layer and is left out of the merge entirely.</string>
           </property>
           <property name="checked">
            <bool>false</bool>


### PR DESCRIPTION
 reopened the issue with two more findings, backed by
screenshots:

1. **"Merged by attribute, should be by overlapping."** The in-place
   merge matched the existing feature to update via
   `features_by_name.get(side_name)` — pairing this run's
   `'Left Transitional Surface'` with whichever *existing* feature was
   *also named* `'Left'`, same for `'Right'`. But an inverted-direction
   run swaps which physical side of the runway ends up called "Left" vs
   "Right" — so name-based pairing could glue together two geometries
   that don't belong to the same physical side. Symptom: selecting a
   merged feature highlighted edges on both sides instead of one, and a
   screenshot showed a visibly **darker magenta band** exactly where the
   two mis-paired wedges overlapped each other (two stacked semi-
   transparent fills, not one dissolved shape).
2. **Reporter's own proposed redesign** — keep the individual per-run
   Left/Right output completely untouched on its own layer, and put any
   merged/dissolved result on a **separate** `"Merged Transitional
   Surface"` layer instead of mutating the individual layer in place.
   This turned out to be strictly simpler and safer than the in-place
   approach, since a full n-way union needs no Left/Right pairing at all
   — the "merged by attribute" bug disappears by construction.

**Fix — `qols/geometry_merge.py`**: replaced the 2-argument
`merge_polygonz_preserving_z(existing_geom, new_geom)` with a general
`dissolve_geometries_preserving_z(geometries: list)` that unions an
arbitrary number of geometries at once via `QgsGeometry.unaryUnion(...)`
— no names, no pairing, dissolves purely by spatial overlap — and returns
one Z-recovered geometry per disjoint/connected part (so each part can
become its own feature; selecting one now highlights exactly one
coherent side). `recover_ring_z` and its pure helpers are unchanged —
already general enough to take any number of source rings.

**Fix — `qols/scripts/TransitionalSurface_UTM.py`**: the individual
`"RWY_Transition Surface"` block is reverted to its original, always-fresh
form (2 features, brand-new memory layer every run — the in-place
lookup-by-name branch is gone entirely). A new, separate block, gated by
`merge_transitional`, maintains a second `"Merged Transitional Surface"`
layer: gathers every geometry already in that layer (0 the first time)
plus this run's fresh Left+Right, dissolves them all via
`dissolve_geometries_preserving_z()`, and replaces the layer's features
with one per dissolved part, each named generically `"Transitional
Surfaces"` (per the reporter's own suggestion — a merged feature can
combine what used to be "Left" from one run with "Right" from another, so
it can no longer claim to be either). 0/1/>1 existing-layer-name matches
handled the same defensive way as before, just for "which layer to
accumulate into" instead of "which feature to pair with".

### `qols/ui/qols_panel_base.ui`

Added `check_merge_transitional` (`QCheckBox`) as row 8 of
`formLayout_transitional`, following the existing
`check_finalWidth1800_takeoff` QFormLayout-checkbox pattern. Label/tooltip
updated after the reopen to describe the separate-layer behavior:
"Create/update Merged Transitional Surface layer".

### UX clarification: the checkbox must be checked on every run, not just the last one

Follow-up live test looked like a second regression (the merged layer
only showed one direction's wedge, not both) — turned out to be a usage
gap, not a bug: the box was only checked on the *second* Calculate, so
the *first* run's geometry was never fed into the merge pipeline at all
(it only went into the individual layer). Confirmed via diagnostic
`print()`s added to `dissolve_geometries_preserving_z()` and the script's
merge block (kept in place — this codebase's scripts already log heavily
via `print()`, same convention) showing `found 0 existing 'Merged
Transitional Surface' layer(s)` on what the reporter believed was the
second run.

Added two things so this doesn't trip up the next person:

- Tooltip now states explicitly: *"Must be checked on EVERY run you want
  included in the merge - including the first one. If it's unchecked for
  a run, that run is only added to the individual layer and is left out
  of the merge entirely."*
- The first time a run creates the `"Merged Transitional Surface"` layer,
  an info message bar (`MSG_INFO`, 8s) reminds the user:
  *"Layer created. Keep '...' checked on every run (direction/params) you
  want included - it's not enough to check it only on the last one."*

### `qols/ui/dockwidget.py`

- Cherry-picked #119's `Z0`/`ZE` swap-on-inverted-direction fix into
  `get_parameters()`'s `SurfaceType.TRANSITIONAL` branch (see `doc/PR_119.md`
  for that fix's own writeup).
- Added `'merge_transitional': self.check_merge_transitional.isChecked()`
  to `specific_params`. Read passively at Calculate time, no signal
  wiring needed.

No `qols/plugin.py` changes: `execute_script()` already flows
`specific_params` into the exec namespace, and the merge-target lookup is
entirely self-contained in the script (name-based, not session-tracked).

### Tests

- `tests/test_geometry_merge.py` (new, 18 tests) — exact-match, tie-
  breaking, edge interpolation, a hand-built two-overlapping-squares
  end-to-end scenario, and degenerate/empty-input cases.
- `tests/test_dockwidget_logic.py` — new `TestGetParametersTransitionalMergeFlag`
  (2 tests); `_make_wgt`/`_transitional_params_subject` now default/accept
  `check_merge_transitional`.

---

## Verification

```bash
pytest -q -p no:pytest-qt
# 532 passed — includes tests/test_geometry_merge.py's pure recover_ring_z
# tests (unaffected by the wrapper-level rename/redesign) and the merge-flag
# tests in tests/test_dockwidget_logic.py.

flake8 qols/geometry_merge.py
# 0 issues
```

Manual QGIS check (pending, cannot be automated — `tests/conftest.py`
mocks every `qgis.*` import):

1. Whether `QgsGeometry.unaryUnion()` actually drops/zeroes Z on
   `PolygonZ`/`MultiPolygonZ` input in the installed QGIS/GEOS version.
2. Full end-to-end (the reporter's own repro): create the first
   Transitional, check the box, calculate the second (inverted-direction,
   different params) Transitional — confirm (a) `"RWY_Transition
   Surface"` still shows 2 fresh Left/Right features from the *latest*
   run only, untouched by merging; (b) a new `"Merged Transitional
   Surface"` layer appears, dissolved by actual spatial overlap, no
   darker double-drawn seam; (c) selecting one merged feature highlights
   only one coherent side; (d) a third Calculate (box still checked)
   folds correctly into the same Merged layer.
3. `mapLayersByName` 0/1/>1 handling if the user duplicates/renames the
   `"Merged Transitional Surface"` layer between clicks.

---

## Risk / notes

- `qols/scripts/*.py` stays flake8-exempt (TD-03); `geometry_merge.py` is
  a normal module and is flake8-clean.
- The `parameters` JSON field on a merged feature only reflects the most
  recent contributing run — the "view as HTML" action on a merged feature
  does not show a merge history. Documented limitation, acceptable for an
  interim convenience feature per the issue's own framing.
