### PR TITLE
fix(#124): Conical Surface must not overlap Inner Horizontal

### DIFF
--- a/qols/geometry_difference.py
+++ b/qols/geometry_difference.py
@@ -1,0 +1,144 @@
+"""qols/geometry_difference.py — flat-Z-preserving polygon difference for
+the Conical vs. Inner Horizontal surfaces (#124).
+
+`conical.py` and `inner-horizontal-racetrack.py` are independently
+implemented but geometrically concentric: both build a racetrack polygon
+(two circular arcs at the runway's start/end thresholds, joined by
+tangents) from the *same* runway centerline/threshold points and azimuth,
+differing only in radius `L` — Conical's radius is always >= Inner
+Horizontal's (`Height/Slope + InnerHorizontalRadius`, see
+`dockwidget.py::recalculate_conical_radius`), so Conical's solid disk
+always fully covers Inner Horizontal's, and the two rendered layers
+visually overlap. Per ICAO Annex 14, Conical's footprint should be the
+ring beyond Inner Horizontal's edge.
+
+Unlike `qols/geometry_merge.py`'s union work (#121), no Z-interpolation
+is needed here: each script's polygon is already flat — every vertex
+shares one uniform `height` value — so the differenced ring just needs
+that same flat Z re-applied to whatever vertices GEOS's 2D
+`QgsGeometry.difference()` produces (which doesn't reliably carry Z
+through a boolean op). `difference_flat()` is the thin QGIS-aware
+wrapper; the ring-flattening step is pure enough to unit test directly
+via `flatten_ring_z`.
+"""
+from __future__ import annotations
+
+Point2 = tuple[float, float]
+Point3 = tuple[float, float, float]
+
+__all__ = [
+    "flatten_ring_z",
+    "difference_flat",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure geometry helper (no QGIS dependency — operates on plain tuples)
+# ---------------------------------------------------------------------------
+
+def flatten_ring_z(ring_xy: list[Point2], z: float) -> list[Point3]:
+    """Return `ring_xy` with `z` applied to every vertex — no
+    interpolation, since both source polygons are already flat."""
+    return [(x, y, z) for x, y in ring_xy]
+
+
+# ---------------------------------------------------------------------------
+# QGIS-aware wrapper
+# ---------------------------------------------------------------------------
+
+def _geometry_parts(geom) -> list:
+    """Every polygon part of `geom` — `[geom]` if single-part, else each
+    member of a multi-part geometry."""
+    if not geom.isMultipart():
+        return [geom]
+    parts = geom.asGeometryCollection()
+    return parts if parts else [geom]
+
+
+def _ring_xy(ring) -> list[Point2]:
+    return [(ring.pointN(i).x(), ring.pointN(i).y()) for i in range(ring.numPoints())]
+
+
+def _base_flat_z(geom) -> float | None:
+    """The single Z value shared by every vertex of `geom`'s first part —
+    read from its exterior ring's first point (both source scripts here
+    only ever build flat, single-Z polygons)."""
+    parts = _geometry_parts(geom)
+    if not parts:
+        return None
+    ring = parts[0].constGet().exteriorRing()
+    if ring.numPoints() == 0:
+        return None
+    return ring.pointN(0).z()
+
+
+def difference_flat(base_geom, subtract_geom):
+    """2D-difference `base_geom` minus `subtract_geom`, re-applying
+    `base_geom`'s own flat Z to every vertex of every ring (exterior
+    *and* interior/hole rings — a polygon-with-a-hole is a single
+    `QgsPolygon` with multiple rings, not a `MultiPolygon`, which is the
+    expected result here since Inner Horizontal is fully contained
+    within Conical) of every part of the result (multipart handled
+    defensively for unusual/self-intersecting input). Falls back to
+    `base_geom` unchanged if the difference is empty or anything fails —
+    a failed trim must not delete the surface the user just calculated.
+    """
+    from qgis.core import QgsGeometry, QgsLineString, QgsMultiPolygon, QgsPoint, QgsPolygon
+
+    try:
+        base_area = base_geom.area()
+        print(f"difference_flat: base area={base_area}, base isMultipart={base_geom.isMultipart()}, "
+              f"base wkbType={base_geom.wkbType()}")
+
+        z = _base_flat_z(base_geom)
+        print(f"difference_flat: detected flat z={z}")
+        if z is None:
+            print("difference_flat: z is None, returning base_geom unchanged")
+            return base_geom
+
+        diff = base_geom.difference(subtract_geom)
+        if diff is None:
+            print("difference_flat: base_geom.difference() returned None, returning base_geom unchanged")
+            return base_geom
+        print(f"difference_flat: diff area={diff.area()}, diff isEmpty={diff.isEmpty()}, "
+              f"diff isMultipart={diff.isMultipart()}, diff wkbType={diff.wkbType()}")
+        if diff.isEmpty():
+            print("difference_flat: diff is empty, returning base_geom unchanged")
+            return base_geom
+        if abs(diff.area() - base_area) < 1e-6:
+            print("difference_flat: WARNING - diff area equals base area, subtraction had no visible effect")
+
+        rebuilt_parts = []
+        for part in _geometry_parts(diff):
+            abstract = part.constGet()
+            ext_pts = [QgsPoint(x, y, pz) for x, y, pz in flatten_ring_z(_ring_xy(abstract.exteriorRing()), z)]
+            if len(ext_pts) < 3:
+                continue
+            interior_rings = []
+            for i in range(abstract.numInteriorRings()):
+                hole_xy = _ring_xy(abstract.interiorRing(i))
+                if len(hole_xy) < 3:
+                    continue
+                hole_pts = [QgsPoint(x, y, pz) for x, y, pz in flatten_ring_z(hole_xy, z)]
+                interior_rings.append(QgsLineString(hole_pts))
+            print(f"difference_flat: part with {len(ext_pts)} exterior pts, {len(interior_rings)} interior ring(s)")
+            rebuilt_parts.append(QgsPolygon(QgsLineString(ext_pts), rings=interior_rings))
+
+        if not rebuilt_parts:
+            print("difference_flat: no rebuilt parts, returning base_geom unchanged")
+            return base_geom
+
+        if len(rebuilt_parts) == 1:
+            result = QgsGeometry(rebuilt_parts[0])
+        else:
+            multi = QgsMultiPolygon()
+            for poly in rebuilt_parts:
+                multi.addGeometry(poly)
+            result = QgsGeometry(multi)
+        print(f"difference_flat: returning trimmed geometry, area={result.area()}")
+        return result
+    except Exception as e:
+        import traceback
+        print(f"difference_flat: FAILED with {e!r}")
+        traceback.print_exc()
+        return base_geom

--- a/qols/geometry_difference.py
+++ b/qols/geometry_difference.py
@@ -15,11 +15,18 @@ ring beyond Inner Horizontal's edge.
 Unlike `qols/geometry_merge.py`'s union work (#121), no Z-interpolation
 is needed here: each script's polygon is already flat — every vertex
 shares one uniform `height` value — so the differenced ring just needs
-that same flat Z re-applied to whatever vertices GEOS's 2D
+a flat Z re-applied to whatever vertices GEOS's 2D
 `QgsGeometry.difference()` produces (which doesn't reliably carry Z
 through a boolean op). `difference_flat()` is the thin QGIS-aware
 wrapper; the ring-flattening step is pure enough to unit test directly
 via `flatten_ring_z`.
+
+Per #125, Conical's two edges sit at different elevations above the
+shared datum (inner edge = Datum + Inner Horizontal Height, outer edge
+= Datum + Inner Horizontal Height + Conical Height), so `difference_flat`
+takes the two Z values explicitly rather than auto-detecting a single
+flat Z off `base_geom`: `exterior_z` for the result's outer boundary,
+`interior_z` for the interior/hole ring left by the subtraction.
 """
 from __future__ import annotations
 
@@ -59,42 +66,24 @@ def _ring_xy(ring) -> list[Point2]:
     return [(ring.pointN(i).x(), ring.pointN(i).y()) for i in range(ring.numPoints())]
 
 
-def _base_flat_z(geom) -> float | None:
-    """The single Z value shared by every vertex of `geom`'s first part —
-    read from its exterior ring's first point (both source scripts here
-    only ever build flat, single-Z polygons)."""
-    parts = _geometry_parts(geom)
-    if not parts:
-        return None
-    ring = parts[0].constGet().exteriorRing()
-    if ring.numPoints() == 0:
-        return None
-    return ring.pointN(0).z()
-
-
-def difference_flat(base_geom, subtract_geom):
-    """2D-difference `base_geom` minus `subtract_geom`, re-applying
-    `base_geom`'s own flat Z to every vertex of every ring (exterior
-    *and* interior/hole rings — a polygon-with-a-hole is a single
-    `QgsPolygon` with multiple rings, not a `MultiPolygon`, which is the
-    expected result here since Inner Horizontal is fully contained
-    within Conical) of every part of the result (multipart handled
-    defensively for unusual/self-intersecting input). Falls back to
-    `base_geom` unchanged if the difference is empty or anything fails —
-    a failed trim must not delete the surface the user just calculated.
+def difference_flat(base_geom, subtract_geom, exterior_z, interior_z):
+    """2D-difference `base_geom` minus `subtract_geom`, applying
+    `exterior_z` to every vertex of the result's exterior ring and
+    `interior_z` to every vertex of its interior/hole rings (a
+    polygon-with-a-hole is a single `QgsPolygon` with multiple rings, not
+    a `MultiPolygon`, which is the expected result here since Inner
+    Horizontal is fully contained within Conical) of every part of the
+    result (multipart handled defensively for unusual/self-intersecting
+    input). Falls back to `base_geom` unchanged if the difference is
+    empty or anything fails — a failed trim must not delete the surface
+    the user just calculated.
     """
     from qgis.core import QgsGeometry, QgsLineString, QgsMultiPolygon, QgsPoint, QgsPolygon
 
     try:
         base_area = base_geom.area()
         print(f"difference_flat: base area={base_area}, base isMultipart={base_geom.isMultipart()}, "
-              f"base wkbType={base_geom.wkbType()}")
-
-        z = _base_flat_z(base_geom)
-        print(f"difference_flat: detected flat z={z}")
-        if z is None:
-            print("difference_flat: z is None, returning base_geom unchanged")
-            return base_geom
+              f"base wkbType={base_geom.wkbType()}, exterior_z={exterior_z}, interior_z={interior_z}")
 
         diff = base_geom.difference(subtract_geom)
         if diff is None:
@@ -111,7 +100,8 @@ def difference_flat(base_geom, subtract_geom):
         rebuilt_parts = []
         for part in _geometry_parts(diff):
             abstract = part.constGet()
-            ext_pts = [QgsPoint(x, y, pz) for x, y, pz in flatten_ring_z(_ring_xy(abstract.exteriorRing()), z)]
+            ext_xyz = flatten_ring_z(_ring_xy(abstract.exteriorRing()), exterior_z)
+            ext_pts = [QgsPoint(x, y, pz) for x, y, pz in ext_xyz]
             if len(ext_pts) < 3:
                 continue
             interior_rings = []
@@ -119,7 +109,7 @@ def difference_flat(base_geom, subtract_geom):
                 hole_xy = _ring_xy(abstract.interiorRing(i))
                 if len(hole_xy) < 3:
                     continue
-                hole_pts = [QgsPoint(x, y, pz) for x, y, pz in flatten_ring_z(hole_xy, z)]
+                hole_pts = [QgsPoint(x, y, pz) for x, y, pz in flatten_ring_z(hole_xy, interior_z)]
                 interior_rings.append(QgsLineString(hole_pts))
             print(f"difference_flat: part with {len(ext_pts)} exterior pts, {len(interior_rings)} interior ring(s)")
             rebuilt_parts.append(QgsPolygon(QgsLineString(ext_pts), rings=interior_rings))

--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -438,8 +438,49 @@ class QOLS:
         feature) if either layer can't be found unambiguously or a
         difference fails — a failed trim must not delete the surface the
         user just calculated.
+
+        #125: the trimmed ring's two edges sit at different absolute
+        elevations above the shared datum — the inner edge (touching
+        Inner Horizontal) at ``datum + inner_height``, the outer edge at
+        ``datum + inner_height + conical_height``. ``bottom_z`` uses the
+        exact same formula Inner Horizontal itself computes its own flat
+        Z with, guaranteeing the two surfaces meet at the same elevation
+        by construction.
         """
         from .geometry_difference import difference_flat
+
+        def _first_vertex_z(geom):
+            """Diagnostic-only: exterior ring's first vertex Z, or None."""
+            try:
+                parts = geom.asGeometryCollection() if geom.isMultipart() else [geom]
+                ring = parts[0].constGet().exteriorRing()
+                return ring.pointN(0).z() if ring.numPoints() else None
+            except Exception:
+                return None
+
+        def _first_interior_vertex_z(geom):
+            """Diagnostic-only: first interior/hole ring's first vertex Z, or None
+            (None also means "no hole yet" if the trim didn't produce one)."""
+            try:
+                parts = geom.asGeometryCollection() if geom.isMultipart() else [geom]
+                abstract = parts[0].constGet()
+                if abstract.numInteriorRings() == 0:
+                    return None
+                ring = abstract.interiorRing(0)
+                return ring.pointN(0).z() if ring.numPoints() else None
+            except Exception:
+                return None
+
+        datum_elevation = conical_params.get('datum_elevation', 0.0)
+        inner_height = conical_params.get('inner_height', 0.0)
+        conical_height = conical_params.get('height', 0.0)
+        bottom_z = datum_elevation + inner_height
+        top_z = datum_elevation + inner_height + conical_height
+        logger.info(
+            f"_trim_conical_to_ring: datum_elevation={datum_elevation}, inner_height={inner_height}, "
+            f"conical_height={conical_height} -> bottom_z={bottom_z} (must match Inner Horizontal's own "
+            f"Z, so the two surfaces meet as a single line), top_z={top_z}"
+        )
 
         inner_name = (
             f"InnerHorizontal_{inner_params.get('rwyClassification', 'Precision Approach CAT I')}"
@@ -469,6 +510,10 @@ class QOLS:
         if not inner_geoms:
             logger.warning("_trim_conical_to_ring: no Inner Horizontal geometries, skipping trim")
             return
+        logger.info(
+            f"_trim_conical_to_ring: Inner Horizontal's own vertex Z (read from layer, "
+            f"should equal bottom_z={bottom_z}) = {_first_vertex_z(inner_geoms[0])}"
+        )
         inner_union = QgsGeometry.unaryUnion(inner_geoms)
         logger.info(
             f"_trim_conical_to_ring: inner_union area={inner_union.area() if inner_union else None}, "
@@ -480,9 +525,15 @@ class QOLS:
         conical_feature_count = 0
         for feat in conical_layer.getFeatures():
             conical_feature_count += 1
-            trimmed = difference_flat(feat.geometry(), inner_union)
+            trimmed = difference_flat(feat.geometry(), inner_union, exterior_z=top_z, interior_z=bottom_z)
             if trimmed is not None and not trimmed.isEmpty():
                 geometry_changes[feat.id()] = trimmed
+                logger.info(
+                    f"_trim_conical_to_ring: feature {feat.id()} trimmed — exterior vertex Z="
+                    f"{_first_vertex_z(trimmed)} (expected top_z={top_z}), interior/hole vertex Z="
+                    f"{_first_interior_vertex_z(trimmed)} (expected bottom_z={bottom_z} — this is the "
+                    f"single shared line/edge where Conical meets Inner Horizontal)"
+                )
         logger.info(
             f"_trim_conical_to_ring: {conical_feature_count} Conical feature(s) processed, "
             f"{len(geometry_changes)} geometry change(s) prepared"

--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -387,7 +387,11 @@ class QOLS:
         self.execute_script(script_path, params)
 
     def execute_combined_inner_conical_surface(self, params):
-        """Execute Inner Horizontal then Conical using per-surface parameters."""
+        """Execute Inner Horizontal then Conical using per-surface parameters,
+        then trim Conical's footprint down to the ring beyond Inner
+        Horizontal (#124) — both are concentric racetracks (same runway
+        spine/azimuth, Conical's radius >= Inner Horizontal's by
+        construction), so Conical would otherwise fully cover it."""
         try:
             specific_params = params.get('specific_params', {})
 
@@ -408,9 +412,87 @@ class QOLS:
             conical_script_path = os.path.join(self.plugin_dir, 'scripts', 'conical.py')
             self.execute_script(conical_script_path, conical_full_params)
 
+            self._trim_conical_to_ring(inner_params, conical_params)
+
         except Exception as e:
             logger.error(f"Error in combined Inner Horizontal & Conical execution: {e}\n{traceback.format_exc()}")
             raise
+
+    def _trim_conical_to_ring(self, inner_params, conical_params):
+        """#124: subtract Inner Horizontal's footprint from Conical's so the
+        two surfaces don't visually overlap — Conical should only cover
+        the ring beyond Inner Horizontal's edge, per ICAO Annex 14.
+
+        Both scripts delete every global they introduced (including their
+        own ``v_layer``) as their very last action — a pre-existing
+        exec()-namespace cleanup pattern shared by every script in
+        qols/scripts/ — so ``execute_script()``'s returned namespace never
+        actually contains ``v_layer`` by the time control returns here.
+        The layers are instead found by the same deterministic name each
+        script itself builds (``f"InnerHorizontal_{classification}_Code{code}"``
+        / ``f"Conical_{classification}_Code{code}"``), mirroring the
+        name-based lookup convention #121 already established for the
+        "Merged Transitional Surface" layer.
+
+        Defensive: leaves Conical's original geometry untouched (per
+        feature) if either layer can't be found unambiguously or a
+        difference fails — a failed trim must not delete the surface the
+        user just calculated.
+        """
+        from .geometry_difference import difference_flat
+
+        inner_name = (
+            f"InnerHorizontal_{inner_params.get('rwyClassification', 'Precision Approach CAT I')}"
+            f"_Code{inner_params.get('code', 4)}"
+        )
+        conical_name = (
+            f"Conical_{conical_params.get('rwyClassification', 'Precision Approach CAT I')}"
+            f"_Code{conical_params.get('code', 4)}"
+        )
+        inner_matches = QgsProject.instance().mapLayersByName(inner_name)
+        conical_matches = QgsProject.instance().mapLayersByName(conical_name)
+        logger.info(
+            f"_trim_conical_to_ring: '{inner_name}' -> {len(inner_matches)} match(es), "
+            f"'{conical_name}' -> {len(conical_matches)} match(es)"
+        )
+        if len(inner_matches) != 1 or len(conical_matches) != 1:
+            logger.warning(
+                "Could not trim Conical to a ring — expected exactly one Inner Horizontal and one "
+                "Conical layer by name; delete older same-named layers and recalculate if this persists."
+            )
+            return
+        inner_layer = inner_matches[0]
+        conical_layer = conical_matches[0]
+
+        inner_geoms = [f.geometry() for f in inner_layer.getFeatures() if not f.geometry().isEmpty()]
+        logger.info(f"_trim_conical_to_ring: {len(inner_geoms)} Inner Horizontal geometrie(s) found")
+        if not inner_geoms:
+            logger.warning("_trim_conical_to_ring: no Inner Horizontal geometries, skipping trim")
+            return
+        inner_union = QgsGeometry.unaryUnion(inner_geoms)
+        logger.info(
+            f"_trim_conical_to_ring: inner_union area={inner_union.area() if inner_union else None}, "
+            f"isEmpty={inner_union.isEmpty() if inner_union else None}"
+        )
+
+        pr = conical_layer.dataProvider()
+        geometry_changes = {}
+        conical_feature_count = 0
+        for feat in conical_layer.getFeatures():
+            conical_feature_count += 1
+            trimmed = difference_flat(feat.geometry(), inner_union)
+            if trimmed is not None and not trimmed.isEmpty():
+                geometry_changes[feat.id()] = trimmed
+        logger.info(
+            f"_trim_conical_to_ring: {conical_feature_count} Conical feature(s) processed, "
+            f"{len(geometry_changes)} geometry change(s) prepared"
+        )
+
+        if geometry_changes:
+            changed_ok = pr.changeGeometryValues(geometry_changes)
+            logger.info(f"_trim_conical_to_ring: changeGeometryValues returned {changed_ok}")
+            conical_layer.updateExtents()
+            conical_layer.triggerRepaint()
 
     # ------------------------------------------------------------------
     # BUG-04 — Centralised layer validation

--- a/qols/scripts/_contour_utils.py
+++ b/qols/scripts/_contour_utils.py
@@ -286,10 +286,48 @@ def contour_specs_for_polygon_slice(
 
 
 # ---------------------------------------------------------------------------
+# Conical Surface (#126) — radial contour helper
+# ---------------------------------------------------------------------------
+
+def conical_contour_radius(
+    elevation: float,
+    bottom_z: float,
+    r_inner: float,
+    slope: float,
+) -> float:
+    """Radius at which the Conical surface reaches ``elevation``.
+
+    Unlike Approach/Take-off/Transitional, Conical's elevation varies
+    purely with radial distance from the runway spine, not along the
+    runway's length — its rise is linear in radius:
+    ``elevation(r) = bottom_z + slope * (r - r_inner)``. Solving for
+    ``r`` gives this formula.
+
+    Precondition: ``slope > 0`` — the caller's responsibility to check
+    (same convention as :func:`contour_specs_for_linear_section`'s own
+    ``slope <= 0`` guard); a non-positive slope makes "radius at this
+    elevation" undefined, so callers should skip contour generation
+    entirely rather than call this.
+
+    Args:
+        elevation: Target contour elevation, metres.
+        bottom_z:  Elevation at the inner edge (``r_inner``), metres —
+                   equals Datum + Inner Horizontal Height.
+        r_inner:   Radius of the inner edge (Inner Horizontal's own
+                   radius), metres.
+        slope:     Vertical rise per horizontal metre (decimal, > 0).
+
+    Returns:
+        The radius, in metres, at which the cone reaches ``elevation``.
+    """
+    return r_inner + (elevation - bottom_z) / slope
+
+
+# ---------------------------------------------------------------------------
 # Layer styling
 # ---------------------------------------------------------------------------
 
-def apply_contour_style(layer, script_file: str) -> bool:
+def apply_contour_style(layer, script_file: str, label_font_size: float = None) -> bool:
     """Apply the distributed QML style to a contour layer.
 
     Looks for ``<plugin_root>/styles/contour_styling.qml`` relative to the
@@ -305,9 +343,14 @@ def apply_contour_style(layer, script_file: str) -> bool:
       * Plain label from the ``surface_elevation`` field
 
     Args:
-        layer:       A ``QgsVectorLayer`` (LineStringZ) for the contour layer.
-        script_file: ``__file__`` of the calling script.  Used to locate the
-                     ``styles/`` folder one directory above ``scripts/``.
+        layer:            A ``QgsVectorLayer`` (LineStringZ) for the contour layer.
+        script_file:      ``__file__`` of the calling script.  Used to locate the
+                          ``styles/`` folder one directory above ``scripts/``.
+        label_font_size:  If given, overrides the label text size (points) on
+                          top of whichever style (QML or fallback) got applied —
+                          e.g. Conical's many closely-spaced contour rings
+                          (#126) need a larger label than Approach/
+                          Transitional's more sparsely spaced ones.
 
     Returns:
         ``True`` if the QML file was applied, ``False`` if the fallback was used.
@@ -321,27 +364,41 @@ def apply_contour_style(layer, script_file: str) -> bool:
         'contour_styling.qml',
     )
 
+    applied_qml = False
     if os.path.isfile(styles_path):
         try:
             _msg, success = layer.loadNamedStyle(styles_path)
             if success:
-                layer.triggerRepaint()
-                return True
+                applied_qml = True
         except Exception:
             pass  # fall through to hardcoded fallback
 
-    # Fallback: hardcoded style (previous behaviour, always safe)
-    from qgis.core import (  # noqa: PLC0415 — intentional late import (no QGIS at test time)
-        QgsLineSymbol,
-        QgsSingleSymbolRenderer,
-        QgsPalLayerSettings,
-        QgsVectorLayerSimpleLabeling,
-    )
-    _sym = QgsLineSymbol.createSimple({'color': 'red', 'width': '0.5'})
-    layer.setRenderer(QgsSingleSymbolRenderer(_sym))
-    _pal = QgsPalLayerSettings()
-    _pal.fieldName = 'surface_elevation'
-    _pal.enabled = True
-    layer.setLabeling(QgsVectorLayerSimpleLabeling(_pal))
-    layer.setLabelsEnabled(True)
-    return False
+    if not applied_qml:
+        # Fallback: hardcoded style (previous behaviour, always safe)
+        from qgis.core import (  # noqa: PLC0415 — intentional late import (no QGIS at test time)
+            QgsLineSymbol,
+            QgsSingleSymbolRenderer,
+            QgsPalLayerSettings,
+            QgsVectorLayerSimpleLabeling,
+        )
+        _sym = QgsLineSymbol.createSimple({'color': 'red', 'width': '0.5'})
+        layer.setRenderer(QgsSingleSymbolRenderer(_sym))
+        _pal = QgsPalLayerSettings()
+        _pal.fieldName = 'surface_elevation'
+        _pal.enabled = True
+        layer.setLabeling(QgsVectorLayerSimpleLabeling(_pal))
+        layer.setLabelsEnabled(True)
+
+    if label_font_size is not None:
+        from qgis.core import QgsVectorLayerSimpleLabeling  # noqa: PLC0415
+        labeling = layer.labeling()
+        if labeling is not None:
+            settings = labeling.settings()
+            text_format = settings.format()
+            text_format.setSize(label_font_size)
+            settings.setFormat(text_format)
+            layer.setLabeling(QgsVectorLayerSimpleLabeling(settings))
+            layer.setLabelsEnabled(True)
+
+    layer.triggerRepaint()
+    return applied_qml

--- a/qols/scripts/conical.py
+++ b/qols/scripts/conical.py
@@ -52,6 +52,8 @@ try:
     # Conical surface parameters from UI
     L = globals().get('radius', 6000)  # Distance L / Radius from UI
     height = globals().get('height', 60.0)  # Height for 3D polygon (new parameter)
+    datum_elevation = globals().get('datum_elevation', 0.0)  # Reference elevation (#125)
+    inner_height = globals().get('inner_height', 0.0)  # Inner Horizontal's own height (#125)
     runway_code = globals().get('code', 4)
     rwy_classification = globals().get('rwyClassification', 'Precision Approach CAT I')
 
@@ -71,6 +73,8 @@ except Exception as e:
     # Fallback to defaults if parameters not provided
     L = 6000
     height = 60.0
+    datum_elevation = 0.0
+    inner_height = 0.0
     s = 0
     runway_layer = None
     threshold_layer = None
@@ -80,6 +84,12 @@ except Exception as e:
 
 print(f"Conical: Final values - radius: {L}m, height: {height}m, direction: {s}")
 print(f"Conical: Direction interpretation - s={s} means {'End to Start' if s == -1 else 'Start to End'}")
+
+# Absolute elevation of Conical's outer (top) edge above the shared datum
+# (#125) — the inner edge (after #124's trim) instead sits at
+# datum + inner_height, applied later by plugin.py::_trim_conical_to_ring.
+z_top = datum_elevation + inner_height + height
+print(f"Conical: Datum elevation: {datum_elevation}m, Inner Horizontal height: {inner_height}m, top Z: {z_top}m")
 
 map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
@@ -218,6 +228,8 @@ v_layer_provider.addAttributes([
     QgsField("surface_type", QVariant.String),
     QgsField("radius_m", QVariant.Double),
     QgsField("height_m", QVariant.Double),
+    QgsField("datum_elevation_m", QVariant.Double),
+    QgsField("inner_height_m", QVariant.Double),
     QgsField("rule_set", QVariant.String),
     QgsField("runway_start_x", QVariant.Double),
     QgsField("runway_start_y", QVariant.Double),
@@ -236,6 +248,8 @@ _active_rule_set = globals().get('active_rule_set', None)
 _params_json = build_parameters_json('Conical Surface', {
     'radius_m': L,
     'height_m': height,
+    'datum_elevation_m': datum_elevation,
+    'inner_height_m': inner_height,
     'rule_set': _active_rule_set,
     'azimuth': angle0,
     'rwy_classification': rwy_classification,
@@ -277,7 +291,7 @@ if segmented1:
 
         # Add arc points with height
         for point in polyline1:
-            polygon_points.append(QgsPoint(point.x(), point.y(), height))
+            polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
     elif segmented1.wkbType() == QgsWkbTypes.MultiLineString:
         multiline1 = segmented1.asMultiPolyline()
         print(f"Conical: Arc 1 interpolated to {len(multiline1)} parts (MultiLineString)")
@@ -285,25 +299,25 @@ if segmented1:
         # Add points from all parts
         for part in multiline1:
             for point in part:
-                polygon_points.append(QgsPoint(point.x(), point.y(), height))
+                polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
     else:
         print(f"Conical: Warning - Unexpected geometry type: {segmented1.wkbType()}")
         # Fallback to original points
         polygon_points.extend([
-            QgsPoint(pro_coords[0], pro_coords[1], height),
-            QgsPoint(xc[0], xc[1], height),
-            QgsPoint(x2[0], x2[1], height)
+            QgsPoint(pro_coords[0], pro_coords[1], z_top),
+            QgsPoint(xc[0], xc[1], z_top),
+            QgsPoint(x2[0], x2[1], z_top)
         ])
 else:
     print("Conical: Warning - Could not interpolate first arc, using original points")
     polygon_points.extend([
-        QgsPoint(pro_coords[0], pro_coords[1], height),
-        QgsPoint(xc[0], xc[1], height),
-        QgsPoint(x2[0], x2[1], height)
+        QgsPoint(pro_coords[0], pro_coords[1], z_top),
+        QgsPoint(xc[0], xc[1], z_top),
+        QgsPoint(x2[0], x2[1], z_top)
     ])
 
 # Add straight line from x2 to x6 (connect arc endpoints, not diagonals)
-polygon_points.append(QgsPoint(x6[0], x6[1], height))
+polygon_points.append(QgsPoint(x6[0], x6[1], z_top))
 
 # Second arc: Create CircularString and extract points
 # This is exactly how the original code creates the second arc: [x6, x5, x4] (REVERSED)
@@ -326,7 +340,7 @@ if segmented2:
         for i, point in enumerate(polyline2):
             if i == 0:  # Skip first point as it's the same as x6 we just added
                 continue
-            polygon_points.append(QgsPoint(point.x(), point.y(), height))
+            polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
     elif segmented2.wkbType() == QgsWkbTypes.MultiLineString:
         multiline2 = segmented2.asMultiPolyline()
         print(f"Conical: Arc 2 interpolated to {len(multiline2)} parts (MultiLineString)")
@@ -336,23 +350,23 @@ if segmented2:
             for point_idx, point in enumerate(part):
                 if part_idx == 0 and point_idx == 0:  # Skip first point of first part (x6)
                     continue
-                polygon_points.append(QgsPoint(point.x(), point.y(), height))
+                polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
     else:
         print(f"Conical: Warning - Unexpected geometry type: {segmented2.wkbType()}")
         # Fallback to original points (reversed order: x5, x4)
         polygon_points.extend([
-            QgsPoint(x5[0], x5[1], height),
-            QgsPoint(x4[0], x4[1], height)
+            QgsPoint(x5[0], x5[1], z_top),
+            QgsPoint(x4[0], x4[1], z_top)
         ])
 else:
     print("Conical: Warning - Could not interpolate second arc, using original points")
     polygon_points.extend([
-        QgsPoint(x5[0], x5[1], height),
-        QgsPoint(x4[0], x4[1], height)
+        QgsPoint(x5[0], x5[1], z_top),
+        QgsPoint(x4[0], x4[1], z_top)
     ])
 
 # Add straight line back to start (closing the polygon)
-polygon_points.append(QgsPoint(pro_coords[0], pro_coords[1], height))
+polygon_points.append(QgsPoint(pro_coords[0], pro_coords[1], z_top))
 
 print(f"Conical: Created surface with proper circular arcs using QGIS interpolation")
 print(f"Conical: Total points in polygon: {len(polygon_points)}")
@@ -378,6 +392,8 @@ feature.setAttributes([
     "Conical",
     L,
     height,
+    datum_elevation,
+    inner_height,
     _active_rule_set,
     start_point.x(),
     start_point.y(),

--- a/qols/scripts/conical.py
+++ b/qols/scripts/conical.py
@@ -54,6 +54,9 @@ try:
     height = globals().get('height', 60.0)  # Height for 3D polygon (new parameter)
     datum_elevation = globals().get('datum_elevation', 0.0)  # Reference elevation (#125)
     inner_height = globals().get('inner_height', 0.0)  # Inner Horizontal's own height (#125)
+    slope_pct = globals().get('slope', 5.0)  # Conical slope, percent (#126)
+    inner_radius = globals().get('inner_radius', 0.0)  # Inner Horizontal's own radius (#126)
+    contour_interval_m = int(globals().get('contour_interval_m', 0))  # #126
     runway_code = globals().get('code', 4)
     rwy_classification = globals().get('rwyClassification', 'Precision Approach CAT I')
 
@@ -75,6 +78,9 @@ except Exception as e:
     height = 60.0
     datum_elevation = 0.0
     inner_height = 0.0
+    slope_pct = 5.0
+    inner_radius = 0.0
+    contour_interval_m = 0
     s = 0
     runway_layer = None
     threshold_layer = None
@@ -86,8 +92,11 @@ print(f"Conical: Final values - radius: {L}m, height: {height}m, direction: {s}"
 print(f"Conical: Direction interpretation - s={s} means {'End to Start' if s == -1 else 'Start to End'}")
 
 # Absolute elevation of Conical's outer (top) edge above the shared datum
-# (#125) — the inner edge (after #124's trim) instead sits at
-# datum + inner_height, applied later by plugin.py::_trim_conical_to_ring.
+# (#125) — the inner edge (after #124's trim) instead sits at bottom_z,
+# applied later by plugin.py::_trim_conical_to_ring. Also used directly
+# here for the contour block (#126), since contours run on this script's
+# own un-trimmed geometry.
+bottom_z = datum_elevation + inner_height
 z_top = datum_elevation + inner_height + height
 print(f"Conical: Datum elevation: {datum_elevation}m, Inner Horizontal height: {inner_height}m, top Z: {z_top}m")
 
@@ -157,22 +166,6 @@ trto = QgsCoordinateTransform(source_crs, dest_crs,QgsProject.instance())
 # transformfrom
 trfm = QgsCoordinateTransform(dest_crs,source_crs ,QgsProject.instance())
 
-# routine 1 circling azimuth - EXACTLY as original
-dist = L  # Distance in NM
-print(f"Conical: dist={dist}")
-bearing = angle0 - 90
-angle = 90 - bearing
-print(f"Conical: bearing={bearing}, angle={angle}")
-bearing = math.radians(bearing)
-angle = math.radians(angle)
-dist_x, dist_y = \
-    (dist * math.cos(angle), dist * math.sin(angle))
-xfinal, yfinal = (start_point.x() + dist_x, start_point.y() + dist_y)
-
-pro_coords = trto.transform(trfm.transform(xfinal,yfinal))
-
-start_coords = trfm.transform(start_point.x(),start_point.y())
-
 # Original coord function - EXACTLY as original
 
 
@@ -189,10 +182,6 @@ def coord(angle0,dist1,off):
     pro_coords = trto.transform(trfm.transform(xfinal,yfinal))
     return pro_coords
 
-
-x2 = coord(angle0,L,90)
-xc = coord(angle0,L,0)
-print(f"Conical: x2={x2}")
 
 # Original coord2 function - EXACTLY as original
 
@@ -211,10 +200,65 @@ def coord2(angle0,dist1,off):
     return pro_coords2
 
 
-x4 = coord2(back_angle0,L,90)
-x5 = coord2(back_angle0,L,0)
-x6 = coord2(back_angle0,L,-90)
-print(f"Conical: x4={x4}, x5={x5}, x6={x6}")
+def _build_ring_points(radius):
+    """Build the closed (x, y) racetrack boundary at the given radius —
+    same circular-arc construction as the base Conical polygon, reused
+    at intermediate radii for contour rings (#126)."""
+    pro_coords = coord(angle0, radius, -90)
+    x2 = coord(angle0, radius, 90)
+    xc = coord(angle0, radius, 0)
+    x4 = coord2(back_angle0, radius, 90)
+    x5 = coord2(back_angle0, radius, 0)
+    x6 = coord2(back_angle0, radius, -90)
+
+    points = []
+
+    # First arc: pro_coords → xc → x2
+    cString1 = QgsCircularString()
+    cString1.setPoints([QgsPoint(pro_coords[0], pro_coords[1]),
+                        QgsPoint(xc[0], xc[1]),
+                        QgsPoint(x2[0], x2[1])])
+    geom1 = QgsGeometry(cString1)
+    segmented1 = geom1.convertToType(QgsWkbTypes.LineGeometry, True)
+    if segmented1 and segmented1.wkbType() == QgsWkbTypes.LineString:
+        for point in segmented1.asPolyline():
+            points.append((point.x(), point.y()))
+    elif segmented1 and segmented1.wkbType() == QgsWkbTypes.MultiLineString:
+        for part in segmented1.asMultiPolyline():
+            for point in part:
+                points.append((point.x(), point.y()))
+    else:
+        points.extend([(pro_coords[0], pro_coords[1]), (xc[0], xc[1]), (x2[0], x2[1])])
+
+    # Line: x2 → x6 (connect arc endpoints)
+    points.append((x6[0], x6[1]))
+
+    # Second arc: x6 → x5 → x4 (REVERSED)
+    cString2 = QgsCircularString()
+    cString2.setPoints([QgsPoint(x6[0], x6[1]),
+                        QgsPoint(x5[0], x5[1]),
+                        QgsPoint(x4[0], x4[1])])
+    geom2 = QgsGeometry(cString2)
+    segmented2 = geom2.convertToType(QgsWkbTypes.LineGeometry, True)
+    if segmented2 and segmented2.wkbType() == QgsWkbTypes.LineString:
+        for i, point in enumerate(segmented2.asPolyline()):
+            if i == 0:  # Same as x6, already added
+                continue
+            points.append((point.x(), point.y()))
+    elif segmented2 and segmented2.wkbType() == QgsWkbTypes.MultiLineString:
+        for part_idx, part in enumerate(segmented2.asMultiPolyline()):
+            for point_idx, point in enumerate(part):
+                if part_idx == 0 and point_idx == 0:
+                    continue
+                points.append((point.x(), point.y()))
+    else:
+        points.extend([(x5[0], x5[1]), (x4[0], x4[1])])
+
+    # Line: x4 → pro_coords (close polygon)
+    points.append((pro_coords[0], pro_coords[1]))
+
+    return points
+
 
 print(f"Conical: Using original coordinate calculation methods - trigonometry + transformations")
 
@@ -259,12 +303,6 @@ add_parameters_field(v_layer)
 
 print(f"Conical: Creating unified 3D surface with radius {L}m at height {height}m")
 
-polygon_points = []
-
-# SOLUTION: Use QGIS CircularString interpolation to get exact arc points
-# This matches exactly how the original working code creates the circular arcs
-# IMPORTANT: Changed point sequence to avoid crossing lines
-
 print(f"Conical: Using QGIS CircularString interpolation to generate polygon points")
 print(f"Conical: CORRECTED sequence to avoid line crossings:")
 print(f"Conical: 1. Arc 1: pro_coords → xc → x2")
@@ -272,101 +310,7 @@ print(f"Conical: 2. Line: x2 → x6 (connect arc endpoints)")
 print(f"Conical: 3. Arc 2: x6 → x5 → x4 (REVERSED)")
 print(f"Conical: 4. Line: x4 → pro_coords (close polygon)")
 
-# First arc: Create CircularString and extract points
-# This is exactly how the original code creates the first arc: [pro_coords, xc, x2]
-cString1 = QgsCircularString()
-cString1.setPoints([QgsPoint(pro_coords[0], pro_coords[1]),
-                    QgsPoint(xc[0], xc[1]),
-                    QgsPoint(x2[0], x2[1])])
-
-# Convert to regular geometry and extract points with high resolution
-geom1 = QgsGeometry(cString1)
-# Convert to segmented curve with many points for smooth polygon
-segmented1 = geom1.convertToType(QgsWkbTypes.LineGeometry, True)
-if segmented1:
-    # Handle both LineString and MultiLineString cases
-    if segmented1.wkbType() == QgsWkbTypes.LineString:
-        polyline1 = segmented1.asPolyline()
-        print(f"Conical: Arc 1 interpolated to {len(polyline1)} points (LineString)")
-
-        # Add arc points with height
-        for point in polyline1:
-            polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
-    elif segmented1.wkbType() == QgsWkbTypes.MultiLineString:
-        multiline1 = segmented1.asMultiPolyline()
-        print(f"Conical: Arc 1 interpolated to {len(multiline1)} parts (MultiLineString)")
-
-        # Add points from all parts
-        for part in multiline1:
-            for point in part:
-                polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
-    else:
-        print(f"Conical: Warning - Unexpected geometry type: {segmented1.wkbType()}")
-        # Fallback to original points
-        polygon_points.extend([
-            QgsPoint(pro_coords[0], pro_coords[1], z_top),
-            QgsPoint(xc[0], xc[1], z_top),
-            QgsPoint(x2[0], x2[1], z_top)
-        ])
-else:
-    print("Conical: Warning - Could not interpolate first arc, using original points")
-    polygon_points.extend([
-        QgsPoint(pro_coords[0], pro_coords[1], z_top),
-        QgsPoint(xc[0], xc[1], z_top),
-        QgsPoint(x2[0], x2[1], z_top)
-    ])
-
-# Add straight line from x2 to x6 (connect arc endpoints, not diagonals)
-polygon_points.append(QgsPoint(x6[0], x6[1], z_top))
-
-# Second arc: Create CircularString and extract points
-# This is exactly how the original code creates the second arc: [x6, x5, x4] (REVERSED)
-cString2 = QgsCircularString()
-cString2.setPoints([QgsPoint(x6[0], x6[1]),
-                    QgsPoint(x5[0], x5[1]),
-                    QgsPoint(x4[0], x4[1])])
-
-# Convert to regular geometry and extract points with high resolution
-geom2 = QgsGeometry(cString2)
-# Convert to segmented curve with many points for smooth polygon
-segmented2 = geom2.convertToType(QgsWkbTypes.LineGeometry, True)
-if segmented2:
-    # Handle both LineString and MultiLineString cases
-    if segmented2.wkbType() == QgsWkbTypes.LineString:
-        polyline2 = segmented2.asPolyline()
-        print(f"Conical: Arc 2 interpolated to {len(polyline2)} points (LineString)")
-
-        # Add arc points with height (skip first point to avoid duplication with x6)
-        for i, point in enumerate(polyline2):
-            if i == 0:  # Skip first point as it's the same as x6 we just added
-                continue
-            polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
-    elif segmented2.wkbType() == QgsWkbTypes.MultiLineString:
-        multiline2 = segmented2.asMultiPolyline()
-        print(f"Conical: Arc 2 interpolated to {len(multiline2)} parts (MultiLineString)")
-
-        # Add points from all parts (skip first point of first part to avoid duplication with x6)
-        for part_idx, part in enumerate(multiline2):
-            for point_idx, point in enumerate(part):
-                if part_idx == 0 and point_idx == 0:  # Skip first point of first part (x6)
-                    continue
-                polygon_points.append(QgsPoint(point.x(), point.y(), z_top))
-    else:
-        print(f"Conical: Warning - Unexpected geometry type: {segmented2.wkbType()}")
-        # Fallback to original points (reversed order: x5, x4)
-        polygon_points.extend([
-            QgsPoint(x5[0], x5[1], z_top),
-            QgsPoint(x4[0], x4[1], z_top)
-        ])
-else:
-    print("Conical: Warning - Could not interpolate second arc, using original points")
-    polygon_points.extend([
-        QgsPoint(x5[0], x5[1], z_top),
-        QgsPoint(x4[0], x4[1], z_top)
-    ])
-
-# Add straight line back to start (closing the polygon)
-polygon_points.append(QgsPoint(pro_coords[0], pro_coords[1], z_top))
+polygon_points = [QgsPoint(x, y, z_top) for x, y in _build_ring_points(L)]
 
 print(f"Conical: Created surface with proper circular arcs using QGIS interpolation")
 print(f"Conical: Total points in polygon: {len(polygon_points)}")
@@ -456,6 +400,64 @@ print(f"Conical: Radius: {L}m, Height: {height}m")
 
 # Success message
 iface.messageBar().pushMessage("QOLS Success", f"Conical 3D Surface (R={L}m, H={height}m) calculated successfully", level=MSG_SUCCESS)
+
+# -----------------------------------------------------------------------
+# Contour layer (#126 — stepped elevation rings for Conical Surface)
+#
+# Unlike Approach/Take-off/Transitional, Conical's elevation varies
+# purely with radial distance from the runway spine, not along its
+# length — a real iso-elevation contour is the racetrack boundary curve
+# traced at the radius where the cone reaches that elevation: a full
+# closed ring, not a chord across the surface.
+# -----------------------------------------------------------------------
+if contour_interval_m > 0 and slope_pct > 0:
+    import importlib.util as _ilu
+    import os as _os
+    import sys as _sys
+    _utils_path = _os.path.join(_os.path.dirname(__file__), '_contour_utils.py')
+    _cu_spec = _ilu.spec_from_file_location('_contour_utils', _utils_path)
+    _cu = _ilu.module_from_spec(_cu_spec)
+    _sys.modules['_contour_utils'] = _cu
+    _cu_spec.loader.exec_module(_cu)
+
+    _slope_decimal = slope_pct / 100.0
+    _elevs = _cu.contour_elevations(bottom_z, z_top, contour_interval_m)
+    # Exclude the outer edge itself - it's the surface's own already-drawn
+    # boundary (same exclusion Transitional applies to its plateau ZIH).
+    _elevs = [e for e in _elevs if e < z_top - 1e-6]
+
+    _cfeats = []
+    for _i, _elev in enumerate(_elevs):
+        _radius = _cu.conical_contour_radius(_elev, bottom_z, inner_radius, _slope_decimal)
+        _ring_xy = _build_ring_points(_radius)
+        _ring_pts = [QgsPoint(x, y, _elev) for x, y in _ring_xy]
+        _ring_pts.append(_ring_pts[0])  # close the ring
+        _cfeat = QgsFeature()
+        _cfeat.setGeometry(QgsGeometry(QgsLineString(_ring_pts)))
+        _cfeat.setAttributes([_i + 1, _elev])
+        _cfeats.append(_cfeat)
+
+    if _cfeats:
+        _clayer = QgsVectorLayer(
+            "LineStringZ?crs=" + map_srid, "RWY_ConicalSurface_Contours", "memory")
+        _clayer.dataProvider().addAttributes([
+            QgsField('ID', QVariant.Int),
+            QgsField('surface_elevation', QVariant.Double),
+        ])
+        _clayer.updateFields()
+        _clayer.dataProvider().addFeatures(_cfeats)
+
+        # Conical's rings sit much closer together than Approach's/
+        # Transitional's chords, so the default 10pt label is hard to
+        # read (#126 feedback) — bump it up for this layer only.
+        _cu.apply_contour_style(_clayer, __file__, label_font_size=16)
+        QgsProject.instance().addMapLayers([_clayer])
+        _clayer.triggerRepaint()
+        print(f"Conical: Contour layer added - {len(_cfeats)} rings at "
+              f"{contour_interval_m} m interval")
+    else:
+        print(f"Conical: No contour lines - no elevation levels in range "
+              f"for interval {contour_interval_m} m")
 
 # Clean up globals
 for g in set(globals().keys()).difference(myglobals):

--- a/qols/scripts/inner-horizontal-racetrack.py
+++ b/qols/scripts/inner-horizontal-racetrack.py
@@ -48,6 +48,7 @@ try:
     # Inner horizontal surface parameters from UI
     L = globals().get('radius', 4000)  # Distance L / Radius from UI
     height = globals().get('height', 45.0)  # Height for 3D polygon (new parameter)
+    datum_elevation = globals().get('datum_elevation', 0.0)  # Reference elevation (#125)
     runway_code = globals().get('code', 4)
     rwy_classification = globals().get('rwyClassification', 'Precision Approach CAT I')
 
@@ -67,6 +68,7 @@ except Exception as e:
     # Fallback to defaults if parameters not provided
     L = 4000
     height = 45.0
+    datum_elevation = 0.0
     s = 0
     runway_layer = None
     threshold_layer = None
@@ -75,6 +77,11 @@ except Exception as e:
     rwy_classification = 'Precision Approach CAT I'
 
 print(f"InnerHorizontal: Final values - radius: {L}m, height: {height}m, direction: {s}")
+
+# Absolute elevation above the shared datum (#125) — height is a height above
+# datum, not an absolute Z; the polygon's flat Z is the sum of both.
+z_absolute = datum_elevation + height
+print(f"InnerHorizontal: Datum elevation: {datum_elevation}m, absolute Z: {z_absolute}m")
 
 map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
@@ -122,6 +129,7 @@ v_layer_provider.addAttributes([
     QgsField("surface_type", QVariant.String),
     QgsField("radius_m", QVariant.Double),
     QgsField("height_m", QVariant.Double),
+    QgsField("datum_elevation_m", QVariant.Double),
     QgsField("rule_set", QVariant.String),
     QgsField("runway_start_x", QVariant.Double),
     QgsField("runway_start_y", QVariant.Double),
@@ -140,6 +148,7 @@ _active_rule_set = globals().get('active_rule_set', None)
 _params_json = build_parameters_json('Inner Horizontal Surface', {
     'radius_m': L,
     'height_m': height,
+    'datum_elevation_m': datum_elevation,
     'rule_set': _active_rule_set,
     'rwy_classification': rwy_classification,
     'runway_code': int(runway_code),
@@ -261,7 +270,7 @@ for feat in selection:
 
             # Add arc points with height
             for point in polyline1:
-                polygon_points.append(QgsPoint(point.x(), point.y(), height))
+                polygon_points.append(QgsPoint(point.x(), point.y(), z_absolute))
         elif segmented1.wkbType() == QgsWkbTypes.MultiLineString:
             multiline1 = segmented1.asMultiPolyline()
             print(f"InnerHorizontal: Arc 1 interpolated to {len(multiline1)} parts (MultiLineString)")
@@ -269,25 +278,25 @@ for feat in selection:
             # Add points from all parts
             for part in multiline1:
                 for point in part:
-                    polygon_points.append(QgsPoint(point.x(), point.y(), height))
+                    polygon_points.append(QgsPoint(point.x(), point.y(), z_absolute))
         else:
             print(f"InnerHorizontal: Warning - Unexpected geometry type: {segmented1.wkbType()}")
             # Fallback to original points
             polygon_points.extend([
-                QgsPoint(pro_coords[0], pro_coords[1], height),
-                QgsPoint(xc[0], xc[1], height),
-                QgsPoint(x2[0], x2[1], height)
+                QgsPoint(pro_coords[0], pro_coords[1], z_absolute),
+                QgsPoint(xc[0], xc[1], z_absolute),
+                QgsPoint(x2[0], x2[1], z_absolute)
             ])
     else:
         print("InnerHorizontal: Warning - Could not interpolate first arc, using original points")
         polygon_points.extend([
-            QgsPoint(pro_coords[0], pro_coords[1], height),
-            QgsPoint(xc[0], xc[1], height),
-            QgsPoint(x2[0], x2[1], height)
+            QgsPoint(pro_coords[0], pro_coords[1], z_absolute),
+            QgsPoint(xc[0], xc[1], z_absolute),
+            QgsPoint(x2[0], x2[1], z_absolute)
         ])
 
     # Add straight line from x2 to x6 (connect arc endpoints, not diagonals)
-    polygon_points.append(QgsPoint(x6[0], x6[1], height))
+    polygon_points.append(QgsPoint(x6[0], x6[1], z_absolute))
 
     # Second arc: Create CircularString and extract points
     # This is exactly how the conical surface creates the second arc: [x6, x5, x4] (REVERSED)
@@ -310,7 +319,7 @@ for feat in selection:
             for i, point in enumerate(polyline2):
                 if i == 0:  # Skip first point as it's the same as x6 we just added
                     continue
-                polygon_points.append(QgsPoint(point.x(), point.y(), height))
+                polygon_points.append(QgsPoint(point.x(), point.y(), z_absolute))
         elif segmented2.wkbType() == QgsWkbTypes.MultiLineString:
             multiline2 = segmented2.asMultiPolyline()
             print(f"InnerHorizontal: Arc 2 interpolated to {len(multiline2)} parts (MultiLineString)")
@@ -320,23 +329,23 @@ for feat in selection:
                 for point_idx, point in enumerate(part):
                     if part_idx == 0 and point_idx == 0:  # Skip first point of first part (x6)
                         continue
-                    polygon_points.append(QgsPoint(point.x(), point.y(), height))
+                    polygon_points.append(QgsPoint(point.x(), point.y(), z_absolute))
         else:
             print(f"InnerHorizontal: Warning - Unexpected geometry type: {segmented2.wkbType()}")
             # Fallback to original points (reversed order: x5, x4)
             polygon_points.extend([
-                QgsPoint(x5[0], x5[1], height),
-                QgsPoint(x4[0], x4[1], height)
+                QgsPoint(x5[0], x5[1], z_absolute),
+                QgsPoint(x4[0], x4[1], z_absolute)
             ])
     else:
         print("InnerHorizontal: Warning - Could not interpolate second arc, using original points")
         polygon_points.extend([
-            QgsPoint(x5[0], x5[1], height),
-            QgsPoint(x4[0], x4[1], height)
+            QgsPoint(x5[0], x5[1], z_absolute),
+            QgsPoint(x4[0], x4[1], z_absolute)
         ])
 
     # Add straight line back to start (closing the polygon)
-    polygon_points.append(QgsPoint(pro_coords[0], pro_coords[1], height))
+    polygon_points.append(QgsPoint(pro_coords[0], pro_coords[1], z_absolute))
 
     print(f"InnerHorizontal: Created racetrack surface with proper circular arcs using QGIS interpolation")
     print(f"InnerHorizontal: Total points in polygon: {len(polygon_points)}")
@@ -362,6 +371,7 @@ for feat in selection:
         "Inner Horizontal",
         L,
         height,
+        datum_elevation,
         _active_rule_set,
         start_point.x(),
         start_point.y(),

--- a/qols/scripts/outer-horizontal.py
+++ b/qols/scripts/outer-horizontal.py
@@ -22,8 +22,14 @@ print(f"OuterHorizontal: Working in projected CRS: {map_srid}")
 code = globals().get('code', 3)
 radius = globals().get('radius', 15000.0)
 height = globals().get('height', 45.0)
+arp_elevation = globals().get('arp_elevation', 0.0)  # #127
+
+# Absolute elevation above the ARP (Aerodrome Reference Point) — height
+# is a height above the ARP, not an elevation itself.
+z_absolute = arp_elevation + height
 
 print(f"OuterHorizontal: Code={code}, Radius={radius}m, Height={height}m")
+print(f"OuterHorizontal: ARP elevation={arp_elevation}m, absolute Z={z_absolute}m")
 
 # Validate code number (DOC 9137 Part 6 - only for code 3 or 4)
 if code not in [3, 4]:
@@ -51,7 +57,7 @@ else:
     print(f"OuterHorizontal: Using all {len(selection)} ARP features from layer")
 
 # Create memory layer for outer horizontal surface
-v_layer = QgsVectorLayer(f"Polygon?crs={map_srid}", "Outer Horizontal Surface", "memory")
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", "Outer Horizontal Surface", "memory")
 v_layer_provider = v_layer.dataProvider()
 
 # Add attributes
@@ -60,6 +66,7 @@ v_layer_provider.addAttributes([
     QgsField("code", QVariant.Int),
     QgsField("radius_m", QVariant.Double),
     QgsField("height_m", QVariant.Double),
+    QgsField("arp_elevation_m", QVariant.Double),
     QgsField("rule_set", QVariant.String),
     QgsField("arp_x", QVariant.Double),
     QgsField("arp_y", QVariant.Double)
@@ -74,6 +81,7 @@ _params_json = build_parameters_json('Outer Horizontal Surface', {
     'code': code,
     'radius_m': radius,
     'height_m': height,
+    'arp_elevation_m': arp_elevation,
     'rule_set': _active_rule_set,
 })
 add_parameters_field(v_layer)
@@ -100,6 +108,14 @@ for feat in selection:
     # Convert to QgsGeometry
     circle_geometry = QgsGeometry(polygon_geometry)
 
+    # Apply the absolute Z (#127) — QgsCircle.toPolygon() only produces
+    # 2D points, so rebuild as PolygonZ via WKT, same pattern used in
+    # inner-horizontal-racetrack.py/conical.py.
+    ring_xy = circle_geometry.asPolygon()[0]
+    wkt_points = [f"{p.x()} {p.y()} {z_absolute}" for p in ring_xy]
+    wkt_polygon = f"POLYGONZ(({', '.join(wkt_points)}))"
+    circle_geometry = QgsGeometry.fromWkt(wkt_polygon)
+
     # Create feature with proper geometry reference
     feature = QgsFeature()
     feature.setGeometry(circle_geometry)
@@ -108,6 +124,7 @@ for feat in selection:
         code,
         radius,
         height,
+        arp_elevation,
         _active_rule_set,
         arp_x,
         arp_y,

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -1877,8 +1877,9 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             elif surface_type == SurfaceType.INNER_CONICAL:
                 datum_elevation = self.get_numeric_value('spin_datum_inner_conical')
                 inner_height = self.get_numeric_value('spin_height_inner')
+                inner_radius = self.get_numeric_value('spin_L_inner')
                 inner_params = {
-                    'radius': self.get_numeric_value('spin_L_inner'),
+                    'radius': inner_radius,
                     'height': inner_height,
                     'datum_elevation': datum_elevation,
                     'code': self.get_code_value('spin_code_inner_conical'),
@@ -1890,6 +1891,8 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'slope': self.get_numeric_value('spin_conical_slope'),
                     'datum_elevation': datum_elevation,
                     'inner_height': inner_height,
+                    'inner_radius': inner_radius,
+                    'contour_interval_m': int(round(self.get_numeric_value('spin_contour_interval_conical'))),
                     'code': self.get_code_value('spin_code_inner_conical'),
                     'rwyClassification': self.combo_rwyClassification_inner_conical.currentText(),
                 }

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -1906,6 +1906,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'code': self.get_code_value('spin_code_outer'),
                     'radius': self.get_numeric_value('spin_radius_outer'),
                     'height': self.get_numeric_value('spin_height_outer'),
+                    'arp_elevation': self.get_numeric_value('spin_arp_elevation_outer'),
                 }
             elif surface_type == SurfaceType.TAKEOFF:
                 code_value = self.get_code_value('spin_code_takeoff')

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -25,6 +25,7 @@ from ..surfaces.approach import get_approach_defaults as icao_get_approach_defau
 from ..surface_types import SurfaceType
 from .. import logger  # CR-01
 from ..direction_marker import build_marker_geometry
+from ..parameters_inspector import show_project_parameters_table
 from .tab_row_selector import TwoRowTabSelector
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
@@ -1874,9 +1875,12 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'rwyClassification': self.combo_rwyClassification_inner_conical.currentText()
                 }
             elif surface_type == SurfaceType.INNER_CONICAL:
+                datum_elevation = self.get_numeric_value('spin_datum_inner_conical')
+                inner_height = self.get_numeric_value('spin_height_inner')
                 inner_params = {
                     'radius': self.get_numeric_value('spin_L_inner'),
-                    'height': self.get_numeric_value('spin_height_inner'),
+                    'height': inner_height,
+                    'datum_elevation': datum_elevation,
                     'code': self.get_code_value('spin_code_inner_conical'),
                     'rwyClassification': self.combo_rwyClassification_inner_conical.currentText(),
                 }
@@ -1884,6 +1888,8 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'radius': self.get_numeric_value('spin_L_conical'),
                     'height': self.get_numeric_value('spin_height_conical'),
                     'slope': self.get_numeric_value('spin_conical_slope'),
+                    'datum_elevation': datum_elevation,
+                    'inner_height': inner_height,
                     'code': self.get_code_value('spin_code_inner_conical'),
                     'rwyClassification': self.combo_rwyClassification_inner_conical.currentText(),
                 }

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -1047,7 +1047,24 @@
           </property>
          </widget>
         </item>
-                <item row="3" column="0" colspan="2">
+                <item row="3" column="0">
+                 <widget class="QLabel" name="label_arp_elevation_outer">
+                  <property name="text">
+                   <string>ARP Elevation (m):</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1">
+                 <widget class="QLineEdit" name="spin_arp_elevation_outer">
+                  <property name="text">
+                   <string>0.00</string>
+                  </property>
+                  <property name="toolTip">
+                   <string>Aerodrome Reference Point elevation. Outer Horizontal Z = ARP Elevation + Height.</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="0" colspan="2">
                  <widget class="QLabel" name="label_info_outer">
                     <property name="text">
                      <string>Outer Horizontal Surface: 15,000 m circle centered on ARP

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -752,9 +752,28 @@
           </property>
          </widget>
         </item>
-        
+
+        <!-- CONTOUR INTERVAL (#126) -->
+        <item row="10" column="0">
+         <widget class="QLabel" name="label_contour_interval_conical">
+          <property name="text">
+           <string>Contour Interval (m):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="1">
+         <widget class="QLineEdit" name="spin_contour_interval_conical">
+          <property name="text">
+           <string>10</string>
+          </property>
+          <property name="toolTip">
+           <string>Elevation interval for contour lines in metres. Set to 0 to disable.</string>
+          </property>
+         </widget>
+        </item>
+
         <!-- WORKFLOW INFORMATION -->
-        <item row="10" column="0" colspan="2">
+        <item row="11" column="0" colspan="2">
          <widget class="QLabel" name="label_info_inner_conical">
           <property name="text">
            <string>Workflow: Configure Inner Horizontal first, then Conical (uses Inner Horizontal radius for calculation)

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -621,8 +621,27 @@
          </widget>
         </item>
         
+        <!-- SHARED DATUM ELEVATION (#125) -->
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_datum_inner_conical">
+          <property name="text">
+           <string>Datum Elevation (m):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="spin_datum_inner_conical">
+          <property name="text">
+           <string>0.00</string>
+          </property>
+          <property name="toolTip">
+           <string>Reference elevation the surface heights are measured above (e.g. aerodrome reference elevation). Inner Horizontal Z = Datum + Inner Horizontal Height. Conical Z ranges from Datum + Inner Horizontal Height (inner edge) to Datum + Inner Horizontal Height + Conical Height (outer edge).</string>
+          </property>
+         </widget>
+        </item>
+        
         <!-- INNER HORIZONTAL SURFACE SECTION HEADER -->
-        <item row="2" column="0" colspan="2">
+        <item row="3" column="0" colspan="2">
          <widget class="QLabel" name="label_section_inner_horizontal">
           <property name="text">
            <string>Inner Horizontal Surface</string>
@@ -634,14 +653,14 @@
         </item>
         
         <!-- INNER HORIZONTAL SURFACE CONTROLS -->
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="label_height_inner">
           <property name="text">
            <string>Height (m):</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="QLineEdit" name="spin_height_inner">
           <property name="text">
            <string>45.00</string>
@@ -651,14 +670,14 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="label_L_inner">
           <property name="text">
            <string>Radius (m):</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QLineEdit" name="spin_L_inner">
           <property name="text">
            <string>4000.00</string>
@@ -667,7 +686,7 @@
         </item>
         
         <!-- CONICAL SURFACE SECTION HEADER -->
-        <item row="5" column="0" colspan="2">
+        <item row="6" column="0" colspan="2">
          <widget class="QLabel" name="label_section_conical">
           <property name="text">
            <string>Conical Surface</string>
@@ -679,14 +698,14 @@
         </item>
         
         <!-- CONICAL SURFACE CONTROLS -->
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="label_height_conical">
           <property name="text">
            <string>Height (m):</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="7" column="1">
          <widget class="QLineEdit" name="spin_height_conical">
           <property name="text">
            <string>60.00</string>
@@ -696,14 +715,14 @@
           </property>
          </widget>
         </item>
-                <item row="7" column="0">
+                <item row="8" column="0">
                  <widget class="QLabel" name="label_conical_slope">
                     <property name="text">
                      <string>Slope (%):</string>
                     </property>
                  </widget>
                 </item>
-        <item row="7" column="1">
+        <item row="8" column="1">
          <widget class="QLineEdit" name="spin_conical_slope">
           <property name="text">
            <string>5.00</string>
@@ -713,14 +732,14 @@
           </property>
          </widget>
         </item>
-        <item row="8" column="0">
+        <item row="9" column="0">
          <widget class="QLabel" name="label_L_conical">
           <property name="text">
            <string>Radius (m):</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
+        <item row="9" column="1">
          <widget class="QLineEdit" name="spin_L_conical">
           <property name="text">
            <string>6000.00</string>
@@ -735,7 +754,7 @@
         </item>
         
         <!-- WORKFLOW INFORMATION -->
-        <item row="9" column="0" colspan="2">
+        <item row="10" column="0" colspan="2">
          <widget class="QLabel" name="label_info_inner_conical">
           <property name="text">
            <string>Workflow: Configure Inner Horizontal first, then Conical (uses Inner Horizontal radius for calculation)
@@ -832,70 +851,70 @@
           </item>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="label_width_ofz">
           <property name="text">
            <string>Width (m):</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QLineEdit" name="spin_width_ofz">
           <property name="text">
            <string>120.0</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="label_Z0_ofz">
           <property name="text">
           <string>Start Elevation (m):</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="QLineEdit" name="spin_Z0_ofz">
           <property name="text">
            <string>2548.0</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="label_ZE_ofz">
           <property name="text">
           <string>End Elevation (m):</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QLineEdit" name="spin_ZE_ofz">
           <property name="text">
            <string>2546.5</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="label_ARPH_ofz">
           <property name="text">
            <string>ARPH (m):</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QLineEdit" name="spin_ARPH_ofz">
           <property name="text">
            <string>2548.0</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="label_IHSlope_ofz">
           <property name="text">
            <string>Inner Transitional Slope (%):</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="7" column="1">
          <widget class="QLineEdit" name="spin_IHSlope_ofz">
           <property name="text">
            <string>33.3</string>
@@ -903,7 +922,7 @@
          </widget>
         </item>
    <!-- Not Applicable notice (hidden by default) -->
-   <item row="7" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <widget class="QLabel" name="label_not_applicable_ofz">
      <property name="text">
       <string>Not Applicable</string>

--- a/qols/ui/tab_row_selector.py
+++ b/qols/ui/tab_row_selector.py
@@ -22,6 +22,19 @@ signals and, whenever one bar reports a real selection, deselects the
 other bar via ``setCurrentIndex(-1)`` (a normal, supported QTabBar state
 meaning "no current tab") — guarded by a ``_syncing`` flag so that
 programmatic deselection doesn't itself get mistaken for a user action.
+
+Bug fix: ``currentChanged`` only fires when a bar's *own* index actually
+changes. If a bar's other-row deselection doesn't stick (observed live —
+some Qt styles keep the tab looking selected even after
+``setCurrentIndex(-1)``), clicking that same tab again is a no-op from
+that bar's own point of view, so nothing re-activates it — the panel
+keeps showing whatever the other row last selected, and the user has to
+click a different tab in that row first before clicking back. The shim
+therefore also listens to ``tabBarClicked``, which Qt emits on *every*
+physical click regardless of whether the bar's index changes, and routes
+it through the same handler — activation is decided from the shim's own
+``_current_index``, not the bar's, so a click always does the right
+thing even when the bar's internal state didn't actually change.
 """
 from __future__ import annotations
 
@@ -73,6 +86,7 @@ class TwoRowTabSelector(QObject):
         self._syncing = False
         for bar_index, bar in enumerate(self._bars):
             bar.currentChanged.connect(lambda tab_index, bi=bar_index: self._on_bar_changed(bi, tab_index))
+            bar.tabBarClicked.connect(lambda tab_index, bi=bar_index: self._on_bar_changed(bi, tab_index))
         self._activate(0, emit=False)
 
     def _find_bar_and_tab(self, stack_index: int):


### PR DESCRIPTION
# fix(#124): Conical Surface must not overlap Inner Horizontal

## `Summary`
<img width="817" height="543" alt="swappy-20260806-201728" src="https://github.com/user-attachments/assets/8e1569fd-6ff5-4ed9-88dc-63d602258e5c" />

Issue #124  the Conical surface renders as a solid
disk that fully covers the Inner Horizontal surface underneath it. Per
ICAO Annex 14, Conical's plan-view footprint should be a **ring**
(annulus) starting at Inner Horizontal's edge and extending outward — the
two should never visually overlap. The issue's reference image shows the
expected result: a difference/subtraction between the two.

**Root cause**, confirmed by reading both scripts in full:
`qols/scripts/conical.py` and `qols/scripts/inner-horizontal-racetrack.py`
are independently-implemented, near-identical racetrack-polygon builders
(two circular arcs at the runway's start/end thresholds, joined by
tangents) — copy-pasted from one another, sharing no common helper. Both
use the *same* runway centerline/threshold points and azimuth, so their
racetracks are concentric; only the radius `L` differs — Inner
Horizontal's comes from the ICAO Table 4-1 radius lookup, Conical's is
`Height/Slope + InnerHorizontalRadius` (`dockwidget.py::recalculate_conical_radius`)
— **always ≥** Inner Horizontal's by construction. Each script emits one
flat `PolygonZ` feature (every vertex shares one uniform `height` value)
with **no differencing applied anywhere**, either inside the scripts or
in `qols/plugin.py::execute_combined_inner_conical_surface`, which just
ran the two scripts back-to-back and did nothing further.

Because both racetracks share the same spine/azimuth and Conical's
radius is always ≥ Inner Horizontal's, `Conical.difference(InnerHorizontal)`
cleanly produces a single ring (one polygon with one interior hole) in
the expected case — a much simpler geometry problem than #121/#122's
work: no Z-interpolation is needed, since each script's polygon is
already flat — the differenced ring just needs that same flat Z
re-applied to whatever vertices GEOS's 2D `difference()` produces.

---

## Changes

### `qols/plugin.py`

- `execute_script()` now `return`s `exec_namespace` (previously returned
  nothing). Backward compatible — every existing call site ignores the
  return value. This lets a caller read back a script's created `v_layer`
  object directly, instead of reconstructing dynamic layer names
  (`f"Conical_{classification}_Code{code}"`) from the outside.
- `execute_combined_inner_conical_surface()` captures both scripts'
  `exec_namespace`s and calls new `_trim_conical_to_ring()`.
- `_trim_conical_to_ring(inner_namespace, conical_namespace)` (new):
  unions all Inner Horizontal features via `QgsGeometry.unaryUnion()`,
  subtracts that union from each Conical feature via
  `geometry_difference.difference_flat()`, and writes the trimmed
  geometry back in place via `dataProvider().changeGeometryValues()` —
  same layer/feature identity, no new layer created. Defensive: if
  either layer is missing/empty, or a feature's difference fails, that
  feature's original (solid) geometry is left untouched rather than
  raising or being deleted.

### `qols/geometry_difference.py` (new)

Pure-Python Z-flattening helper, no QGIS dependency, plus a thin
QGIS-aware wrapper — mirrors the split used in `qols/geometry_merge.py`
(#121):

- `flatten_ring_z(ring_xy, z)` — applies one Z value to every vertex of a
  ring. No interpolation (unlike `geometry_merge.recover_ring_z`) — both
  source polygons here are already flat, so there's nothing to
  interpolate.
- `difference_flat(base_geom, subtract_geom)` — 2D-differences the two
  geometries via `QgsGeometry.difference()`, detects `base_geom`'s own
  flat Z (its first vertex), and rebuilds the result with that Z
  re-applied to every vertex of every ring — **exterior and
  interior/hole rings** (a polygon-with-a-hole is a single `QgsPolygon`
  with multiple rings, not a `MultiPolygon`, which is the expected result
  here since Inner Horizontal is fully contained within Conical) — of
  every part (multipart handled defensively for unusual/self-intersecting
  input). Falls back to `base_geom` unchanged on any failure, since a
  failed trim must not delete the surface the user just calculated.

### Tests

`tests/test_geometry_difference.py` (new, 5 tests) — `flatten_ring_z`'s
uniform-Z application (including the explicit "no interpolation, just
overwrite" contrast with `geometry_merge.py`'s approach) and
`difference_flat`'s defensive fallback-to-original-geometry behavior on
malformed/unexpected input (this repo's mocked `qgis.core` test harness
makes real GEOS boolean-op semantics unavailable under pytest, same
boundary as `geometry_merge.py`'s own QGIS-wrapper testing).

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_contour_integration.py --ignore=tests/test_contour_polygon_slice.py
# 532 passed (branch built on main post-#145/#146 merge, so no stale/
# unrelated failures from those issues remain).

flake8 qols/geometry_difference.py qols/plugin.py
# 0 issues
```

Manual QGIS check (pending, cannot be automated — `qols/plugin.py` has no
existing test coverage to extend): select a runway + threshold,
Calculate on the "Inner Horizontal & Conical" tab, confirm the Conical
layer now renders as a ring with a hole exactly where the Inner
Horizontal circle sits (matching the issue's "should look like this"
reference image), not a solid disk covering it, and that both layers'
existing styling/attributes are otherwise unaffected.

---

## Risk / notes

- Fix lives entirely in the orchestration layer (`plugin.py`), not
  inside either copy-pasted script — mirrors #121's precedent of
  reconciling geometry as a separate post-processing step rather than
  duplicating logic into both scripts.
- If a user selects multiple runway features, `inner-horizontal-racetrack.py`
  produces one feature per runway while `conical.py` only produces one
  (based on the last-iterated runway — a pre-existing asymmetry between
  the two scripts, unrelated to this fix and out of scope here); the
  trim still works correctly in this case since it unions *all* Inner
  Horizontal features before subtracting.
