### PR TITLE
 feature(#131): ARP layer and elevation requested at the top

### DIFF
--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -371,7 +371,9 @@ class QOLS:
             'width_m': ofs.get('inner_edge_m', 175.0),
             'start_elevation_m': ofs.get('start_elevation_m', 0.0),
             'end_elevation_m': ofs.get('end_elevation_m', 0.0),
-            'highest_thr_elev_m': ofs.get('arp_elevation_m', 0.0),
+            # #131: arp_elevation_m is now a top-level shared param, not
+            # part of the OFS tab's own specific_params.
+            'highest_thr_elev_m': params.get('arp_elevation_m', 0.0),
             'slope_pct': 20.0,
             'cap_height_m': 60.0,
             'approach_slope_pct': ofs.get('slope_pct', 3.33),

--- a/qols/scripts/outer-horizontal.py
+++ b/qols/scripts/outer-horizontal.py
@@ -1,12 +1,11 @@
 '''
-Outer Horizontal Surface 
+Outer Horizontal Surface
 DOC 9137 Part 6 Implementation - 15,000m circle centered on ARP
 For Aerodrome Code 3 or 4 only
 Procedure to be used in Projected Coordinate System Only
 
-Note: Plugin integration uses 'threshold_layer' parameter name for compatibility
-with existing UI, but this script uses ARP (Aerodrome Reference Point) terminology
-for clarity and DOC 9137 compliance.
+Reads the ARP (Aerodrome Reference Point) from the shared top-level
+ARP Layer / ARP Elevation panel inputs (#131).
 '''
 # flake8: noqa  # exec()-dispatched script; star imports intentional (see TD-03)
 
@@ -35,17 +34,15 @@ print(f"OuterHorizontal: ARP elevation={arp_elevation}m, absolute Z={z_absolute}
 if code not in [3, 4]:
     print(f"OuterHorizontal: WARNING - Code {code} not standard for outer horizontal (DOC 9137 requires code 3 or 4)")
 
-# Get ARP (Aerodrome Reference Point) from threshold layer
-# Note: Plugin parameter is still named 'threshold_layer' for compatibility,
-# but we use descriptive variable name for better code documentation
-aerodrome_reference_point_layer = globals().get('threshold_layer')
-use_threshold_selected = globals().get('use_threshold_selected', False)
+# Get ARP (Aerodrome Reference Point) from the shared ARP Layer combo (#131)
+aerodrome_reference_point_layer = globals().get('arp_layer')
+use_arp_selected = globals().get('use_arp_selected', False)
 
 if not aerodrome_reference_point_layer:
-    raise Exception("No ARP (Aerodrome Reference Point) layer provided. Please select a threshold layer from the UI.")
+    raise Exception("No ARP (Aerodrome Reference Point) layer provided. Please select an ARP layer from the UI.")
 
 # Get ARP coordinates - use selection or all features based on UI setting
-if use_threshold_selected:
+if use_arp_selected:
     selection = aerodrome_reference_point_layer.selectedFeatures()
     if not selection:
         raise Exception("No ARP (Aerodrome Reference Point) features selected. Please select ARP feature.")

--- a/qols/ui/dockwidget.py
+++ b/qols/ui/dockwidget.py
@@ -74,7 +74,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         'spin_widthApp':              280.0,
         'spin_Z0':                   2548.0,
         'spin_ZE':                   2546.5,
-        'spin_ARPH':                 2548.0,
         'spin_L1':                   3000.0,
         'spin_L2':                   3600.0,
         'spin_LH':                   8400.0,
@@ -87,7 +86,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         'spin_width_ofz':             120.0,
         'spin_Z0_ofz':               2548.0,
         'spin_ZE_ofz':               2546.5,
-        'spin_ARPH_ofz':             2548.0,
         'spin_IHSlope_ofz':            33.3,
         # Outer Horizontal
         'spin_radius_outer':        15000.0,
@@ -101,8 +99,10 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         'spin_widthApp_transitional': 280.0,
         'spin_Z0_transitional':      2548.0,
         'spin_ZE_transitional':      2546.5,
-        'spin_ARPH_transitional':    2548.0,
         'spin_Tslope_transitional':    14.3,
+        # ARP (Aerodrome Reference Point) — shared by every tab that needs
+        # a Z datum, moved to a single top-level field (#131).
+        'spin_ARP_elevation':        2548.0,
     }
 
     # Widgets declared in qols_panel_base.ui, guaranteed available after setupUi() (R-04)
@@ -146,12 +146,15 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         # Track connected layers for selection signals (Issue #59)
         self.connected_runway_layer = None
         self.connected_threshold_layer = None
+        self.connected_arp_layer = None  # #131
         # Lambda slots stored for proper selectionChanged disconnection (Issue #105)
         self._runway_selection_slot = None
         self._threshold_selection_slot = None
+        self._arp_selection_slot = None  # #131
         # State tracking for dropdown tooltip optimization (BUG-05)
         self._last_runway_count = 0
         self._last_threshold_count = 0
+        self._last_arp_count = 0  # #131
         # Tracked signal connections for clean teardown in closeEvent (R-05)
         self._connections: list = []
         # Cached approach defaults — always exists so get_parameters() never needs getattr fallback
@@ -224,6 +227,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
 
             self.useSelectedRunwayCheckBox.setChecked(False)
             self.useSelectedThresholdCheckBox.setChecked(False)
+            self.useSelectedArpCheckBox.setChecked(False)  # #131
 
             self.initialize_all_numeric_defaults()
             self.update_takeoff_final_width_controls()
@@ -277,16 +281,20 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # Connect signals for real-time feedback (tracked for clean closeEvent teardown)
             self._connect(self.useSelectedRunwayCheckBox.toggled, self.update_selection_info)
             self._connect(self.useSelectedThresholdCheckBox.toggled, self.update_selection_info)
+            self._connect(self.useSelectedArpCheckBox.toggled, self.update_selection_info)  # #131
             self._connect(self.runwayLayerCombo.layerChanged, self.update_selection_info)
             self._connect(self.thresholdLayerCombo.layerChanged, self.update_selection_info)
+            self._connect(self.arpLayerCombo.layerChanged, self.update_selection_info)  # #131
 
             # Connect to layer changes for selection signal management (Issue #59)
             self._connect(self.runwayLayerCombo.layerChanged, self.connect_layer_selection_signals)
             self._connect(self.thresholdLayerCombo.layerChanged, self.connect_layer_selection_signals)
+            self._connect(self.arpLayerCombo.layerChanged, self.connect_layer_selection_signals)  # #131
 
             # SAFETY: Connect to layer combo changes for immediate validation
             self._connect(self.runwayLayerCombo.layerChanged, self.validate_layer_change)
             self._connect(self.thresholdLayerCombo.layerChanged, self.validate_layer_change)
+            self._connect(self.arpLayerCombo.layerChanged, self.validate_layer_change)  # #131
 
             # Connect signals
             self._connect(self.calculateButton.clicked, self.on_calculate_clicked)
@@ -356,16 +364,17 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         """Configure numeric input validation for all QLineEdit widgets (formerly QDoubleSpinBox)."""
         try:
             lineedit_names = [
-                'spin_widthApp', 'spin_Z0', 'spin_ZE', 'spin_ARPH',
+                'spin_widthApp', 'spin_Z0', 'spin_ZE',
                 'spin_L1', 'spin_L2', 'spin_LH',
                 'spin_L_conical', 'spin_height_conical',
                 'spin_L_inner', 'spin_height_inner',
-                'spin_width_ofz', 'spin_Z0_ofz', 'spin_ZE_ofz', 'spin_ARPH_ofz', 'spin_IHSlope_ofz',
+                'spin_width_ofz', 'spin_Z0_ofz', 'spin_ZE_ofz', 'spin_IHSlope_ofz',
                 'spin_radius_outer', 'spin_height_outer',
                 'spin_widthDep_takeoff', 'spin_maxWidthDep_takeoff',
                 'spin_CWYLength_takeoff', 'spin_Z0_takeoff',
                 'spin_widthApp_transitional', 'spin_Z0_transitional', 'spin_ZE_transitional',
-                'spin_ARPH_transitional', 'spin_Tslope_transitional',
+                'spin_Tslope_transitional',
+                'spin_ARP_elevation',  # #131 — shared ARP elevation field
             ]
 
             # Allow unlimited decimals; optional sign and decimal part
@@ -550,7 +559,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 'label_width_ofz', 'spin_width_ofz',
                 'label_Z0_ofz', 'spin_Z0_ofz',
                 'label_ZE_ofz', 'spin_ZE_ofz',
-                'label_ARPH_ofz', 'spin_ARPH_ofz',
                 'label_IHSlope_ofz', 'spin_IHSlope_ofz'
             ]
 
@@ -576,6 +584,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
 
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
+            arp_layer = self.arpLayerCombo.currentLayer()  # #131
 
             # Connect to Runway Layer Centerline selection changes.
             # Lambda wrapper discards the 3 args emitted by selectionChanged so the
@@ -594,6 +603,14 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 self.connected_threshold_layer = threshold_layer
             else:
                 self._threshold_selection_slot = None
+
+            # Connect to ARP layer selection changes (#131)
+            if arp_layer and isinstance(arp_layer, QgsVectorLayer):
+                self._arp_selection_slot = lambda *_: self.update_selection_info()
+                arp_layer.selectionChanged.connect(self._arp_selection_slot)
+                self.connected_arp_layer = arp_layer
+            else:
+                self._arp_selection_slot = None
 
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
@@ -620,6 +637,16 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     pass  # Signal might not be connected
                 self.connected_threshold_layer = None
                 self._threshold_selection_slot = None
+
+            if self.connected_arp_layer and self._arp_selection_slot:  # #131
+                try:
+                    self.connected_arp_layer.selectionChanged.disconnect(
+                        self._arp_selection_slot
+                    )
+                except RuntimeError:
+                    pass  # Signal might not be connected
+                self.connected_arp_layer = None
+                self._arp_selection_slot = None
 
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
@@ -969,6 +996,15 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             self.thresholdLayerCombo.setShowCrs(False)
             self.thresholdLayerCombo.setAllowEmptyLayer(False)
 
+            # Configure ARP layer combo - only show POINT geometry layers (#131).
+            # Unlike Runway/Threshold, empty is a valid state: only surfaces
+            # that actually consume the ARP layer (e.g. Outer Horizontal)
+            # require one to be selected.
+            self.arpLayerCombo.setFilters(QgsMapLayerProxyModel.VectorLayer)
+            self.arpLayerCombo.setExceptedLayerList([])
+            self.arpLayerCombo.setShowCrs(False)
+            self.arpLayerCombo.setAllowEmptyLayer(True)
+
             # Apply geometry filtering
             self.apply_geometry_filters()
 
@@ -991,6 +1027,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # Filter Runway Layer Centerline layers - only show LINE geometry
             runway_excluded = []
             threshold_excluded = []
+            arp_excluded = []
 
             for layer in vector_layers:
                 if layer.geometryType() != QgsWkbTypes.LineGeometry:
@@ -998,10 +1035,12 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
 
                 if layer.geometryType() != QgsWkbTypes.PointGeometry:
                     threshold_excluded.append(layer)
+                    arp_excluded.append(layer)  # #131 — ARP layer is also POINT-only
 
             # Apply exclusion lists
             self.runwayLayerCombo.setExceptedLayerList(runway_excluded)
             self.thresholdLayerCombo.setExceptedLayerList(threshold_excluded)
+            self.arpLayerCombo.setExceptedLayerList(arp_excluded)
 
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
@@ -1015,19 +1054,23 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(QgsProject.instance().layersRemoved, self.update_dropdown_item_tooltips)
             self._connect(self.runwayLayerCombo.layerChanged, self.update_dropdown_item_tooltips)
             self._connect(self.thresholdLayerCombo.layerChanged, self.update_dropdown_item_tooltips)
+            self._connect(self.arpLayerCombo.layerChanged, self.update_dropdown_item_tooltips)  # #131
 
             # Connect to mouse events on the dropdown views for real-time tooltip updates
             try:
                 runway_view = self.runwayLayerCombo.view()
                 threshold_view = self.thresholdLayerCombo.view()
+                arp_view = self.arpLayerCombo.view()  # #131
 
                 # Set mouse tracking to capture hover events
                 runway_view.setMouseTracking(True)
                 threshold_view.setMouseTracking(True)
+                arp_view.setMouseTracking(True)  # #131
 
                 # Install event filters for hover detection
                 runway_view.installEventFilter(self)
                 threshold_view.installEventFilter(self)
+                arp_view.installEventFilter(self)  # #131
 
             except Exception as e:
                 logger.warning(f"Unhandled error: {e}")
@@ -1044,14 +1087,17 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # Reduce logging frequency - only log when layers change
             current_runway_count = self.runwayLayerCombo.count()
             current_threshold_count = self.thresholdLayerCombo.count()
+            current_arp_count = self.arpLayerCombo.count()  # #131
 
             # Only proceed if layer counts have changed
             if (current_runway_count == self._last_runway_count
-                    and current_threshold_count == self._last_threshold_count):
+                    and current_threshold_count == self._last_threshold_count
+                    and current_arp_count == self._last_arp_count):
                 return  # No changes, skip update
 
             self._last_runway_count = current_runway_count
             self._last_threshold_count = current_threshold_count
+            self._last_arp_count = current_arp_count  # #131
 
             # Force update tooltips using multiple methods for maximum compatibility
             try:
@@ -1093,10 +1139,28 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                         except (AttributeError, TypeError):
                             pass
 
+                # Update ARP combo tooltips - focus on tooltip data only (#131)
+                arp_model = self.arpLayerCombo.model()
+                for i in range(self.arpLayerCombo.count()):
+                    layer = self.arpLayerCombo.layer(i)
+                    if layer:
+                        geom_type = self.get_geometry_type_name(layer)
+                        feature_count = layer.featureCount()
+                        tooltip = f"Layer: {layer.name()}\nType: {geom_type}\nFeatures: {feature_count}"
+
+                        index = arp_model.index(i, 0)
+                        arp_model.setData(index, tooltip, TOOLTIP_ROLE)
+
+                        try:
+                            self.arpLayerCombo.setItemData(i, tooltip, TOOLTIP_ROLE)
+                        except (AttributeError, TypeError):
+                            pass
+
                 # Force view refresh to ensure tooltips are applied
                 try:
                     self.runwayLayerCombo.view().update()
                     self.thresholdLayerCombo.view().update()
+                    self.arpLayerCombo.view().update()
                 except AttributeError:
                     pass
 
@@ -1127,13 +1191,17 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # Check if this is a mouse move event in one of our dropdown views
             if event.type() == EVENT_MOUSE_MOVE:
                 # Get the view that received the event
-                if obj == self.runwayLayerCombo.view() or obj == self.thresholdLayerCombo.view():
+                _combo_views = {
+                    self.runwayLayerCombo.view(): self.runwayLayerCombo,
+                    self.thresholdLayerCombo.view(): self.thresholdLayerCombo,
+                    self.arpLayerCombo.view(): self.arpLayerCombo,  # #131
+                }
+                if obj in _combo_views:
                     # Get the item under the mouse
                     index = obj.indexAt(event.pos())
                     if index.isValid():
                         # Get the layer for this index
-                        is_runway = obj == self.runwayLayerCombo.view()
-                        combo = self.runwayLayerCombo if is_runway else self.thresholdLayerCombo
+                        combo = _combo_views[obj]
                         layer = combo.layer(index.row())
                         if layer:
                             geom_type = self.get_geometry_type_name(layer)
@@ -1168,6 +1236,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             # Clear any inline stylesheets so the active QGIS theme (dark/light) owns rendering.
             self.runwayLayerCombo.setStyleSheet("")
             self.thresholdLayerCombo.setStyleSheet("")
+            self.arpLayerCombo.setStyleSheet("")  # #131
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
@@ -1177,9 +1246,11 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         try:
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
+            arp_layer = self.arpLayerCombo.currentLayer()  # #131
 
             use_runway_selected = self.useSelectedRunwayCheckBox.isChecked()
             use_threshold_selected = self.useSelectedThresholdCheckBox.isChecked()
+            use_arp_selected = self.useSelectedArpCheckBox.isChecked()  # #131
 
             # Update runway info
             if runway_layer:
@@ -1211,6 +1282,21 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             else:
                 threshold_status = "No layer"
 
+            # Update ARP info (#131) — optional, so "No layer" isn't an error
+            if arp_layer:
+                arp_selected = len(arp_layer.selectedFeatures())
+                arp_total = arp_layer.featureCount()
+
+                if use_arp_selected:
+                    if arp_selected > 0:
+                        arp_status = f"Selected ({arp_selected})"
+                    else:
+                        arp_status = "No selection"
+                else:
+                    arp_status = f"All ({arp_total})"
+            else:
+                arp_status = "No layer"
+
             # Detect active theme (dark vs light) to pick readable label colors.
             _is_dark = QApplication.palette().window().color().lightness() < 128
             _c_warn = "#FFA726" if _is_dark else "#E65100"  # orange
@@ -1238,12 +1324,25 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 threshold_icon = "✘"
                 threshold_style = f"QLabel {{ color: {_c_err}; {_base_style} }}"
 
+            # ARP is optional (#131) — "No layer" is a neutral state, not an error
+            if "All" in arp_status:
+                arp_icon = "⚠"
+                arp_style = f"QLabel {{ color: {_c_warn}; {_base_style} }}"
+            elif "Selected" in arp_status:
+                arp_icon = "✔"
+                arp_style = f"QLabel {{ color: {_c_ok}; {_base_style} }}"
+            else:
+                arp_icon = "•"
+                arp_style = f"QLabel {{ {_base_style} }}"
+
             # Update per-layer labels
             try:
                 self.runwaySelectionStatusLabel.setText(f"{runway_icon} {runway_status}")
                 self.runwaySelectionStatusLabel.setStyleSheet(runway_style)
                 self.thresholdSelectionStatusLabel.setText(f"{threshold_icon} {threshold_status}")
                 self.thresholdSelectionStatusLabel.setStyleSheet(threshold_style)
+                self.arpSelectionStatusLabel.setText(f"{arp_icon} {arp_status}")
+                self.arpSelectionStatusLabel.setStyleSheet(arp_style)
             except Exception as e:
                 logger.warning(f"Unhandled error: {e}")
 
@@ -1257,6 +1356,7 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
             try:
                 self.runwaySelectionStatusLabel.setText("❌ Error")
                 self.thresholdSelectionStatusLabel.setText("❌ Error")
+                self.arpSelectionStatusLabel.setText("❌ Error")
             except (AttributeError, RuntimeError):
                 pass
 
@@ -1354,7 +1454,21 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     self.thresholdLayerCombo.setLayer(None)
                     return
 
-            # If both layers are valid, update status
+            # Validate ARP layer (#131) — optional, so only checked when set
+            arp_layer = self.arpLayerCombo.currentLayer()
+            if arp_layer:
+                if arp_layer.geometryType() != QgsWkbTypes.PointGeometry:
+                    geom_type = self.get_layer_geometry_info(arp_layer)
+                    self.show_error_message(
+                        f"Invalid ARP Layer!\n"
+                        f"'{arp_layer.name()}' contains {geom_type} geometry.\n"
+                        f"ARP Layer must contain POINT geometry (the ARP point)."
+                    )
+                    # Reset to no selection
+                    self.arpLayerCombo.setLayer(None)
+                    return
+
+            # If all layers are valid, update status
             self.update_selection_info()
 
         except Exception as e:
@@ -1795,9 +1909,16 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
         try:
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
+            arp_layer = self.arpLayerCombo.currentLayer()  # #131
 
             use_runway_selected = self.useSelectedRunwayCheckBox.isChecked()
             use_threshold_selected = self.useSelectedThresholdCheckBox.isChecked()
+            use_arp_selected = self.useSelectedArpCheckBox.isChecked()  # #131
+
+            # ARP (Aerodrome Reference Point) elevation — a single shared
+            # value reused by every tab that needs a Z datum, instead of
+            # the 4 duplicate per-tab fields removed in #131.
+            arp_elevation_m = self.get_numeric_value('spin_ARP_elevation')
 
             # Get direction
             direction = 0 if self.direction_start_to_end else -1
@@ -1828,12 +1949,15 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 code_value = self.get_code_value('spin_code')
                 rwy_text = self.combo_rwyClassification.currentText()
                 width_value = self.get_numeric_value('spin_widthApp')
-                arph_value = self.get_numeric_value('spin_ARPH')
                 l1_value = self.get_numeric_value('spin_L1')
                 l2_value = self.get_numeric_value('spin_L2')
                 lh_value = self.get_numeric_value('spin_LH')
 
-                # Provide both legacy and pythonic keys for compatibility
+                # Provide both legacy and pythonic keys for compatibility.
+                # ARPH/arp_elevation_m no longer collected per-tab (#131) —
+                # the shared value is injected into the top-level params
+                # dict below, reaching this script the same way
+                # runway_layer/threshold_layer already do.
                 specific_params = {
                     # Legacy keys (kept)
                     'code': code_value,
@@ -1841,7 +1965,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'widthApp': width_value,
                     'Z0': Z0_calc,
                     'ZE': ZE_calc,
-                    'ARPH': arph_value,
                     'L1': l1_value,
                     'L2': l2_value,
                     'LH': lh_value,
@@ -1852,7 +1975,6 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'approach_width_m': width_value,
                     'start_elevation_m': Z0_calc,
                     'end_elevation_m': ZE_calc,
-                    'arp_elevation_m': arph_value,
                     'first_section_length_m': l1_value,
                     'second_section_length_m': l2_value,
                     'horizontal_section_length_m': lh_value,
@@ -1906,11 +2028,13 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                     'combined_execution': True,
                 }
             elif surface_type == SurfaceType.OUTER_HORIZONTAL:
+                # arp_elevation no longer collected per-tab (#131) — the
+                # shared value reaches outer-horizontal.py via the
+                # top-level params dict below.
                 specific_params = {
                     'code': self.get_code_value('spin_code_outer'),
                     'radius': self.get_numeric_value('spin_radius_outer'),
                     'height': self.get_numeric_value('spin_height_outer'),
-                    'arp_elevation': self.get_numeric_value('spin_arp_elevation_outer'),
                 }
             elif surface_type == SurfaceType.TAKEOFF:
                 code_value = self.get_code_value('spin_code_takeoff')
@@ -1961,13 +2085,15 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 else:  # Inverted direction
                     Z0_calc, ZE_calc = ze_ui, z0_ui
 
+                # ARPH no longer collected per-tab (#131) — the shared
+                # value reaches TransitionalSurface_UTM.py's ZIH ceiling
+                # via the top-level params dict below.
                 specific_params = {
                     'code': self.get_code_value('spin_code_transitional'),  # QComboBox
                     'rwyClassification': self.combo_rwyClassification_transitional.currentText(),
                     'widthApp': float(self.spin_widthApp_transitional.text() or "0"),  # QLineEdit
                     'Z0': Z0_calc,
                     'ZE': ZE_calc,
-                    'ARPH': float(self.spin_ARPH_transitional.text() or "0"),          # QLineEdit
                     'Tslope': float(self.spin_Tslope_transitional.text() or "0") / 100.0,  # % → decimal
                     's': s_value,  # Special parameter for transitional runway direction
                     'merge_transitional': self.check_merge_transitional.isChecked(),  # #121
@@ -1975,13 +2101,15 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                         self.get_numeric_value('spin_contour_interval_transitional'))),
                 }
             elif surface_type == SurfaceType.OFZ:
+                # ARPH no longer collected per-tab (#131) — the shared
+                # value reaches OFZ_UTM.py's ZIH ceiling via the
+                # top-level params dict below.
                 specific_params = {
                     'code': self.get_code_value('spin_code_ofz'),  # QComboBox
                     'rwyClassification': self.combo_rwyClassification_ofz.currentText(),
                     'width': float(self.spin_width_ofz.text() or "0"),
                     'Z0': float(self.spin_Z0_ofz.text() or "0"),
                     'ZE': float(self.spin_ZE_ofz.text() or "0"),
-                    'ARPH': float(self.spin_ARPH_ofz.text() or "0"),
                     'IHSlope': float(self.spin_IHSlope_ofz.text() or "0") / 100.0  # Convert percentage to decimal
                 }
                 # Inject IA/BL params if available from rules
@@ -2008,9 +2136,21 @@ class QolsDockWidget(QDockWidget, FORM_CLASS):
                 'surface_type': surface_type,
                 'runway_layer': runway_layer,
                 'threshold_layer': threshold_layer,
+                'arp_layer': arp_layer,  # #131
                 'use_runway_selected': use_runway_selected,
                 'use_threshold_selected': use_threshold_selected,
+                'use_arp_selected': use_arp_selected,  # #131
                 'direction': direction,
+                # ARP (Aerodrome Reference Point) elevation, shared by every
+                # script (#131). Injected under every legacy alias each
+                # script already reads via globals().get(...), so no
+                # script math needs to change: OFZ/Transitional/Take-Off/
+                # Approach read 'ARPH' (Approach also checks
+                # 'arp_elevation_m' first); outer-horizontal.py reads
+                # 'arp_elevation'.
+                'arp_elevation_m': arp_elevation_m,
+                'ARPH': arp_elevation_m,
+                'arp_elevation': arp_elevation_m,
                 'specific_params': specific_params
             }
 

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -47,14 +47,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         'spin_slope_ofs':            3.33,
         'spin_Z0_ofs':            2548.0,
         'spin_ZE_ofs':            2546.5,
-        'spin_ARPH_ofs':          2548.0,
         'spin_contour_interval_ofs': 10.0,
         # OES Transitional
         'spin_widthApp_oes':        155.0,
         'spin_Z0_oes':            2548.0,
         'spin_ZE_oes':            2546.5,
-        'spin_ARPH_oes':          2548.0,
         'spin_slope_oes':            20.0,
+        # ARP (Aerodrome Reference Point) — shared by both tabs, moved to
+        # a single top-level field (#131).
+        'spin_ARP_elevation':     2548.0,
     }
 
     combo_rwyType_ofs: QComboBox
@@ -67,25 +68,28 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     spin_slope_ofs: QLineEdit
     spin_Z0_ofs: QLineEdit
     spin_ZE_ofs: QLineEdit
-    spin_ARPH_ofs: QLineEdit
     spin_contour_interval_ofs: QLineEdit
     spin_widthApp_oes: QLineEdit
     spin_Z0_oes: QLineEdit
     spin_ZE_oes: QLineEdit
-    spin_ARPH_oes: QLineEdit
     spin_slope_oes: QLineEdit
+    spin_ARP_elevation: QLineEdit
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
+    arpSelectionStatusLabel: QLabel
 
     def __init__(self, iface, parent=None):
         super(NewOlsDockWidget, self).__init__(parent)
         self.iface = iface
         self.connected_runway_layer = None
         self.connected_threshold_layer = None
+        self.connected_arp_layer = None  # #131
         self._runway_selection_slot = None
         self._threshold_selection_slot = None
+        self._arp_selection_slot = None  # #131
         self._last_runway_count = 0
         self._last_threshold_count = 0
+        self._last_arp_count = 0  # #131
         self._connections: list = []
 
         # Live direction-preview marker (OFS/OES tabs, #117)
@@ -103,6 +107,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
 
             self.useSelectedRunwayCheckBox.setChecked(False)
             self.useSelectedThresholdCheckBox.setChecked(False)
+            self.useSelectedArpCheckBox.setChecked(False)  # #131
 
             try:
                 self._connect(self.combo_rwyType_ofs.currentIndexChanged,
@@ -123,12 +128,16 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
 
             self._connect(self.useSelectedRunwayCheckBox.toggled, self.update_selection_info)
             self._connect(self.useSelectedThresholdCheckBox.toggled, self.update_selection_info)
+            self._connect(self.useSelectedArpCheckBox.toggled, self.update_selection_info)  # #131
             self._connect(self.runwayLayerCombo.layerChanged, self.update_selection_info)
             self._connect(self.thresholdLayerCombo.layerChanged, self.update_selection_info)
+            self._connect(self.arpLayerCombo.layerChanged, self.update_selection_info)  # #131
             self._connect(self.runwayLayerCombo.layerChanged, self.connect_layer_selection_signals)
             self._connect(self.thresholdLayerCombo.layerChanged, self.connect_layer_selection_signals)
+            self._connect(self.arpLayerCombo.layerChanged, self.connect_layer_selection_signals)  # #131
             self._connect(self.runwayLayerCombo.layerChanged, self.validate_layer_change)
             self._connect(self.thresholdLayerCombo.layerChanged, self.validate_layer_change)
+            self._connect(self.arpLayerCombo.layerChanged, self.validate_layer_change)  # #131
 
             self._connect(self.calculateButton.clicked, self.on_calculate_clicked)
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
@@ -157,8 +166,9 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         lineedit_names = [
             'spin_rwyWidth_ofs', 'spin_distThr_ofs', 'spin_innerEdge_ofs',
             'spin_divergence_ofs', 'spin_length_ofs', 'spin_slope_ofs',
-            'spin_Z0_ofs', 'spin_ZE_ofs', 'spin_ARPH_ofs', 'spin_contour_interval_ofs',
-            'spin_widthApp_oes', 'spin_Z0_oes', 'spin_ZE_oes', 'spin_ARPH_oes', 'spin_slope_oes',
+            'spin_Z0_ofs', 'spin_ZE_ofs', 'spin_contour_interval_ofs',
+            'spin_widthApp_oes', 'spin_Z0_oes', 'spin_ZE_oes', 'spin_slope_oes',
+            'spin_ARP_elevation',  # #131 — shared ARP elevation field
         ]
         decimal_pattern = r'^-?\d*(?:\.\d*)?$'
         validator = QRegularExpressionValidator(QRegularExpression(decimal_pattern))
@@ -202,6 +212,12 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self.thresholdLayerCombo.setExceptedLayerList([])
             self.thresholdLayerCombo.setShowCrs(False)
             self.thresholdLayerCombo.setAllowEmptyLayer(False)
+            # ARP layer is optional (#131) — most surfaces only need the
+            # shared elevation number, not the layer geometry.
+            self.arpLayerCombo.setFilters(QgsMapLayerProxyModel.VectorLayer)
+            self.arpLayerCombo.setExceptedLayerList([])
+            self.arpLayerCombo.setShowCrs(False)
+            self.arpLayerCombo.setAllowEmptyLayer(True)
             self.apply_geometry_filters()
             self._connect(QgsProject.instance().layersAdded, self.apply_geometry_filters)
             self._connect(QgsProject.instance().layersRemoved, self.apply_geometry_filters)
@@ -216,8 +232,10 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             ]
             runway_excluded = [lyr for lyr in vector_layers if lyr.geometryType() != QgsWkbTypes.LineGeometry]
             threshold_excluded = [lyr for lyr in vector_layers if lyr.geometryType() != QgsWkbTypes.PointGeometry]
+            arp_excluded = [lyr for lyr in vector_layers if lyr.geometryType() != QgsWkbTypes.PointGeometry]  # #131
             self.runwayLayerCombo.setExceptedLayerList(runway_excluded)
             self.thresholdLayerCombo.setExceptedLayerList(threshold_excluded)
+            self.arpLayerCombo.setExceptedLayerList(arp_excluded)
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
@@ -225,6 +243,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         try:
             self.runwayLayerCombo.setStyleSheet("")
             self.thresholdLayerCombo.setStyleSheet("")
+            self.arpLayerCombo.setStyleSheet("")  # #131
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
@@ -234,13 +253,17 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(QgsProject.instance().layersRemoved, self.update_dropdown_item_tooltips)
             self._connect(self.runwayLayerCombo.layerChanged, self.update_dropdown_item_tooltips)
             self._connect(self.thresholdLayerCombo.layerChanged, self.update_dropdown_item_tooltips)
+            self._connect(self.arpLayerCombo.layerChanged, self.update_dropdown_item_tooltips)  # #131
             try:
                 runway_view = self.runwayLayerCombo.view()
                 threshold_view = self.thresholdLayerCombo.view()
+                arp_view = self.arpLayerCombo.view()  # #131
                 runway_view.setMouseTracking(True)
                 threshold_view.setMouseTracking(True)
+                arp_view.setMouseTracking(True)  # #131
                 runway_view.installEventFilter(self)
                 threshold_view.installEventFilter(self)
+                arp_view.installEventFilter(self)  # #131
             except Exception as e:
                 logger.warning(f"Unhandled error: {e}")
             self.update_dropdown_item_tooltips()
@@ -251,11 +274,14 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         try:
             current_runway_count = self.runwayLayerCombo.count()
             current_threshold_count = self.thresholdLayerCombo.count()
+            current_arp_count = self.arpLayerCombo.count()  # #131
             if (current_runway_count == self._last_runway_count
-                    and current_threshold_count == self._last_threshold_count):
+                    and current_threshold_count == self._last_threshold_count
+                    and current_arp_count == self._last_arp_count):
                 return
             self._last_runway_count = current_runway_count
             self._last_threshold_count = current_threshold_count
+            self._last_arp_count = current_arp_count  # #131
             try:
                 runway_model = self.runwayLayerCombo.model()
                 for i in range(self.runwayLayerCombo.count()):
@@ -281,9 +307,22 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                             self.thresholdLayerCombo.setItemData(i, tooltip, TOOLTIP_ROLE)
                         except (AttributeError, TypeError):
                             pass
+                arp_model = self.arpLayerCombo.model()  # #131
+                for i in range(self.arpLayerCombo.count()):
+                    layer = self.arpLayerCombo.layer(i)
+                    if layer:
+                        tooltip = (f"Layer: {layer.name()}\n"
+                                   f"Type: {self.get_geometry_type_name(layer)}\n"
+                                   f"Features: {layer.featureCount()}")
+                        arp_model.setData(arp_model.index(i, 0), tooltip, TOOLTIP_ROLE)
+                        try:
+                            self.arpLayerCombo.setItemData(i, tooltip, TOOLTIP_ROLE)
+                        except (AttributeError, TypeError):
+                            pass
                 try:
                     self.runwayLayerCombo.view().update()
                     self.thresholdLayerCombo.view().update()
+                    self.arpLayerCombo.view().update()
                 except AttributeError:
                     pass
             except Exception as e:
@@ -322,11 +361,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     def eventFilter(self, obj, event):
         try:
             if event.type() == EVENT_MOUSE_MOVE:
-                if obj in (self.runwayLayerCombo.view(), self.thresholdLayerCombo.view()):
+                _combo_views = {
+                    self.runwayLayerCombo.view(): self.runwayLayerCombo,
+                    self.thresholdLayerCombo.view(): self.thresholdLayerCombo,
+                    self.arpLayerCombo.view(): self.arpLayerCombo,  # #131
+                }
+                if obj in _combo_views:
                     index = obj.indexAt(event.pos())
                     if index.isValid():
-                        is_runway = obj == self.runwayLayerCombo.view()
-                        combo = self.runwayLayerCombo if is_runway else self.thresholdLayerCombo
+                        combo = _combo_views[obj]
                         layer = combo.layer(index.row())
                         if layer:
                             tooltip = (f"Layer: {layer.name()}\n"
@@ -621,9 +664,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         try:
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
+            arp_layer = self.arpLayerCombo.currentLayer()  # #131
             use_runway_selected = self.useSelectedRunwayCheckBox.isChecked()
             use_threshold_selected = self.useSelectedThresholdCheckBox.isChecked()
+            use_arp_selected = self.useSelectedArpCheckBox.isChecked()  # #131
             direction = 0 if self.direction_start_to_end else -1
+
+            # ARP elevation is now a single shared field for both tabs (#131)
+            # instead of the separate spin_ARPH_ofs/spin_ARPH_oes fields.
+            arp_elevation_m = self.get_numeric_value('spin_ARP_elevation')
 
             ofs_oes_index = self.newOlsTabWidget.currentIndex()
             if ofs_oes_index == 0:
@@ -643,7 +692,6 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                     'slope_pct': self.get_numeric_value('spin_slope_ofs'),
                     'start_elevation_m': z0_calc,
                     'end_elevation_m': ze_calc,
-                    'arp_elevation_m': self.get_numeric_value('spin_ARPH_ofs'),
                     'direction': s_value,
                     'contour_interval_m': int(round(self.get_numeric_value('spin_contour_interval_ofs'))),
                 }
@@ -653,7 +701,10 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                 specific_params = {
                     'width_m': self.get_numeric_value('spin_widthApp_oes'),
                     'start_elevation_m': self.get_numeric_value('spin_Z0_oes'),
-                    'highest_thr_elev_m': self.get_numeric_value('spin_ARPH_oes'),
+                    # highest_thr_elev_m: this script's own name for the Z
+                    # ceiling, now sourced from the shared ARP elevation (#131)
+                    # instead of its own spin_ARPH_oes field.
+                    'highest_thr_elev_m': arp_elevation_m,
                     'slope_pct': self.get_numeric_value('spin_slope_oes'),
                     'cap_height_m': 60.0,
                     'approach_slope_pct': self.get_numeric_value('spin_slope_ofs'),
@@ -666,9 +717,12 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                 'surface_type': surface_type,
                 'runway_layer': runway_layer,
                 'threshold_layer': threshold_layer,
+                'arp_layer': arp_layer,  # #131
                 'use_runway_selected': use_runway_selected,
                 'use_threshold_selected': use_threshold_selected,
+                'use_arp_selected': use_arp_selected,  # #131
                 'direction': direction,
+                'arp_elevation_m': arp_elevation_m,  # #131
                 'specific_params': specific_params,
             }
 
@@ -733,8 +787,10 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         try:
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
+            arp_layer = self.arpLayerCombo.currentLayer()  # #131
             use_runway_selected = self.useSelectedRunwayCheckBox.isChecked()
             use_threshold_selected = self.useSelectedThresholdCheckBox.isChecked()
+            use_arp_selected = self.useSelectedArpCheckBox.isChecked()  # #131
 
             if runway_layer:
                 runway_selected = len(runway_layer.selectedFeatures())
@@ -756,6 +812,17 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             else:
                 threshold_status = "No layer"
 
+            # ARP is optional (#131) — "No layer" is a neutral state, not an error
+            if arp_layer:
+                arp_selected = len(arp_layer.selectedFeatures())
+                arp_total = arp_layer.featureCount()
+                if use_arp_selected:
+                    arp_status = f"Selected ({arp_selected})" if arp_selected > 0 else "No selection"
+                else:
+                    arp_status = f"All ({arp_total})"
+            else:
+                arp_status = "No layer"
+
             _is_dark = QApplication.palette().window().color().lightness() < 128
             _c_warn = "#FFA726" if _is_dark else "#E65100"
             _c_ok = "#66BB6A" if _is_dark else "#2E7D32"
@@ -776,11 +843,20 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             else:
                 threshold_icon, threshold_style = "✘", f"QLabel {{ color: {_c_err}; {_base_style} }}"
 
+            if "All" in arp_status:
+                arp_icon, arp_style = "⚠", f"QLabel {{ color: {_c_warn}; {_base_style} }}"
+            elif "Selected" in arp_status:
+                arp_icon, arp_style = "✔", f"QLabel {{ color: {_c_ok}; {_base_style} }}"
+            else:
+                arp_icon, arp_style = "•", f"QLabel {{ {_base_style} }}"
+
             try:
                 self.runwaySelectionStatusLabel.setText(f"{runway_icon} {runway_status}")
                 self.runwaySelectionStatusLabel.setStyleSheet(runway_style)
                 self.thresholdSelectionStatusLabel.setText(f"{threshold_icon} {threshold_status}")
                 self.thresholdSelectionStatusLabel.setStyleSheet(threshold_style)
+                self.arpSelectionStatusLabel.setText(f"{arp_icon} {arp_status}")
+                self.arpSelectionStatusLabel.setStyleSheet(arp_style)
             except Exception as e:
                 logger.warning(f"Unhandled error: {e}")
 
@@ -791,6 +867,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             try:
                 self.runwaySelectionStatusLabel.setText("❌ Error")
                 self.thresholdSelectionStatusLabel.setText("❌ Error")
+                self.arpSelectionStatusLabel.setText("❌ Error")
             except (AttributeError, RuntimeError):
                 pass
 
@@ -798,6 +875,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         try:
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
+            arp_layer = self.arpLayerCombo.currentLayer()  # #131
             if runway_layer and runway_layer.geometryType() != QgsWkbTypes.LineGeometry:
                 self.show_error_message(
                     f"Invalid Runway Layer Centerline!\n"
@@ -814,6 +892,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                 )
                 self.thresholdLayerCombo.setLayer(None)
                 return
+            # ARP is optional (#131) — only validated when actually set
+            if arp_layer and arp_layer.geometryType() != QgsWkbTypes.PointGeometry:
+                self.show_error_message(
+                    f"Invalid ARP Layer!\n"
+                    f"'{arp_layer.name()}' contains {self.get_layer_geometry_info(arp_layer)} geometry.\n"
+                    f"ARP Layer must contain POINT geometry."
+                )
+                self.arpLayerCombo.setLayer(None)
+                return
             self.update_selection_info()
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
@@ -824,6 +911,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         try:
             runway_layer = self.runwayLayerCombo.currentLayer()
             threshold_layer = self.thresholdLayerCombo.currentLayer()
+            arp_layer = self.arpLayerCombo.currentLayer()  # #131
             if runway_layer and isinstance(runway_layer, QgsVectorLayer):
                 self._runway_selection_slot = lambda *_: self.update_selection_info()
                 runway_layer.selectionChanged.connect(self._runway_selection_slot)
@@ -836,6 +924,12 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                 self.connected_threshold_layer = threshold_layer
             else:
                 self._threshold_selection_slot = None
+            if arp_layer and isinstance(arp_layer, QgsVectorLayer):  # #131
+                self._arp_selection_slot = lambda *_: self.update_selection_info()
+                arp_layer.selectionChanged.connect(self._arp_selection_slot)
+                self.connected_arp_layer = arp_layer
+            else:
+                self._arp_selection_slot = None
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
@@ -855,6 +949,13 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                     pass
                 self.connected_threshold_layer = None
                 self._threshold_selection_slot = None
+            if self.connected_arp_layer and self._arp_selection_slot:  # #131
+                try:
+                    self.connected_arp_layer.selectionChanged.disconnect(self._arp_selection_slot)
+                except RuntimeError:
+                    pass
+                self.connected_arp_layer = None
+                self._arp_selection_slot = None
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 

--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -170,6 +170,74 @@
         </widget>
        </item>
 
+       <!-- ARP (Aerodrome Reference Point) LAYER + ELEVATION (#131) -->
+       <item>
+        <widget class="QFrame" name="arpFrame">
+         <property name="frameShape"><enum>QFrame::StyledPanel</enum></property>
+         <layout class="QVBoxLayout" name="arpCompactLayout">
+          <property name="spacing"><number>4</number></property>
+          <property name="margin"><number>4</number></property>
+          <item>
+           <widget class="QLabel" name="arpTitleLabel">
+            <property name="text"><string>ARP Layer</string></property>
+            <property name="styleSheet"><string>QLabel { font-weight: bold; }</string></property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="arpControlLayout">
+            <property name="spacing"><number>8</number></property>
+            <item>
+             <widget class="QgsMapLayerComboBox" name="arpLayerCombo">
+              <property name="minimumHeight"><number>24</number></property>
+              <property name="maximumHeight"><number>28</number></property>
+              <property name="toolTip"><string>Select the layer containing the Aerodrome Reference Point (ARP). Optional unless the active surface requires it.</string></property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch><verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="useSelectedArpCheckBox">
+              <property name="text"><string>Selected Only</string></property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch><verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="arpSelectionStatusLabel">
+            <property name="text"><string>No layer</string></property>
+            <property name="styleSheet"><string>QLabel { font-weight: bold; font-size: 11px; }</string></property>
+            <property name="minimumHeight"><number>16</number></property>
+            <property name="maximumHeight"><number>16</number></property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="arpElevationLayout">
+            <property name="spacing"><number>8</number></property>
+            <item>
+             <widget class="QLabel" name="label_ARP_elevation">
+              <property name="text"><string>ARP Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="spin_ARP_elevation">
+              <property name="text"><string>2548.00</string></property>
+              <property name="toolTip"><string>Aerodrome Reference Point elevation, shared by the OFS and OES tabs.</string></property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
       </layout>
      </widget>
     </item>
@@ -313,36 +381,25 @@
         </item>
 
         <item row="10" column="0">
-         <widget class="QLabel" name="label_ARPH_ofs">
-          <property name="text"><string>ARPH (m):</string></property>
-         </widget>
-        </item>
-        <item row="10" column="1">
-         <widget class="QLineEdit" name="spin_ARPH_ofs">
-          <property name="text"><string>2548.00</string></property>
-         </widget>
-        </item>
-
-        <item row="11" column="0">
          <widget class="QLabel" name="label_contour_interval_ofs">
           <property name="text"><string>Contour Interval (m):</string></property>
          </widget>
         </item>
-        <item row="11" column="1">
+        <item row="10" column="1">
          <widget class="QLineEdit" name="spin_contour_interval_ofs">
           <property name="text"><string>10</string></property>
           <property name="toolTip"><string>Elevation interval for contour lines. Set to 0 to disable.</string></property>
          </widget>
         </item>
 
-        <item row="12" column="0" colspan="2">
+        <item row="11" column="0" colspan="2">
          <widget class="QPushButton" name="btn_adg_help">
           <property name="text"><string>ADG Reference Table</string></property>
           <property name="toolTip"><string>Show the Aeroplane Design Group (ADG) reference table (ICAO Table 1-2)</string></property>
          </widget>
         </item>
 
-        <item row="13" column="0" colspan="2">
+        <item row="12" column="0" colspan="2">
          <widget class="QLabel" name="label_approach_note_ofs">
           <property name="text">
            <string>Note: The OFS Approach surface establishes the airspace to be maintained free from obstacles during the visual approach phase.</string>
@@ -399,30 +456,18 @@
         </item>
 
         <item row="3" column="0">
-         <widget class="QLabel" name="label_ARPH_oes">
-          <property name="text"><string>Highest THR Elev (m):</string></property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="spin_ARPH_oes">
-          <property name="text"><string>2548.00</string></property>
-          <property name="toolTip"><string>Elevation of the highest threshold. Upper edge = this + 60 m.</string></property>
-         </widget>
-        </item>
-
-        <item row="4" column="0">
          <widget class="QLabel" name="label_slope_oes">
           <property name="text"><string>Slope (%):</string></property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="3" column="1">
          <widget class="QLineEdit" name="spin_slope_oes">
           <property name="text"><string>20.00</string></property>
           <property name="toolTip"><string>Transitional surface slope in percent. Default 20%.</string></property>
          </widget>
         </item>
 
-        <item row="5" column="0" colspan="2">
+        <item row="4" column="0" colspan="2">
          <widget class="QLabel" name="label_oes_note">
           <property name="text">
            <string>Upper edge at 60 m above the highest threshold elevation. Lateral extent = 60 / (slope/100) from approach edge.</string>

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -299,7 +299,121 @@
          </layout>
         </widget>
        </item>
-       
+
+       <!-- ARP (Aerodrome Reference Point) LAYER + ELEVATION (#131) -->
+       <item>
+        <widget class="QFrame" name="arpFrame">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+
+         <layout class="QVBoxLayout" name="arpCompactLayout">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="margin">
+           <number>4</number>
+          </property>
+
+          <!-- Title Row -->
+          <item>
+           <widget class="QLabel" name="arpTitleLabel">
+            <property name="text">
+             <string>ARP Layer</string>
+            </property>
+            <property name="styleSheet">
+             <string>QLabel { font-weight: bold; }</string>
+            </property>
+           </widget>
+          </item>
+
+          <!-- Horizontal Control Row -->
+          <item>
+           <layout class="QHBoxLayout" name="arpControlLayout">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <item>
+             <widget class="QgsMapLayerComboBox" name="arpLayerCombo">
+              <property name="minimumHeight">
+               <number>24</number>
+              </property>
+              <property name="maximumHeight">
+               <number>28</number>
+              </property>
+              <property name="toolTip">
+               <string>Select the layer containing the Aerodrome Reference Point (ARP). Optional unless the active surface requires it (e.g. Outer Horizontal). This layer should contain a point feature representing the ARP.</string>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="useSelectedArpCheckBox">
+              <property name="text">
+               <string>Selected Only</string>
+              </property>
+              <property name="toolTip">
+               <string>Check to use only the selected ARP feature instead of all features in the layer</string>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+
+          <!-- Status Row -->
+          <item>
+           <widget class="QLabel" name="arpSelectionStatusLabel">
+            <property name="text">
+             <string>No layer</string>
+            </property>
+            <property name="styleSheet">
+             <string>QLabel { font-weight: bold; font-size: 11px; }</string>
+            </property>
+            <property name="minimumHeight"><number>16</number></property>
+            <property name="maximumHeight"><number>16</number></property>
+           </widget>
+          </item>
+
+          <!-- ARP Elevation Row -->
+          <item>
+           <layout class="QHBoxLayout" name="arpElevationLayout">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_ARP_elevation">
+              <property name="text">
+               <string>ARP Elevation (m):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="spin_ARP_elevation">
+              <property name="text">
+               <string>2548.00</string>
+              </property>
+              <property name="toolTip">
+               <string>Aerodrome Reference Point elevation, shared by every surface that needs a Z datum (Approach, OFZ, Transitional, Take-Off, Outer Horizontal).</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
    <!-- Removed combined selection status label (replaced by per-layer labels in frames) -->
       </layout>
      </widget>
@@ -463,71 +577,56 @@
          </widget>
         </item>
         <item row="5" column="0">
-         <widget class="QLabel" name="label_ARPH">
-          <property name="text">
-           <string>ARPH (m):</string>
-          </property>
-          
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLineEdit" name="spin_ARPH">
-          <property name="text">
-           <string>15.00</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
          <widget class="QLabel" name="label_L1">
           <property name="text">
           <string>First section (m)</string>
           </property>
-          
+
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="5" column="1">
          <widget class="QLineEdit" name="spin_L1">
           <property name="text">
            <string>3000.0</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="label_L2">
           <property name="text">
           <string>Second section (m)</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
+        <item row="6" column="1">
          <widget class="QLineEdit" name="spin_L2">
           <property name="text">
            <string>3600.0</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="label_LH">
           <property name="text">
           <string>Horizontal section (m)</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
+        <item row="7" column="1">
          <widget class="QLineEdit" name="spin_LH">
           <property name="text">
            <string>8400.0</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="0">
+        <item row="8" column="0">
          <widget class="QLabel" name="label_contour_interval">
           <property name="text">
            <string>Contour Interval (m):</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="1">
+        <item row="8" column="1">
          <widget class="QLineEdit" name="spin_contour_interval">
           <property name="text">
            <string>10</string>
@@ -913,27 +1012,13 @@
          </widget>
         </item>
         <item row="6" column="0">
-         <widget class="QLabel" name="label_ARPH_ofz">
-          <property name="text">
-           <string>ARPH (m):</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="spin_ARPH_ofz">
-          <property name="text">
-           <string>2548.0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
          <widget class="QLabel" name="label_IHSlope_ofz">
           <property name="text">
            <string>Inner Transitional Slope (%):</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
+        <item row="6" column="1">
          <widget class="QLineEdit" name="spin_IHSlope_ofz">
           <property name="text">
            <string>33.3</string>
@@ -941,7 +1026,7 @@
          </widget>
         </item>
    <!-- Not Applicable notice (hidden by default) -->
-   <item row="8" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="QLabel" name="label_not_applicable_ofz">
      <property name="text">
       <string>Not Applicable</string>
@@ -1047,24 +1132,7 @@
           </property>
          </widget>
         </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="label_arp_elevation_outer">
-                  <property name="text">
-                   <string>ARP Elevation (m):</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QLineEdit" name="spin_arp_elevation_outer">
-                  <property name="text">
-                   <string>0.00</string>
-                  </property>
-                  <property name="toolTip">
-                   <string>Aerodrome Reference Point elevation. Outer Horizontal Z = ARP Elevation + Height.</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="0" colspan="2">
+                <item row="3" column="0" colspan="2">
                  <widget class="QLabel" name="label_info_outer">
                     <property name="text">
                      <string>Outer Horizontal Surface: 15,000 m circle centered on ARP
@@ -1198,31 +1266,19 @@
 
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_ARPH_transitional">
-          <property name="text">
-           <string>ARPH (m):</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLineEdit" name="spin_ARPH_transitional">
-
-         </widget>
-        </item>
-    <item row="6" column="0">
+    <item row="5" column="0">
      <widget class="QLabel" name="label_Tslope_transitional">
       <property name="text">
        <string>Slope (%):</string>
       </property>
      </widget>
     </item>
-        <item row="6" column="1">
+        <item row="5" column="1">
          <widget class="QLineEdit" name="spin_Tslope_transitional">
 
          </widget>
         </item>
-        <item row="7" column="0" colspan="2">
+        <item row="6" column="0" colspan="2">
          <widget class="QPushButton" name="button_rotate_transitional">
           <property name="text">
            <string>🔄 Runway Direction: Normal</string>
@@ -1257,7 +1313,7 @@ QPushButton:checked:hover {
           </property>
          </widget>
         </item>
-        <item row="8" column="0" colspan="2">
+        <item row="7" column="0" colspan="2">
          <widget class="QCheckBox" name="check_merge_transitional">
           <property name="text">
            <string>Create/update Merged Transitional Surface layer</string>
@@ -1272,14 +1328,14 @@ Must be checked on EVERY run you want included in the merge - including the firs
           </property>
          </widget>
         </item>
-        <item row="9" column="0">
+        <item row="8" column="0">
          <widget class="QLabel" name="label_contour_interval_transitional">
           <property name="text">
            <string>Contour Interval (m):</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="1">
+        <item row="8" column="1">
          <widget class="QLineEdit" name="spin_contour_interval_transitional">
           <property name="text">
            <string>10</string>


### PR DESCRIPTION
# feature(#131): ARP layer and elevation requested at the top

## Summary

Closes #131.

Issue #131 The ARP elevation doesn't change, this
is used by several scripts/tabs, so it seems to make more sense to move
to the top and reuse. This will require to adjust accordingly the
scripts making sure they are working ok. This same concept needs to be
introduced in the new OLS implementation."

Before this change, ARP elevation was duplicated across four separate
per-tab "ARPH (m)" fields (Approach, OFZ, Transitional, Outer Horizontal)
that the user had to keep in sync manually, plus two more in the New OLS
panel (OFS/OES). Outer Horizontal additionally had no dedicated ARP
layer selector at all — it silently repurposed the Threshold Layer combo
as its ARP point source, which the issue flagged as wrong.

Both dockwidgets now expose a single **ARP Layer** combo + **ARP
Elevation (m)** field under "Input Layers", next to Runway/Threshold,
reused by every surface that needs a Z datum.

---

## Changes

### `qols/ui/qols_panel_base.ui` / `qols/ui/new_ols_panel.ui`
Added a shared `arpFrame` (ARP Layer combo, "Selected Only" checkbox,
status label, and ARP Elevation field) to each panel's `layersGroup`,
mirroring the existing Runway/Threshold frame layout. Removed the 4
per-tab ARPH widgets from the classic panel (Approach, OFZ, Transitional,
Outer Horizontal) and the 2 from the New OLS panel (OFS, OES), with row
renumbering to close the resulting gaps in each `QFormLayout`.

### `qols/ui/dockwidget.py`
- `_WIDGET_DEFAULTS`, numeric-validation setup, `update_ofz_visibility`:
  removed the 4 per-tab ARPH entries, added one shared
  `spin_ARP_elevation`.
- Extended the existing Runway/Threshold layer-combo plumbing
  (`setup_layer_filters`, `apply_geometry_filters`,
  `setup_dropdown_tooltips`/`update_dropdown_item_tooltips`/
  `eventFilter`, `setup_enhanced_combos`, `update_selection_info`,
  `connect_layer_selection_signals`/`disconnect_layer_selection_signals`,
  `validate_layer_change`) to also manage `arpLayerCombo`. Unlike
  Runway/Threshold, an empty ARP layer is a valid, non-error state
  (`useSelectedArpCheckBox`, `setAllowEmptyLayer(True)`, "No layer"
  rendered as a neutral `•` status, not a red `✘`) — only surfaces that
  actually consume the layer (Outer Horizontal) enforce it, via their
  own script-level check, unchanged from before.
- `get_parameters()`: removed the per-tab ARPH reads from the
  Approach/OFZ/Transitional/Outer-Horizontal branches; reads the shared
  `spin_ARP_elevation` once and injects `arp_layer`, `use_arp_selected`,
  and the elevation value into the **top-level** `params` dict (like
  `runway_layer`/`threshold_layer` already are) under every legacy alias
  each script already reads via `globals().get(...)`: `arp_elevation_m`,
  `ARPH`, `arp_elevation`. This means **no script math changed** for
  Approach, OFZ, Transitional, or Take-Off — each already had its own
  `globals().get('ARPH', ...)` fallback — and Take-Off's previously
  unreachable `ARPH` (it never had a UI field, always fell back to a
  hardcoded `2548`) is now correctly wired for free.

### `qols/ui/new_ols_dockwidget.py`
Same pattern as above, scoped to this file's single shared
Runway/Threshold/ARP section for both OFS and OES tabs. `get_parameters()`
now reads the shared `spin_ARP_elevation` once; the OES branch's
`highest_thr_elev_m` (that script's own name for the same Z-ceiling
concept) is sourced from it directly instead of its own now-removed
`spin_ARPH_oes` field.

### `qols/scripts/outer-horizontal.py`
The one real script-level fix: switched from
`globals().get('threshold_layer')` / `use_threshold_selected` to
`globals().get('arp_layer')` / `use_arp_selected`, so the 15,000 m circle
is now centered on the actual ARP layer instead of the Threshold layer.
Error messages updated to reference the ARP Layer combo. The elevation
read (`globals().get('arp_elevation', 0.0)`) needed no change — it
already reads the alias the dockwidget now populates from the shared
field.

### `qols/plugin.py`
`execute_new_ols_ofs_approach`: `highest_thr_elev_m` (forwarded into the
paired OES-transitional run) now reads `params.get('arp_elevation_m',
0.0)` — the shared top-level value — instead of
`ofs.get('arp_elevation_m', 0.0)`, since the OFS tab's `specific_params`
no longer carries that key.

### `tests/test_dockwidget_logic.py` (gitignored, not part of this diff)
Added `arpLayerCombo`/`useSelectedArpCheckBox`/`spin_ARP_elevation`
defaults to the shared `_make_wgt()` fixture so every existing
`get_parameters()`/`connect_layer_selection_signals()` test keeps
working with the new combo present; removed the now-stale
`label_ARPH_ofz`/`spin_ARPH_ofz`/`spin_ARPH`/`spin_ARPH_transitional`
references left over from the removed per-tab widgets.

---

## Out of scope (per the issue's own screenshots)

- Conical/Inner Horizontal's `datum_elevation`/`spin_datum_inner_conical`
  (added in #125) is a separate, already-shared field, not marked in the
  issue's screenshots — left untouched.
- `qols/qols_dockwidget.py` (top-level, ~2000 lines) is dead code —
  nothing imports it (the live classic panel is `qols/ui/dockwidget.py`).
  Not touched.

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 551 passed

flake8 qols/ui/dockwidget.py qols/ui/new_ols_dockwidget.py qols/scripts/outer-horizontal.py qols/plugin.py
# outer-horizontal.py / plugin.py: 0 issues
# dockwidget.py / new_ols_dockwidget.py: 4 pre-existing findings total
# (2x F821 dead-code New OLS defaults methods in dockwidget.py, F401
# unused QPushButton + F821 show_project_parameters_table in
# new_ols_dockwidget.py), confirmed byte-identical via `git stash`
# before/after — none introduced by this change.
```

Both `.ui` files were validated with `xml.dom.minidom.parse()` after
every edit; all touched `.py` files pass `ast.parse()`.

Manual QGIS check (pending): confirm the "ARP Layer" section appears
under Input Layers on both panels; confirm
Approach/OFZ/Transitional/Take-Off calculate correctly using only the
shared "ARP Elevation (m)" field (no ARP layer selected); confirm Outer
Horizontal now requires and correctly uses the ARP Layer combo (not
Threshold) for its circle center; confirm the per-tab ARPH fields are
gone from all 4 classic tabs and both New OLS tabs; confirm the New OLS
combined Calculate flow (OFS + OES together) still uses the shared
elevation as the OES cap datum.