### PR TITLE
fix(#129): Selected features not working properly - gets stuck

### DIFF
--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -514,7 +514,6 @@ class QOLS:
                 'MSG_CRITICAL': MSG_CRITICAL,
                 'MSG_SUCCESS': MSG_SUCCESS,
                 # Convenience aliases
-                'use_selected_feature': params.get('use_threshold_selected', False),
                 'active_rule_set': rule_mgr.get_active_rule_set_name(),
             }
             exec_namespace.update(params)

--- a/qols/scripts/OFZ_UTM.py
+++ b/qols/scripts/OFZ_UTM.py
@@ -61,7 +61,8 @@ try:
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
-    use_selected_feature = globals().get('use_selected_feature', True)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    use_threshold_selected = globals().get('use_threshold_selected', True)
 
     # Optional rule-driven parameters injected from UI
     IA_width = globals().get('IA_width', None)
@@ -74,7 +75,7 @@ try:
     BL_slope = globals().get('BL_slope', None)  # ratio
 
     print(f"OFZ: Using parameters - code: {code}, width: {width}, Z0: {Z0}, ZE: {ZE}")
-    print(f"OFZ: Direction parameter s: {s}, Use selected: {use_selected_feature}")
+    print(f"OFZ: Direction parameter s: {s}, Use selected runway: {use_runway_selected}, Use selected threshold: {use_threshold_selected}")
 
 except Exception as e:
     print(f"OFZ: Error getting parameters, using defaults: {e}")
@@ -89,7 +90,8 @@ except Exception as e:
     s = 0
     runway_layer = None
     threshold_layer = None
-    use_selected_feature = True
+    use_runway_selected = True
+    use_threshold_selected = True
 
 # Calculate derived parameters
 ZIH = 45+ARPH
@@ -105,7 +107,7 @@ try:
     if runway_layer is not None:
         print(f"OFZ: Using Runway Layer Centerline from UI: {runway_layer.name()}")
 
-        if use_selected_feature:
+        if use_runway_selected:
             # Require explicit feature selection
             selection = runway_layer.selectedFeatures()
             if not selection:
@@ -168,7 +170,7 @@ try:
     if threshold_layer is not None:
         print(f"OFZ: Using threshold layer from UI: {threshold_layer.name()}")
 
-        if use_selected_feature:
+        if use_threshold_selected:
             # Require explicit feature selection
             threshold_selection = threshold_layer.selectedFeatures()
             if not threshold_selection:
@@ -377,10 +379,13 @@ v_layer.selectAll()
 canvas = iface.mapCanvas()
 canvas.zoomToSelected(v_layer)
 v_layer.removeSelection()
-try:
-    layer.removeSelection()
-except:
-    pass
+
+# Clean up selections only if they weren't originally selected
+# This prevents losing user selections for subsequent calculations
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+if not use_threshold_selected and threshold_layer:
+    threshold_layer.removeSelection()
 
 # get canvas scale
 sc = canvas.scale()

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -64,10 +64,11 @@ try:
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
-    use_selected_feature = globals().get('use_selected_feature', True)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    use_threshold_selected = globals().get('use_threshold_selected', True)
 
     print(f"TransitionalSurface: Using parameters - code: {code}, widthApp: {widthApp}, Z0: {Z0}, ZE: {ZE}")
-    print(f"TransitionalSurface: CRITICAL - Runway direction parameter s: {s}, Use selected: {use_selected_feature}")
+    print(f"TransitionalSurface: CRITICAL - Runway direction parameter s: {s}, Use selected runway: {use_runway_selected}, Use selected threshold: {use_threshold_selected}")
 
 except Exception as e:
     print(f"TransitionalSurface: Error getting parameters, using defaults: {e}")
@@ -87,7 +88,8 @@ except Exception as e:
     contour_interval_m = 0
     runway_layer = None
     threshold_layer = None
-    use_selected_feature = True
+    use_runway_selected = True
+    use_threshold_selected = True
 
 # Calculate derived parameters
 ZIH = 45 + ARPH
@@ -108,7 +110,7 @@ try:
     if runway_layer is not None:
         print(f"TransitionalSurface: Using Runway Layer Centerline from UI: {runway_layer.name()}")
 
-        if use_selected_feature:
+        if use_runway_selected:
             # Require explicit feature selection
             selection = runway_layer.selectedFeatures()
             if not selection:
@@ -162,7 +164,7 @@ try:
     if threshold_layer is not None:
         print(f"TransitionalSurface: Using threshold layer from UI: {threshold_layer.name()}")
 
-        if use_selected_feature:
+        if use_threshold_selected:
             # Require explicit feature selection
             threshold_selection = threshold_layer.selectedFeatures()
             if not threshold_selection:
@@ -426,10 +428,11 @@ v_layer.selectAll()
 canvas = iface.mapCanvas()
 canvas.zoomToSelected(v_layer)
 v_layer.removeSelection()
-# Clean up selections
-if 'runway_layer' in locals() and runway_layer:
+# Clean up selections only if they weren't originally selected
+# This prevents losing user selections for subsequent calculations
+if not use_runway_selected and 'runway_layer' in locals() and runway_layer:
     runway_layer.removeSelection()
-if 'threshold_layer' in locals() and threshold_layer:
+if not use_threshold_selected and 'threshold_layer' in locals() and threshold_layer:
     threshold_layer.removeSelection()
 # get canvas scale
 sc = canvas.scale()

--- a/qols/scripts/approach-surface-UTM.py
+++ b/qols/scripts/approach-surface-UTM.py
@@ -89,13 +89,14 @@ try:
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
-    use_selected_feature = globals().get('use_selected_feature', True)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    use_threshold_selected = globals().get('use_threshold_selected', True)
 
     print(
         f"QOLS: Using parameters - runway_code: {runway_code}, rwy_classification: {rwy_classification}, "
         f"approach_width_m: {approach_width_m}, start_elevation_m: {start_elevation_m}, end_elevation_m: {end_elevation_m}"
     )
-    print(f"QOLS: Direction: {direction}, Use selected features: {use_selected_feature}")
+    print(f"QOLS: Direction: {direction}, Use selected runway: {use_runway_selected}, Use selected threshold: {use_threshold_selected}")
 
 except Exception as e:
     print(f"QOLS: Error getting parameters, using defaults: {e}")
@@ -112,7 +113,8 @@ except Exception as e:
     direction = 0
     runway_layer = None
     threshold_layer = None
-    use_selected_feature = True
+    use_runway_selected = True
+    use_threshold_selected = True
 
 # Calculate derived parameters
 zih_elevation_m = 45 + arp_elevation_m
@@ -127,7 +129,7 @@ try:
     if runway_layer is not None:
         print(f"QOLS: Using Runway Layer Centerline from UI: {runway_layer.name()}")
 
-        if use_selected_feature:
+        if use_runway_selected:
             # Require explicit feature selection
             selection = runway_layer.selectedFeatures()
             if not selection:
@@ -177,7 +179,7 @@ try:
     if threshold_layer is not None:
         print(f"QOLS: Using threshold layer from UI: {threshold_layer.name()}")
 
-        if use_selected_feature:
+        if use_threshold_selected:
             # Require explicit feature selection
             threshold_selection = threshold_layer.selectedFeatures()
             if not threshold_selection:
@@ -397,13 +399,11 @@ approach_layer.removeSelection()
 
 # Clean up selections only if they weren't originally selected
 # This prevents losing user selections for subsequent calculations
-if not use_selected_feature:
-    # Only clean up if we're not using selected features
-    if runway_layer:
-        runway_layer.removeSelection()
-    if threshold_layer:
-        threshold_layer.removeSelection()
-else:
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+if not use_threshold_selected and threshold_layer:
+    threshold_layer.removeSelection()
+if use_runway_selected or use_threshold_selected:
     # Keep selections for next calculation
     print("QOLS: Keeping feature selections for next calculation")
 

--- a/qols/scripts/conical.py
+++ b/qols/scripts/conical.py
@@ -61,10 +61,10 @@ try:
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
-    use_selected_feature = globals().get('use_selected_feature', True)
+    use_runway_selected = globals().get('use_runway_selected', True)
 
     print(f"Conical: Using parameters - radius: {L}m, height: {height}m, code: {runway_code}, class: {rwy_classification}")
-    print(f"Conical: Direction parameter s: {s}, Use selected: {use_selected_feature}")
+    print(f"Conical: Direction parameter s: {s}, Use selected: {use_runway_selected}")
 
 except Exception as e:
     print(f"Conical: Error getting parameters, using defaults: {e}")
@@ -74,7 +74,7 @@ except Exception as e:
     s = 0
     runway_layer = None
     threshold_layer = None
-    use_selected_feature = True
+    use_runway_selected = True
     runway_code = 4
     rwy_classification = 'Precision Approach CAT I'
 
@@ -90,7 +90,7 @@ try:
     if runway_layer is not None:
         print(f"Conical: Using Runway Layer Centerline from UI: {runway_layer.name()}")
 
-        if use_selected_feature:
+        if use_runway_selected:
             # Require explicit feature selection
             selection = runway_layer.selectedFeatures()
             if not selection:
@@ -420,7 +420,7 @@ canvas.zoomToSelected(v_layer)
 v_layer.removeSelection()
 
 # Clean up selections only if they weren't originally selected
-if not use_selected_feature:
+if not use_runway_selected:
     # Only clean up if we're not using selected features
     if runway_layer:
         runway_layer.removeSelection()

--- a/qols/scripts/inner-horizontal-racetrack.py
+++ b/qols/scripts/inner-horizontal-racetrack.py
@@ -57,10 +57,10 @@ try:
     # Layer parameters
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
-    use_selected_feature = globals().get('use_selected_feature', True)
+    use_runway_selected = globals().get('use_runway_selected', True)
 
     print(f"InnerHorizontal: Using parameters - radius: {L}m, height: {height}m, code: {runway_code}, class: {rwy_classification}")
-    print(f"InnerHorizontal: Direction parameter s: {s}, Use selected: {use_selected_feature}")
+    print(f"InnerHorizontal: Direction parameter s: {s}, Use selected: {use_runway_selected}")
 
 except Exception as e:
     print(f"InnerHorizontal: Error getting parameters, using defaults: {e}")
@@ -70,7 +70,7 @@ except Exception as e:
     s = 0
     runway_layer = None
     threshold_layer = None
-    use_selected_feature = True
+    use_runway_selected = True
     runway_code = 4
     rwy_classification = 'Precision Approach CAT I'
 
@@ -91,7 +91,7 @@ try:
     if runway_layer is not None:
         print(f"InnerHorizontal: Using Runway Layer Centerline from UI: {runway_layer.name()}")
 
-        if use_selected_feature:
+        if use_runway_selected:
             selection = runway_layer.selectedFeatures()
             if not selection:
                 raise Exception("No runway features selected. Please select runway features.")
@@ -413,7 +413,7 @@ if features_created > 0:
     canvas.zoomScale(sc)
 
 # Clean up selections
-if not use_selected_feature:
+if not use_runway_selected:
     if runway_layer:
         runway_layer.removeSelection()
 else:

--- a/qols/scripts/new-ols-oes-transitional-UTM.py
+++ b/qols/scripts/new-ols-oes-transitional-UTM.py
@@ -77,7 +77,8 @@ try:
     opp_start_elevation_m = globals().get('opp_start_elevation_m', 0.0)
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
-    use_selected_feature = globals().get('use_selected_feature', True)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    use_threshold_selected = globals().get('use_threshold_selected', True)
 
     slope_ratio = slope_pct / 100.0
     approach_slope = approach_slope_pct / 100.0
@@ -117,7 +118,7 @@ map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 try:
     if runway_layer is None:
         raise Exception("No Runway Layer Centerline provided.")
-    if use_selected_feature:
+    if use_runway_selected:
         selection = runway_layer.selectedFeatures()
         if not selection:
             raise Exception("No runway features selected.")
@@ -139,7 +140,7 @@ for feat in selection:
 try:
     if threshold_layer is None:
         raise Exception("No threshold layer provided.")
-    if use_selected_feature:
+    if use_threshold_selected:
         threshold_sel = threshold_layer.selectedFeatures()
         if not threshold_sel:
             raise Exception("No threshold features selected.")

--- a/qols/scripts/new-ols-ofs-approach-UTM.py
+++ b/qols/scripts/new-ols-ofs-approach-UTM.py
@@ -58,7 +58,8 @@ try:
     direction = globals().get('direction', 0)
     runway_layer = globals().get('runway_layer', None)
     threshold_layer = globals().get('threshold_layer', None)
-    use_selected_feature = globals().get('use_selected_feature', True)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    use_threshold_selected = globals().get('use_threshold_selected', True)
     contour_interval_m = int(globals().get('contour_interval_m', 0))
 
     slope_ratio = slope_pct / 100.0
@@ -80,7 +81,7 @@ map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 try:
     if runway_layer is None:
         raise Exception("No Runway Layer Centerline provided.")
-    if use_selected_feature:
+    if use_runway_selected:
         selection = runway_layer.selectedFeatures()
         if not selection:
             raise Exception("No runway features selected.")
@@ -103,7 +104,7 @@ for feat in selection:
 try:
     if threshold_layer is None:
         raise Exception("No threshold layer provided.")
-    if use_selected_feature:
+    if use_threshold_selected:
         threshold_sel = threshold_layer.selectedFeatures()
         if not threshold_sel:
             raise Exception("No threshold features selected.")
@@ -139,7 +140,14 @@ azimuth = far_end_pt.azimuth(near_end_pt)
 # toggling direction is the user's responsibility (same as legacy); in
 # "All" mode threshold_sel already covers every feature, so the nearest
 # match still follows direction automatically.
-near_thr_feat = _closest_feature(threshold_sel, near_end_pt)
+if len(threshold_sel) == 1:
+    # Exactly one candidate (the common "Selected Only" case) - use it
+    # directly rather than re-deriving it by distance, which depends on
+    # near_end_pt being exactly right for a pick that isn't actually
+    # ambiguous (#132).
+    near_thr_feat = threshold_sel[0]
+else:
+    near_thr_feat = _closest_feature(threshold_sel, near_end_pt)
 thr_geom = near_thr_feat.geometry().asPoint()
 new_geom = QgsPoint(thr_geom)
 new_geom.addZValue(start_elevation_m)

--- a/qols/scripts/take-off-surface_UTM.py
+++ b/qols/scripts/take-off-surface_UTM.py
@@ -77,6 +77,8 @@ try:
     # Layer parameters from UI
     runway_layer = globals().get('runway_layer')
     threshold_layer = globals().get('threshold_layer')
+    use_runway_selected = globals().get('use_runway_selected', True)  # #129
+    use_threshold_selected = globals().get('use_threshold_selected', True)  # #129
 
     print(f"TakeOffSurface: Using UI parameters - code={code}, direction={s}")
     print(f"TakeOffSurface: Z0={Z0}, ZE={ZE}, widthDep={widthDep}, maxWidthDep={maxWidthDep}")
@@ -108,6 +110,8 @@ except Exception as e:
     slopePct = 2.0
     runway_layer = None
     threshold_layer = None
+    use_runway_selected = True
+    use_threshold_selected = True
 
 # ORIGINAL calculations - Exactly as original
 ZIH = 45 + ARPH
@@ -129,14 +133,21 @@ try:
         # Use layer from UI
         print(f"TakeOffSurface: Using Runway Layer Centerline from UI: {runway_layer.name()}")
         layer = runway_layer
-        selection = layer.selectedFeatures()
-        if not selection:
-            # No selection, use all features
-            selection = list(layer.getFeatures())
+        if use_runway_selected:
+            # Require explicit feature selection (#129)
+            selection = layer.selectedFeatures()
             if not selection:
-                raise Exception("No features found in Runway Layer Centerline.")
-            print(f"TakeOffSurface: No selection, using first feature from layer")
-            selection = [selection[0]]
+                raise Exception("No runway features selected. Please select runway features.")
+            print(f"TakeOffSurface: Using {len(selection)} selected runway features")
+        else:
+            selection = layer.selectedFeatures()
+            if not selection:
+                # No selection, use all features
+                selection = list(layer.getFeatures())
+                if not selection:
+                    raise Exception("No features found in Runway Layer Centerline.")
+                print(f"TakeOffSurface: No selection, using first feature from layer")
+                selection = [selection[0]]
     else:
         # ORIGINAL METHOD - Gets the Runway Layer Centerline based on name and selected feature
         print("TakeOffSurface: No Runway Layer Centerline from UI, searching by name")
@@ -218,14 +229,21 @@ try:
     if threshold_layer:
         # Use layer from UI
         print(f"TakeOffSurface: Using threshold layer from UI: {threshold_layer.name()}")
-        threshold_selection = threshold_layer.selectedFeatures()
-        if not threshold_selection:
-            # No selection, use all features
-            threshold_selection = list(threshold_layer.getFeatures())
+        if use_threshold_selected:
+            # Require explicit feature selection (#129)
+            threshold_selection = threshold_layer.selectedFeatures()
             if not threshold_selection:
-                raise Exception("No features found in threshold layer.")
-            print(f"TakeOffSurface: No selection, using first feature from threshold layer")
-            threshold_selection = [threshold_selection[0]]
+                raise Exception("No threshold features selected. Please select threshold features.")
+            print(f"TakeOffSurface: Using {len(threshold_selection)} selected threshold features")
+        else:
+            threshold_selection = threshold_layer.selectedFeatures()
+            if not threshold_selection:
+                # No selection, use all features
+                threshold_selection = list(threshold_layer.getFeatures())
+                if not threshold_selection:
+                    raise Exception("No features found in threshold layer.")
+                print(f"TakeOffSurface: No selection, using first feature from threshold layer")
+                threshold_selection = [threshold_selection[0]]
     else:
         # ORIGINAL METHOD - Gets the THR definition from active layer
         print("TakeOffSurface: No threshold layer from UI, using active layer")
@@ -335,7 +353,13 @@ v_layer.selectAll()
 canvas = iface.mapCanvas()
 canvas.zoomToSelected(v_layer)
 v_layer.removeSelection()
-layer.removeSelection()
+
+# Clean up selections only if they weren't originally selected (#129)
+# This prevents losing user selections for subsequent calculations
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+if not use_threshold_selected and threshold_layer:
+    threshold_layer.removeSelection()
 
 # get canvas scale - EXACTLY as original
 sc = canvas.scale()


### PR DESCRIPTION
# fix(#129): Selected features not working properly - gets stuck

## Summary

Closes #129.

Issue #129 "Selected features sometimes is stuck
and doesn't update... allows to use layer... Closing QGIS and opening
up is required to free it up. I did the complete OLS then wanted to do
Takeoff when this happened."

Investigated thoroughly (Explore agent + direct code reading) before
touching anything. There is **no Qt signal-connection leak** —
`qols/ui/dockwidget.py`'s `_connect()`/`self._connections`/`closeEvent`
teardown is implemented consistently throughout, and the one raw
(non-`_connect()`) connection site,
`connect_layer_selection_signals`/`disconnect_layer_selection_signals`
(dockwidget.py:570-624), already disconnects before reconnecting, so it
doesn't leak either. The bug isn't the UI literally freezing — it's
that **the "Selected Only" checkboxes and the actual calculation
silently stopped agreeing with each other**, which reads exactly like
"stuck" to a user, and only restarting QGIS (which clears all in-memory
layer selection state) makes the symptom go away.

Root causes, all confirmed by reading the code directly:

1. **`qols/plugin.py`** injected a single convenience alias into every
   script's exec namespace, `use_selected_feature`, hard-coded to the
   **Threshold** checkbox value only
   (`params.get('use_threshold_selected', False)`) — even though
   `get_parameters()` already correctly produces two independent flags,
   `use_runway_selected`/`use_threshold_selected`, driven by their own
   checkboxes.
2. Every "classic" script that read the generic `use_selected_feature`
   used it to gate **both** its runway-selection check and its
   threshold-selection check with the same value, so even without bug
   (1) they could never treat Runway and Threshold "Selected Only"
   independently: `approach-surface-UTM.py`, `OFZ_UTM.py`,
   `TransitionalSurface_UTM.py`, `new-ols-ofs-approach-UTM.py`,
   `new-ols-oes-transitional-UTM.py`. `conical.py` and
   `inner-horizontal-racetrack.py` only use a runway layer, so for them
   it was a straight mis-naming — the Threshold checkbox silently
   controlled their runway-selection behavior, and the Runway checkbox
   did nothing.
3. **`take-off-surface_UTM.py` read no selection flag at all.** It
   always called `.selectedFeatures()` directly and fell back to "first
   feature" only when nothing was selected — completely ignoring both
   checkboxes. Since several other scripts deliberately *keep* the
   runway/threshold selection after running ("Keeping feature
   selections for next calculation"), switching to Take-Off after
   finishing other surfaces meant it silently computed from whatever
   stale feature was still selected, with no way for the user to
   override it from the UI — exactly the reported reproduction ("did
   the complete OLS then wanted to do Take-Off").
4. **Unconditional selection-clearing** at the end of
   `TransitionalSurface_UTM.py` and `take-off-surface_UTM.py` wiped
   `runway_layer`/`threshold_layer`'s real selection regardless of the
   checkboxes, breaking the "keep selection for chained calculations"
   contract that `approach-surface-UTM.py`, `conical.py`, and
   `inner-horizontal-racetrack.py` already honored correctly.
   `OFZ_UTM.py`'s equivalent cleanup line was dead code — it referenced
   an undefined `layer` variable, always raising `NameError`, silently
   swallowed by a bare `except: pass`.

---

## Changes

### `qols/plugin.py`

Removed the single misleading `use_selected_feature` alias. Every
script now reads the two already-correct, already-present
`use_runway_selected`/`use_threshold_selected` keys directly (they
already reach each script's exec namespace via the existing
`exec_namespace.update(params)`).

### `qols/scripts/conical.py`, `inner-horizontal-racetrack.py`

Renamed `use_selected_feature` → `use_runway_selected` throughout
(these only ever gated a runway-layer selection, so this was a 1:1
rename).

### `qols/scripts/approach-surface-UTM.py`, `OFZ_UTM.py`,
### `TransitionalSurface_UTM.py`, `new-ols-ofs-approach-UTM.py`,
### `new-ols-oes-transitional-UTM.py`

Split the single `use_selected_feature` read into two independent
locals, `use_runway_selected` and `use_threshold_selected`, each
gating its own layer's selection-read. Where a script clears selection
at the end, each layer's clear is now gated on its own flag
independently (`approach-surface-UTM.py` already did this correctly
and was the reference pattern). `OFZ_UTM.py`'s dead
`try: layer.removeSelection() except: pass` was replaced with the same
correctly-gated two-line pattern used everywhere else.

### `qols/scripts/take-off-surface_UTM.py`

Added the same gated pattern fresh (previously had none):
- Reads `use_runway_selected`/`use_threshold_selected` (default
  `True`, matching every other script).
- When checked, requires an explicit selection and raises a clear
  error if none exists (previously silently used "first feature" even
  with an empty selection). When unchecked, behavior is unchanged
  (prefers an active selection if present, else all features) — no
  regression to the existing fallback logic.
- End-of-script cleanup now clears `runway_layer`/`threshold_layer`
  (the actual UI-supplied layers) gated on their own flags, instead of
  unconditionally calling `.removeSelection()` on a reused `layer`
  local that could have been silently reassigned to an unrelated layer
  by an earlier fallback branch (e.g. `iface.activeLayer()`).

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 551 passed

flake8 qols/plugin.py qols/scripts/approach-surface-UTM.py qols/scripts/conical.py \
       qols/scripts/inner-horizontal-racetrack.py qols/scripts/OFZ_UTM.py \
       qols/scripts/TransitionalSurface_UTM.py qols/scripts/take-off-surface_UTM.py
# 0 issues

flake8 qols/scripts/new-ols-ofs-approach-UTM.py qols/scripts/new-ols-oes-transitional-UTM.py
# 95 lines of pre-existing star-import findings (F403/F405/E402) — confirmed via
# `git stash` that the count is byte-identical before and after this change;
# these two files never had the `# flake8: noqa` suppression the other scripts
# carry, but nothing in this diff added a new finding.
```

The three `--ignore`d test files are stale local artifacts from the
still-unmerged `fix/124-conical-inner-horizontal-overlap` branch
(`tests/` is gitignored, so they persist on disk regardless of branch)
— this branch was cut from `main`, which doesn't yet have that
branch's work. Not a #129 regression, same as noted in `doc/PR_128.md`.

