### PR TITLE
Enhance direction marker functionality for Approach, Transitional, Ta…

### DIFF
--- a/qols/direction_marker.py
+++ b/qols/direction_marker.py
@@ -1,5 +1,6 @@
 """qols/direction_marker.py — live direction-preview triangle for the
-Approach/Transitional (and OFS/OES) dockwidget tabs (#117).
+Approach/Transitional/Take-Off/OFZ (and OFS/OES) dockwidget tabs
+(#117, #130).
 
 Mirrors qpansopy's OMNI SID DER marker: a small triangle, tip pointing the
 way the surface will extend, sized in screen pixels so it stays visible at
@@ -118,7 +119,8 @@ def build_marker_geometry(
     runway_layer,
     threshold_layer,
     direction: int,
-    use_selected_feature: bool,
+    use_runway_selected: bool,
+    use_threshold_selected: bool,
     length_px: float,
     half_width_px: float,
     map_units_per_pixel: float,
@@ -134,8 +136,8 @@ def build_marker_geometry(
 
     from qgis.core import QgsGeometry, QgsLineString, QgsPoint, QgsPolygon
 
-    runway_sel = _resolve_features(runway_layer, use_selected_feature)
-    threshold_sel = _resolve_features(threshold_layer, use_selected_feature)
+    runway_sel = _resolve_features(runway_layer, use_runway_selected)
+    threshold_sel = _resolve_features(threshold_layer, use_threshold_selected)
     if not runway_sel or not threshold_sel:
         return None
 

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -1460,27 +1460,31 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         self._update_direction_marker()
 
     def _update_direction_marker(self):
-        """Refresh the live direction-preview triangle (#117) for the
-        currently active tab. Approach/Transitional only — hidden otherwise.
-        Never raises: this runs on every layer/direction/zoom change."""
+        """Refresh the live direction-preview triangle (#117, #130) for
+        the currently active tab. Approach/Transitional/Take-Off/OFZ
+        only — hidden for direction-agnostic surfaces (Inner Horizontal
+        & Conical, Outer Horizontal). Never raises: this runs on every
+        layer/direction/zoom change."""
         try:
             current_tab = self.scriptTabWidget.widget(self.scriptTabWidget.currentIndex())
             tab_name = current_tab.objectName().lower() if current_tab else ''
-            if 'approach' in tab_name:
-                direction = 0 if self.direction_start_to_end else -1
-            elif 'transitional' in tab_name:
+            if 'transitional' in tab_name:
                 direction = 0 if self.transitional_direction_normal else -1
+            elif 'approach' in tab_name or 'takeoff' in tab_name or 'ofz' in tab_name:
+                direction = 0 if self.direction_start_to_end else -1
             else:
                 self._clear_direction_marker()
                 return
 
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
-            use_selected_feature = self.useSelectedThresholdCheckBox.isChecked()
+            use_runway_selected = self.useSelectedRunwayCheckBox.isChecked()
+            use_threshold_selected = self.useSelectedThresholdCheckBox.isChecked()
             map_units_per_pixel = self.iface.mapCanvas().mapUnitsPerPixel()
 
             geometry = build_marker_geometry(
-                runway_layer, threshold_layer, direction, use_selected_feature,
+                runway_layer, threshold_layer, direction,
+                use_runway_selected, use_threshold_selected,
                 _DIRECTION_MARKER_LENGTH_PX, _DIRECTION_MARKER_HALF_WIDTH_PX,
                 map_units_per_pixel,
             )

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -704,11 +704,13 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             direction = 0 if self.direction_start_to_end else -1
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
-            use_selected_feature = self.useSelectedThresholdCheckBox.isChecked()
+            use_runway_selected = self.useSelectedRunwayCheckBox.isChecked()
+            use_threshold_selected = self.useSelectedThresholdCheckBox.isChecked()
             map_units_per_pixel = self.iface.mapCanvas().mapUnitsPerPixel()
 
             geometry = build_marker_geometry(
-                runway_layer, threshold_layer, direction, use_selected_feature,
+                runway_layer, threshold_layer, direction,
+                use_runway_selected, use_threshold_selected,
                 _DIRECTION_MARKER_LENGTH_PX, _DIRECTION_MARKER_HALF_WIDTH_PX,
                 map_units_per_pixel,
             )


### PR DESCRIPTION
# task(#130): Direction marker for Take-Off (and OFZ) surfaces

## Summary

Issue #130  "Takeoff Surface surfaces include
direction marker similar to OMNI SID... This would allow to know
without needing to draw or guess the direction. Include this for
current and new surfaces."

The direction-preview triangle (#117, `qols/direction_marker.py`,
mirrors qpansopy's OMNI SID DER marker) already existed and is fully
generic — it only needs `runway_layer`, `threshold_layer`, `direction`,
and a selection flag, with no dependency on which surface type is
active.

- **New OLS panel** already showed the marker unconditionally for both
  OFS Approach and OES Transitional — "new surfaces" were already
  covered, confirmed by reading `new_ols_dockwidget.py` directly.
- **Classic panel** only recognized `'approach'`/`'transitional'` tabs,
  hiding the marker for everything else. Take-Off (named in the issue)
  genuinely uses `direction` for its azimuth and already shares the
  exact same runway/threshold/checkbox/direction-button state as
  Approach. OFZ is in the identical situation — its script also flips
  azimuth on `direction`, and it was hidden for the same reason. Both
  now show the marker. Inner Horizontal/Conical and Outer Horizontal
  are genuinely direction-agnostic (no azimuth-flip in their scripts)
  and correctly remain without one.

**Adjacent bug fixed along the way**: `build_marker_geometry` took a
single `use_selected_feature: bool`, resolving both runway and
threshold selection from it — the same flag-confusion bug #129 already
fixed in every calculation script, just not yet in this preview-only
file. Both dockwidgets' call sites only ever passed the Threshold
checkbox's value, so the Runway "Selected Only" checkbox had no effect
on the preview marker. Fixed alongside the tab extension so the
preview stays honest.

---

## Changes

### `qols/direction_marker.py`

`build_marker_geometry`'s signature changed from
`use_selected_feature: bool` to
`use_runway_selected: bool, use_threshold_selected: bool`, each applied
to its own `_resolve_features()` call. Pure functions
(`resolve_direction_azimuth`, `triangle_marker_vertices`) unchanged.

### `qols/ui/dockwidget.py`

`_update_direction_marker` now also recognizes `'takeoff'` and `'ofz'`
tabs (both using the same `self.direction_start_to_end` state Approach
already uses — no new UI state). Call site updated to pass
`useSelectedRunwayCheckBox`/`useSelectedThresholdCheckBox` as two
independent flags.

### `qols/ui/new_ols_dockwidget.py`

Call site updated to the new two-flag signature — no tab-gating change
needed, it already covers both New OLS tabs.

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 551 passed — tests/test_direction_marker.py covers only the pure
# functions, unaffected by the wrapper signature change

flake8 qols/direction_marker.py qols/ui/dockwidget.py qols/ui/new_ols_dockwidget.py
# direction_marker.py: 0 issues
# dockwidget.py / new_ols_dockwidget.py: 5 pre-existing findings total
# (F821 dead-code New OLS methods + F821 show_project_parameters_table
# import gap + F401 unused QPushButton import), confirmed byte-identical
# on main via `git stash` — none introduced by this change. The
# show_project_parameters_table import gap is already fixed on the
# still-unmerged fix/124-conical-inner-horizontal-overlap branch; this
# branch was cut from main before that fix landed.
```

Manual QGIS check (pending): open Take-Off, confirm the green direction
triangle appears at the threshold and flips when the direction button
is toggled, same as Approach; same check for OFZ; confirm Inner
Horizontal/Conical and Outer Horizontal still show no marker; toggle
Runway-only vs Threshold-only "Selected Only" independently and confirm
the marker now respects each.

---

## Risk / notes

- No new signal connections or state — reuses existing shared UI
  elements exactly as Approach already does.
- The signature change has exactly two call sites, both updated here.
