### PR TITLE
feat(#123): two-row tab selector for the classic panel

### DIFF
--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -25,12 +25,14 @@ from ..surfaces.approach import get_approach_defaults as icao_get_approach_defau
 from ..surface_types import SurfaceType
 from .. import logger  # CR-01
 from ..direction_marker import build_marker_geometry
+from .tab_row_selector import TwoRowTabSelector
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QColor, QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
     QApplication, QCheckBox, QComboBox, QDialog, QDockWidget,
-    QLabel, QLineEdit, QMessageBox, QPushButton, QTextBrowser, QToolTip, QVBoxLayout,
+    QHBoxLayout, QLabel, QLineEdit, QMessageBox, QPushButton, QStackedWidget, QTabBar,
+    QTextBrowser, QToolTip, QVBoxLayout,
 )
 from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL, GEOM_TYPE_POLYGON
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes, QgsVectorLayer
@@ -124,6 +126,16 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
     spin_maxWidthDep_takeoff: QLineEdit
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
+    # Two-row tab bars (#123) - PyQt6's uic can't construct a bare QTabBar
+    # from .ui XML (it's not in its Designer-placeable widget table, unlike
+    # QTabWidget/QStackedWidget), so tabBarRow1/tabBarRow2 are built in
+    # Python in __init__ and inserted into the (XML-declared, empty)
+    # tabRow1Layout/tabRow2Layout - not setupUi() attributes either.
+    # scriptTabWidget itself is a TwoRowTabSelector instance, also built
+    # in __init__.
+    tabRow1Layout: QHBoxLayout
+    tabRow2Layout: QHBoxLayout
+    scriptTabStack: QStackedWidget
 
     def __init__(self, iface, parent=None):
         """Constructor with enhanced error handling and layer management."""
@@ -152,6 +164,42 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
 
         try:
             self.setupUi(self)
+
+            # Two-row tab selector (#123) - PyQt6's uic can't build a bare
+            # QTabBar straight from .ui XML (unlike QTabWidget/
+            # QStackedWidget, it's not in its Designer-placeable widget
+            # table - "Unknown Qt widget: QTabBar" if declared there), so
+            # both bars are constructed here and inserted into the (empty)
+            # tabRow1Layout/tabRow2Layout declared in qols_panel_base.ui.
+            # Native look, no custom styling. scriptTabStack's 6 pages stay
+            # in their original order (0=Approach ... 5=Take-Off); each row
+            # lists the stack indices of the tabs it owns, in the same
+            # order they're added below.
+            # Row 1 (top): Inner Horizontal & Conical, Outer Horizontal, Take-Off.
+            # Row 2 (bottom): Approach, Transitional, OFZ.
+            self.tabBarRow1 = QTabBar(self)
+            self.tabBarRow2 = QTabBar(self)
+            self.tabRow1Layout.addWidget(self.tabBarRow1)
+            self.tabRow2Layout.addWidget(self.tabBarRow2)
+            for text in ("Inner Horizontal & Conical", "Outer Horizontal", "Take-Off Surface"):
+                self.tabBarRow1.addTab(text)
+            for text in ("Approach Surface", "Transitional", "OFZ"):
+                self.tabBarRow2.addTab(text)
+
+            # scriptTabWidget itself is this shim, not a setupUi() attribute;
+            # it presents the same currentIndex()/tabText()/widget()/
+            # currentChanged surface a QTabWidget did, so every existing
+            # scriptTabWidget call site below keeps working unchanged.
+            self.scriptTabWidget = TwoRowTabSelector(
+                bars=[self.tabBarRow1, self.tabBarRow2],
+                stack_indices_per_bar=[[1, 3, 5], [0, 4, 2]],
+                tab_texts=[
+                    "Approach Surface", "Inner Horizontal & Conical", "OFZ",
+                    "Outer Horizontal", "Transitional", "Take-Off Surface",
+                ],
+                stack=self.scriptTabStack,
+                parent=self,
+            )
 
             # Configure numeric input validation for all QLineEdit widgets (formerly QDoubleSpinBox)
             self.setup_numeric_lineedit_validation()

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -306,16 +306,29 @@
     </item>
     
     <item>
-     <widget class="QTabWidget" name="scriptTabWidget">
-          <property name="tabPosition">
-           <enum>QTabWidget::North</enum>
-          </property>
-      
-      <!-- APPROACH SURFACE TAB -->
+     <widget class="QWidget" name="tabSelectorContainer">
+      <layout class="QVBoxLayout" name="tabSelectorLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="tabRow1Layout"/>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="tabRow2Layout"/>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QStackedWidget" name="scriptTabStack">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
       <widget class="QWidget" name="tab_approach">
-       <attribute name="title">
-        <string>Approach Surface</string>
-       </attribute>
        <layout class="QFormLayout" name="formLayout_approach">
         <property name="fieldGrowthPolicy">
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -526,12 +539,7 @@
         </item>
        </layout>
       </widget>
-      
-      <!-- COMBINED INNER HORIZONTAL & CONICAL TAB -->
             <widget class="QWidget" name="tab_inner_conical">
-       <attribute name="title">
-        <string>Inner Horizontal &amp; Conical</string>
-       </attribute>
        <layout class="QFormLayout" name="formLayout_inner_conical">
         <property name="fieldGrowthPolicy">
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -745,13 +753,7 @@
         </item>
        </layout>
       </widget>
-
-      
-      <!-- OFZ TAB -->
       <widget class="QWidget" name="tab_ofz">
-       <attribute name="title">
-        <string>OFZ</string>
-       </attribute>
     <layout class="QFormLayout" name="formLayout_ofz">
      <property name="fieldGrowthPolicy">
       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -919,12 +921,7 @@
    </item>
        </layout>
       </widget>
-      
-      <!-- OUTER HORIZONTAL TAB -->
       <widget class="QWidget" name="tab_outer_horizontal">
-       <attribute name="title">
-        <string>Outer Horizontal</string>
-       </attribute>
        <layout class="QFormLayout" name="formLayout_outer_horizontal">
         <property name="fieldGrowthPolicy">
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -1031,12 +1028,7 @@
         </item>
        </layout>
       </widget>
-      
-     <!-- TRANSITIONAL TAB (moved before Take-Off) -->
      <widget class="QWidget" name="tab_transitional">
-       <attribute name="title">
-        <string>Transitional</string>
-       </attribute>
     <layout class="QFormLayout" name="formLayout_transitional">
      <property name="fieldGrowthPolicy">
       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -1225,12 +1217,7 @@ QPushButton:checked:hover {
         </item>
        </layout>
       </widget>
-
-        <!-- TAKEOFF TAB (moved to end) -->
         <widget class="QWidget" name="tab_takeoff">
-         <attribute name="title">
-         <string>Take-Off Surface</string>
-         </attribute>
             <layout class="QFormLayout" name="formLayout_takeoff">
         <property name="fieldGrowthPolicy">
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -1422,8 +1409,7 @@ QPushButton:checked:hover {
       </item>
          </layout>
         </widget>
-      
-         </widget>
+     </widget>
     </item>
         </layout>
        </widget>

--- a/qols/ui/tab_row_selector.py
+++ b/qols/ui/tab_row_selector.py
@@ -1,0 +1,122 @@
+"""qols/ui/tab_row_selector.py — two-row tab-bar compatibility shim (#123).
+
+The classic panel's tab bar (qols_panel_base.ui, ``scriptTabWidget``)
+outgrew a single row of tabs — with 6 entries it overflowed horizontally,
+requiring a scroll arrow to reach the later ones. Stock Qt has no
+built-in multi-row tab layout, so the ``.ui`` file now uses two plain
+``QTabBar``s (native look, no custom styling) stacked vertically, each
+holding half the tabs, driving a shared ``QStackedWidget``
+(``scriptTabStack``).
+
+``TwoRowTabSelector`` presents a ``QTabWidget``-compatible surface
+(``currentIndex()``, ``tabText(i)``, ``widget(i)``, a
+``currentChanged(int)`` signal) backed by that two-bar+stack pair, so the
+existing ``self.scriptTabWidget``-based call sites in dockwidget.py need
+no changes beyond constructing this shim once and assigning it to
+``self.scriptTabWidget``.
+
+Each ``QTabBar`` keeps its own native ``currentIndex`` independently of
+the other — nothing in Qt makes two separate ``QTabBar``s mutually
+exclusive. The shim listens to both bars' native ``currentChanged``
+signals and, whenever one bar reports a real selection, deselects the
+other bar via ``setCurrentIndex(-1)`` (a normal, supported QTabBar state
+meaning "no current tab") — guarded by a ``_syncing`` flag so that
+programmatic deselection doesn't itself get mistaken for a user action.
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from qgis.PyQt.QtCore import QObject, pyqtSignal
+
+
+class TwoRowTabSelector(QObject):
+    """QTabWidget-compatible shim over two QTabBar rows + a QStackedWidget.
+
+    ``bars`` and ``stack_indices_per_bar`` must be given in the same
+    order (one entry per row): ``stack_indices_per_bar[i][j]`` is the
+    ``stack`` page index that ``bars[i]``'s tab ``j`` should show.
+    ``tab_texts`` gives the label for each stack index, in stack order —
+    used for ``tabText()`` instead of reading back from a bar, so it
+    doesn't depend on which bar currently owns a given stack index.
+    """
+
+    currentChanged = pyqtSignal(int)
+
+    def __init__(
+        self,
+        bars: Sequence,
+        stack_indices_per_bar: Sequence[Sequence[int]],
+        tab_texts: Sequence[str],
+        stack,
+        parent=None,
+    ):
+        super().__init__(parent)
+        if len(bars) != len(stack_indices_per_bar):
+            raise ValueError("bars and stack_indices_per_bar must have the same length")
+        for bar, row in zip(bars, stack_indices_per_bar):
+            if bar.count() != len(row):
+                raise ValueError(
+                    f"bar has {bar.count()} tabs but its row maps {len(row)} stack indices"
+                )
+        total_tabs = sum(len(row) for row in stack_indices_per_bar)
+        if total_tabs != stack.count() or len(tab_texts) != stack.count():
+            raise ValueError(
+                f"tab/page count mismatch: {total_tabs} mapped tabs, "
+                f"{len(tab_texts)} labels, {stack.count()} pages"
+            )
+        self._bars = list(bars)
+        self._rows = [list(row) for row in stack_indices_per_bar]
+        self._tab_texts = list(tab_texts)
+        self._stack = stack
+        self._current_index = -1
+        self._syncing = False
+        for bar_index, bar in enumerate(self._bars):
+            bar.currentChanged.connect(lambda tab_index, bi=bar_index: self._on_bar_changed(bi, tab_index))
+        self._activate(0, emit=False)
+
+    def _find_bar_and_tab(self, stack_index: int):
+        for bar_index, row in enumerate(self._rows):
+            if stack_index in row:
+                return bar_index, row.index(stack_index)
+        return None, None
+
+    def _activate(self, stack_index: int, emit: bool) -> None:
+        owner_bar, owner_tab = self._find_bar_and_tab(stack_index)
+        self._syncing = True
+        try:
+            for bar_index, bar in enumerate(self._bars):
+                bar.setCurrentIndex(owner_tab if bar_index == owner_bar else -1)
+        finally:
+            self._syncing = False
+        self._current_index = stack_index
+        self._stack.setCurrentIndex(stack_index)
+        if emit:
+            self.currentChanged.emit(stack_index)
+
+    def _on_bar_changed(self, bar_index: int, tab_index: int) -> None:
+        if self._syncing or tab_index < 0:
+            return
+        stack_index = self._rows[bar_index][tab_index]
+        if stack_index == self._current_index:
+            return
+        self._activate(stack_index, emit=True)
+
+    # -- QTabWidget-compatible read API --------------------------------
+
+    def currentIndex(self) -> int:
+        return self._current_index
+
+    def widget(self, index: int):
+        if 0 <= index < len(self._tab_texts):
+            return self._stack.widget(index)
+        return None
+
+    def tabText(self, index: int) -> str:
+        if 0 <= index < len(self._tab_texts):
+            return self._tab_texts[index]
+        return ""
+
+    def setCurrentIndex(self, index: int) -> None:
+        if 0 <= index < len(self._tab_texts) and index != self._current_index:
+            self._activate(index, emit=True)


### PR DESCRIPTION
# feat(#123): two-row tab selector for the classic panel

## Summary
(6 tabs — Approach Surface, Inner Horizontal & Conical, OFZ, Outer
Horizontal, Transitional, Take-Off Surface) overflows horizontally,
needing a "»" scroll arrow to reach the later tabs. Requested two visible
rows instead: Row 1 = Inner Horizontal & Conical, Outer Horizontal,
Take-Off Surface. Row 2 = Approach Surface, Transitional, OFZ.

Stock Qt (`QTabWidget`/`QTabBar`, in both Qt5/Qt6) has no built-in
two-row tab mode — only horizontal-scroll overflow (today's behavior) or
label eliding — so this ships new widget code rather than flipping an
existing property.

**Design iteration**: the first pass used two rows of custom-styled
checkable `QPushButton`s (with inline QSS — colored background, blue
checked-state underline). After seeing it, the user asked for the
*default* look they already had — two rows, but no custom
button/stripe styling. Redesigned to use two plain `QTabBar`s (100%
native appearance, no `styleSheet` at all) instead — see "Changes" below
for the final shape.

---

## Changes

### `qols/ui/qols_panel_base.ui`

Replaced the `scriptTabWidget` `QTabWidget` block with:
- Two empty `QHBoxLayout`s (`tabRow1Layout`, `tabRow2Layout`). The
  `QTabBar`s themselves are **not** declared in the `.ui` at all — an
  earlier version tried `<widget class="QTabBar" name="tabBarRow1"/>`
  directly and it crashed the plugin on load:
  `PyQt6.uic.exceptions.NoSuchWidgetError: Unknown Qt widget: QTabBar`.
  Unlike `QTabWidget`/`QStackedWidget`, a bare `QTabBar` isn't in `uic`'s
  Designer-placeable widget table (it's normally only used internally by
  `QTabWidget`, not dropped standalone from Designer's palette), so it
  can't be constructed straight from `.ui` XML — confirmed by reproducing
  the exact traceback live in QGIS 4.2/PyQt6. Fixed by declaring only the
  two empty layouts in the `.ui` and constructing `QTabBar()` in Python
  (`dockwidget.py::__init__`), then inserting each into its layout via
  `.addWidget()` before adding tabs.
- A `QStackedWidget` (`scriptTabStack`) holding the 6 existing tab pages
  (`tab_approach`, `tab_inner_conical`, `tab_ofz`, `tab_outer_horizontal`,
  `tab_transitional`, `tab_takeoff`) reparented **verbatim** — every
  internal combobox/line-edit/child layout is untouched, only their
  container changed from `QTabWidget` to `QStackedWidget`. Their
  now-meaningless `<attribute name="title">` blocks were removed (a
  `QStackedWidget` page has no title).
- Stack index order stays identical to the original tab order (0=Approach
  … 5=Take-Off) — visual row placement is entirely independent of stack
  index, driven purely by which `QTabBar` a tab is added to.

The `.ui` rewrite was done via a small Python script (not manual editing)
that depth-counted matching `<widget>`/`</widget>` pairs to find each tab
page's exact line range, stripped only its `title` attribute, and
reassembled everything inside the new structure — minimizing the risk of
silently dropping or duplicating any of the ~1100 lines of existing tab
content. XML validity and open/close tag balance were verified after the
rewrite (both the initial button-based version and this final `QTabBar`
version).

### `qols/ui/tab_row_selector.py` (new)

`TwoRowTabSelector(QObject)` — a thin `QTabWidget`-compatible shim over
two real `QTabBar` rows + the shared stack:
- `currentIndex()`, `tabText(i)`, `widget(i)`, `setCurrentIndex(i)`, and a
  `currentChanged = pyqtSignal(int)`.
- Each bar keeps its own native `currentIndex` — nothing in Qt makes two
  separate `QTabBar`s mutually exclusive with each other. The shim
  listens to both bars' native `currentChanged` signals; whenever one
  reports a real selection, it deselects the other bar via
  `setCurrentIndex(-1)` (a normal, Qt-supported "no current tab" state),
  guarded by a `_syncing` flag so that this programmatic deselection
  doesn't get mistaken for a second user action and cause re-entrant
  recursion.
- `tabText(i)` is served from a plain Python list passed at construction
  (in stack-index order), not read back from whichever bar currently owns
  that tab — keeps the lookup independent of which row a given surface
  type happens to live in.
- Validates at construction that each bar's actual `.count()` matches how
  many stack indices its row claims, and that the totals match the
  stack's page count — catches a wiring mistake (bar/row/stack out of
  sync) immediately instead of silently misbehaving later.

### `qols/ui/dockwidget.py`

In `__init__`, right after `self.setupUi(self)`:
```python
self.tabBarRow1 = QTabBar(self)
self.tabBarRow2 = QTabBar(self)
self.tabRow1Layout.addWidget(self.tabBarRow1)
self.tabRow2Layout.addWidget(self.tabBarRow2)
for text in ("Inner Horizontal & Conical", "Outer Horizontal", "Take-Off Surface"):
    self.tabBarRow1.addTab(text)
for text in ("Approach Surface", "Transitional", "OFZ"):
    self.tabBarRow2.addTab(text)

self.scriptTabWidget = TwoRowTabSelector(
    bars=[self.tabBarRow1, self.tabBarRow2],
    stack_indices_per_bar=[[1, 3, 5], [0, 4, 2]],
    tab_texts=["Approach Surface", "Inner Horizontal & Conical", "OFZ",
               "Outer Horizontal", "Transitional", "Take-Off Surface"],
    stack=self.scriptTabStack, parent=self,
)
```
This is mandatory — `setupUi()` no longer creates a `scriptTabWidget`
attribute itself (there's no widget by that name in the `.ui` anymore),
so without it every existing call site would raise `AttributeError`. All
4 existing `scriptTabWidget`-dependent call sites (`currentChanged`
connection, `get_parameters()`'s surface-type dispatch, `on_tab_changed`,
`_update_direction_marker`) are **unchanged** — they were already
string/name-based, never index-hardcoded, so the shim's identical API
surface means zero diff there. Added type-stub declarations for
`tabBarRow1`/`tabBarRow2`/`scriptTabStack` alongside the existing
`check_finalWidth1800_takeoff`-style widget declarations.

### Tests

`tests/test_tab_row_selector.py` (new, 20 tests) — exercises
`TwoRowTabSelector` directly against minimal fake `QTabBar`/
`QStackedWidget` stand-ins (real Qt widget signals are inert under this
repo's mocked test harness, same reasoning as this suite's existing
`_LineEdit`/`_ComboBox` fakes; the fake `QTabBar` mirrors the one native
behavior the shim depends on — `setCurrentIndex(i)` fires
`currentChanged(i)` synchronously, including for `i == -1`):
default-to-stack-index-0, selecting in either row activates the right
stack page and deselects the other row, `currentChanged` fires exactly
once per real switch and not on a no-op reselect, `setCurrentIndex`
parity, out-of-range handling, construction-time count validation — plus
a parametrized regression test pinning all 6 tab-text strings against
`SurfaceType.from_tab_text()`, guarding the new "must stay byte-identical"
invariant now that the string is maintained in Python instead of coming
straight from a native tab title.

`tests/test_dockwidget_logic.py` needed **no changes** — its
`scriptTabWidget` fixtures already inject a bare `MagicMock()` via
keyword override on subjects built with `object.__new__()` (bypassing
`__init__`, hence the real shim, entirely), so they're indifferent to
this change.

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_contour_integration.py --ignore=tests/test_contour_polygon_slice.py
# 525 passed, 2 failed — both pre-existing/unrelated (#122's contour_interval_m
# tests; that work isn't merged into main yet, this branch was cut from main).
# The two --ignore flags exclude two other #122-only test files, same reason
# (tests/ is gitignored so untracked files from other branches persist on disk).

flake8 qols/ui/tab_row_selector.py qols/ui/dockwidget.py
# tab_row_selector.py: 0 issues
# dockwidget.py: 3 pre-existing F821 findings, unrelated (documented
# dead-code baseline, see doc/PR_113.md)
```

Manual QGIS check (pending, cannot be automated):
1. Both rows render fully within the dock's 600×800 max size with no
   horizontal scrolling, using the platform's normal tab appearance.
2. "Inner Horizontal & Conical" doesn't get awkwardly truncated at
   default Qt elide behavior within its row's share of the width.
3. Clicking any tab in either row shows the correct page and visually
   deselects the tab that was previously current in the *other* row;
   switching still updates the direction marker / applies Transitional
   defaults exactly as before.
4. Calculate still dispatches to the correct surface script from every
   tab (exercises the `get_parameters()` → `SurfaceType.from_tab_text()`
   path end-to-end).

---

## Risk / notes

- Purely a classic-panel UI change — no `qols/plugin.py` or calculation
  script changes.
- No custom styling at all means default Qt elide/scroll behavior is
  back in play *per row* if a label doesn't fit — much less likely than
  before (3 tabs per row instead of 6), but not structurally impossible;
  worth a look during manual verification.
- Re-opening `qols_panel_base.ui` in the graphical Qt Designer may
  regenerate/insert `<zorder>` elements for `scriptTabStack`'s pages on
  next save — harmless for `uic` loading at runtime, just expect it as
  incidental diff noise the next time someone edits this file visually.
