### PR TITLE
Add _script_success flag and update global cleanup logic in multiple …

### DIFF
--- a/qols/scripts/OFZ_UTM.py
+++ b/qols/scripts/OFZ_UTM.py
@@ -397,8 +397,10 @@ iface.messageBar().pushMessage("QPANSOPY:", "OFZ Calculation Finished", level=MS
 print("OFZ: Script completed successfully")
 
 
+_script_success = True
+
 set(globals().keys()).difference(myglobals)
 
 for g in set(globals().keys()).difference(myglobals):
-    if g != 'myglobals':
+    if g not in ('myglobals', '_script_success'):
         del globals()[g]

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -501,8 +501,10 @@ if contour_interval_m > 0:
         print(f"TransitionalSurface: No contour lines - no elevation levels in range "
               f"for interval {contour_interval_m} m")
 
+_script_success = True
+
 set(globals().keys()).difference(myglobals)
 
 for g in set(globals().keys()).difference(myglobals):
-    if g != 'myglobals':
+    if g not in ('myglobals', '_script_success'):
         del globals()[g]

--- a/qols/scripts/approach-surface-UTM.py
+++ b/qols/scripts/approach-surface-UTM.py
@@ -496,8 +496,10 @@ if contour_interval_m > 0:
     else:
         print(f"QOLS: No approach contour lines — no elevation levels in range for interval {contour_interval_m} m")
 
+_script_success = True
+
 # Clean up globals
 set(globals().keys()).difference(myglobals)
 for g in set(globals().keys()).difference(myglobals):
-    if g != 'myglobals':
+    if g not in ('myglobals', '_script_success'):
         del globals()[g]

--- a/qols/scripts/conical.py
+++ b/qols/scripts/conical.py
@@ -441,7 +441,9 @@ print(f"Conical: Radius: {L}m, Height: {height}m")
 # Success message
 iface.messageBar().pushMessage("QOLS Success", f"Conical 3D Surface (R={L}m, H={height}m) calculated successfully", level=MSG_SUCCESS)
 
+_script_success = True
+
 # Clean up globals
 for g in set(globals().keys()).difference(myglobals):
-    if g != 'myglobals':
+    if g not in ('myglobals', '_script_success'):
         del globals()[g]

--- a/qols/scripts/inner-horizontal-racetrack.py
+++ b/qols/scripts/inner-horizontal-racetrack.py
@@ -425,7 +425,9 @@ print(f"InnerHorizontal: Radius: {L}m, Height: {height}m")
 # Success message
 iface.messageBar().pushMessage("QOLS Success", f"Inner Horizontal 3D Surface (R={L}m, H={height}m) calculated successfully", level=MSG_SUCCESS)
 
+_script_success = True
+
 # Clean up globals
 for g in set(globals().keys()).difference(myglobals):
-    if g != 'myglobals':
+    if g not in ('myglobals', '_script_success'):
         del globals()[g]

--- a/qols/scripts/outer-horizontal.py
+++ b/qols/scripts/outer-horizontal.py
@@ -154,3 +154,5 @@ if features_created > 0:
     canvas.zoomScale(sc)
 
 print(f"OuterHorizontal: Completed - {features_created} outer horizontal surface(s) created per DOC 9137 Part 6")
+
+_script_success = True

--- a/qols/scripts/take-off-surface_UTM.py
+++ b/qols/scripts/take-off-surface_UTM.py
@@ -410,10 +410,12 @@ if contour_interval_m > 0:
     else:
         print(f"TakeOffSurface: No contour lines — no elevation levels in range for interval {contour_interval_m} m")
 
+_script_success = True
+
 # Cleanup globals - match original pattern
 newglobals = set(globals().keys())
 for var in (newglobals - myglobals):
-    if var not in ['iface']:
+    if var not in ['iface', '_script_success']:
         try:
             del globals()[var]
         except:


### PR DESCRIPTION
# task(#128): Clean Warning Events

## Summary
Issue #128 : every calculation logs
`WARNING Script did not set _script_success=True: <path>` followed by
`WARNING SurfaceType.X completed but script did not set
_script_success=True` — even though the surface calculates correctly.

Root cause (`qols/plugin.py::execute_script`, tagged `# BUG-01: success
sentinel` / `# CR-08`): every `exec()`-dispatched script gets
`_script_success = False` injected into its namespace before running,
and is expected to set it to `True` as its last action to confirm it
completed without silently swallowing a partial failure. Only the two
"New OLS" scripts (`new-ols-ofs-approach-UTM.py`,
`new-ols-oes-transitional-UTM.py`, from #107-#109) ever adopted this
convention — the seven older "classic" scripts never did, so the
warning fired on every successful run of Approach, Transitional,
Conical, Inner Horizontal, OFZ, Outer Horizontal, and Take-Off.

---

## Changes

Added `_script_success = True` to all seven remaining
`exec()`-dispatched scripts, in the exact place/style the two New OLS
scripts already use, and made sure each script's own end-of-script
globals self-cleanup doesn't delete the flag before `plugin.py` reads
it back (the same "script deletes its own globals before exec()
returns" trap already diagnosed once during #124's `v_layer`
debugging).

Three distinct existing cleanup-loop shapes needed matching edits:

- **`approach-surface-UTM.py`, `conical.py`,
  `inner-horizontal-racetrack.py`, `OFZ_UTM.py`,
  `TransitionalSurface_UTM.py`** — all use
  `for g in ...: if g != 'myglobals': del globals()[g]`. Added
  `_script_success = True` right before the loop; changed the
  condition to `if g not in ('myglobals', '_script_success')`.
- **`take-off-surface_UTM.py`** — different style
  (`newglobals`/`var`/`['iface']`). Added `_script_success = True`
  before the `newglobals` snapshot; changed the exclusion to
  `if var not in ['iface', '_script_success']`.
- **`outer-horizontal.py`** — never adopted the globals-cleanup
  convention at all, so nothing to exclude; appended
  `_script_success = True` as the final line.

No changes to `qols/plugin.py` — its sentinel-reading/logging logic was
already correct; only the scripts were incomplete.

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 551 passed

flake8 qols/scripts/approach-surface-UTM.py qols/scripts/conical.py \
       qols/scripts/inner-horizontal-racetrack.py qols/scripts/OFZ_UTM.py \
       qols/scripts/outer-horizontal.py qols/scripts/take-off-surface_UTM.py \
       qols/scripts/TransitionalSurface_UTM.py
# 0 issues
```

The three `--ignore`d test files are stale local artifacts from the
still-unmerged `fix/124-conical-inner-horizontal-overlap` branch
(`tests/` is gitignored, so these files persist on disk regardless of
which branch is checked out) — this branch was cut from `main`, which
doesn't yet have that branch's `qols/geometry_difference.py`,
`_contour_utils.conical_contour_radius`, or the `tab_row_selector.py`
`tabBarClicked` fix, so those test files fail to collect/fail their
assertions here through no fault of this change. Not a #128 regression.
