### PR TITLE
task(#133): Transitional layer name change

### DIFF
--- a/qols/scripts/new-ols-oes-transitional-UTM.py
+++ b/qols/scripts/new-ols-oes-transitional-UTM.py
@@ -275,7 +275,7 @@ else:
 # ---------------------------------------------------------------------------
 # Memory layer
 # ---------------------------------------------------------------------------
-layer_name = "NewOLS_OES_Transitional"
+layer_name = "NewOLS_OFS_Transitional"
 oes_layer = QgsVectorLayer("PolygonZ?crs=" + map_srid, layer_name, "memory")
 oes_layer.dataProvider().addAttributes([
     QgsField('ID', QVariant.Int),


### PR DESCRIPTION
# task(#133): Transitional layer name change

## Summary

Closes #133.

Issue #133  the New OLS OES Transitional script's
output layer loaded as `NewOLS_OES_Transitional`; it should be
`NewOLS_OFS_Transitional`.

## Changes

### `qols/scripts/new-ols-oes-transitional-UTM.py`

Changed the `layer_name` string literal from `"NewOLS_OES_Transitional"`
to `"NewOLS_OFS_Transitional"`. Single occurrence, confirmed via
repo-wide grep — no other code, tests, or docs reference the old name.

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 551 passed

flake8 qols/scripts/new-ols-oes-transitional-UTM.py
# 45 lines of pre-existing star-import findings, confirmed byte-identical
# before/after this change via `git stash`
```