### PR TITLE
feature(#134): Horizontal Surface (New OLS) — OES tab

### DIFF
--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -198,7 +198,11 @@ class QOLS:
             if st == SurfaceType.NEW_OLS_OFS_APPROACH:
                 self.execute_new_ols_ofs_approach(params)
             elif st == SurfaceType.NEW_OLS_OES_TRANSITIONAL:
-                self.execute_new_ols_oes_transitional(params)
+                # #134: Transitional is an OFS-only concept (it flanks the
+                # OFS Approach surface and already runs from that tab's
+                # Calculate via execute_new_ols_ofs_approach). The OES tab
+                # only computes Horizontal Surface — no Transitional here.
+                self.execute_new_ols_oes_horizontal(params)
             else:
                 raise ValueError(f"Unhandled New OLS surface type: {st!r}")
 
@@ -385,6 +389,19 @@ class QOLS:
     def execute_new_ols_oes_transitional(self, params):
         script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-transitional-UTM.py')
         self.execute_script(script_path, params)
+
+    def execute_new_ols_oes_horizontal(self, params):
+        """Horizontal Surface (#134) — a distinct surface from Transitional,
+        just sharing the OES tab's inputs (ADG, aerodrome elevation)."""
+        oes = params.get('specific_params', {})
+        horiz_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-horizontal-UTM.py')
+        horiz_params = params.copy()
+        horiz_params['specific_params'] = {
+            'adg': oes.get('adg', 'IIC'),
+            'aerodrome_elevation_m': oes.get('highest_thr_elev_m', 0.0),
+            'direction': oes.get('direction', 0),
+        }
+        self.execute_script(horiz_path, horiz_params)
 
     def execute_combined_inner_conical_surface(self, params):
         """Execute Inner Horizontal then Conical using per-surface parameters,

--- a/qols/scripts/new-ols-oes-horizontal-UTM.py
+++ b/qols/scripts/new-ols-oes-horizontal-UTM.py
@@ -1,0 +1,251 @@
+"""
+New OLS Concept — OES Horizontal Surface
+ICAO Annex 14 Table 4-10 (Dimensions of horizontal surface), keyed by
+Aeroplane Design Group (ADG). Selecting a higher ADG retains every lower
+tier's ring too (see qols/surfaces/new_ols_horizontal.py), so 1-3
+concentric racetrack rings — each at its own height above the aerodrome
+elevation — are drawn into a single output layer.
+
+Geometry construction mirrors qols/scripts/inner-horizontal-racetrack.py
+exactly (same coord()/coord2() trig closures, same 2-arc/2-line closed
+racetrack), just repeated once per ring instead of once total.
+
+Procedure to be used in Projected Coordinate System Only.
+"""
+myglobals = set(globals().keys())
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from qgis.gui import *
+import math
+from math import sqrt
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+from qols.surfaces.new_ols_horizontal import get_horizontal_surface_rings
+
+_script_success = False
+
+
+def _normalize_polyline_points(geometry):
+    if geometry is None or geometry.isEmpty():
+        raise Exception("Empty geometry provided for runway centerline.")
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            raise Exception("Empty MultiLineString geometry.")
+
+        def length_of(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                dx = pts[i].x() - pts[i - 1].x()
+                dy = pts[i].y() - pts[i - 1].y()
+                total += sqrt(dx * dx + dy * dy)
+            return total
+        return [QgsPoint(p) for p in max(parts, key=length_of)]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [QgsPoint(p) for p in poly]
+    raise Exception("Line geometry cannot be converted to a polyline.")
+
+
+def _racetrack_ring(start_point, end_point, angle0, back_angle0, radius, z_absolute, trto, trfm):
+    """Builds one closed racetrack ring (list of WKT 'x y z' strings) at
+    the given radius/Z, using the same coord()/coord2() trig + circular-arc
+    interpolation as inner-horizontal-racetrack.py."""
+
+    def coord(angle0, dist1, off):
+        bearing = angle0 + off
+        angle = math.radians(90 - bearing)
+        bearing = math.radians(bearing)
+        dist_x, dist_y = (dist1 * math.cos(angle), dist1 * math.sin(angle))
+        xfinal, yfinal = (start_point.x() + dist_x, start_point.y() + dist_y)
+        return trto.transform(trfm.transform(xfinal, yfinal))
+
+    def coord2(angle0, dist1, off):
+        bearing = angle0 + off
+        angle = math.radians(90 - bearing)
+        bearing = math.radians(bearing)
+        dist_x, dist_y = (dist1 * math.cos(angle), dist1 * math.sin(angle))
+        xfinal, yfinal = (end_point.x() + dist_x, end_point.y() + dist_y)
+        return trto.transform(trfm.transform(xfinal, yfinal))
+
+    pro_coords = coord(angle0, radius, -90)   # Starting point left
+    x2 = coord(angle0, radius, 90)            # Starting point right
+    xc = coord(angle0, radius, 0)             # Starting center point
+    x4 = coord2(back_angle0, radius, 90)      # Ending point right
+    x5 = coord2(back_angle0, radius, 0)       # Ending center point
+    x6 = coord2(back_angle0, radius, -90)     # Ending point left
+
+    polygon_points = []
+
+    def _append_arc(p1, p2, p3, skip_first):
+        cstring = QgsCircularString()
+        cstring.setPoints([QgsPoint(p1[0], p1[1]), QgsPoint(p2[0], p2[1]), QgsPoint(p3[0], p3[1])])
+        segmented = QgsGeometry(cstring).convertToType(QgsWkbTypes.LineGeometry, True)
+        pts = []
+        if segmented:
+            if segmented.wkbType() == QgsWkbTypes.LineString:
+                pts = list(segmented.asPolyline())
+            elif segmented.wkbType() == QgsWkbTypes.MultiLineString:
+                for part in segmented.asMultiPolyline():
+                    pts.extend(part)
+        if not pts:
+            pts = [QgsPointXY(p1[0], p1[1]), QgsPointXY(p2[0], p2[1]), QgsPointXY(p3[0], p3[1])]
+        for i, pt in enumerate(pts):
+            if skip_first and i == 0:
+                continue
+            polygon_points.append(QgsPoint(pt.x(), pt.y(), z_absolute))
+
+    _append_arc(pro_coords, xc, x2, skip_first=False)
+    polygon_points.append(QgsPoint(x6[0], x6[1], z_absolute))
+    _append_arc(x6, x5, x4, skip_first=True)
+    polygon_points.append(QgsPoint(pro_coords[0], pro_coords[1], z_absolute))
+
+    return [f"{pt.x()} {pt.y()} {pt.z()}" for pt in polygon_points]
+
+
+# ---------------------------------------------------------------------------
+# Parameter extraction
+# ---------------------------------------------------------------------------
+try:
+    adg = globals().get('adg', 'IIC')
+    aerodrome_elevation_m = globals().get('aerodrome_elevation_m', 0.0)
+    direction = globals().get('direction', 0)
+    runway_layer = globals().get('runway_layer', None)
+    use_runway_selected = globals().get('use_runway_selected', True)
+except Exception as e:
+    print(f"NewOLS_OES_Horizontal: Error getting parameters, using defaults: {e}")
+    adg = 'IIC'
+    aerodrome_elevation_m = 0.0
+    direction = 0
+    runway_layer = None
+    use_runway_selected = True
+
+rings = get_horizontal_surface_rings(adg)
+print(f"NewOLS_OES_Horizontal: ADG={adg} -> {len(rings)} ring(s): {rings}")
+
+map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+source_crs = QgsCoordinateReferenceSystem(4326)
+dest_crs = QgsCoordinateReferenceSystem(map_srid)
+trto = QgsCoordinateTransform(source_crs, dest_crs, QgsProject.instance())
+trfm = QgsCoordinateTransform(dest_crs, source_crs, QgsProject.instance())
+
+if runway_layer is None:
+    raise Exception("No Runway Layer Centerline provided. Please select a Runway Layer Centerline from the UI.")
+
+if use_runway_selected:
+    selection = runway_layer.selectedFeatures()
+    if not selection:
+        raise Exception("No runway features selected. Please select runway features.")
+else:
+    selection = list(runway_layer.getFeatures())
+    if not selection:
+        raise Exception("No features found in Runway Layer Centerline.")
+
+# ---------------------------------------------------------------------------
+# Memory layer — all rings for all runway features go into this one layer
+# ---------------------------------------------------------------------------
+layer_name = "NewOLS_OES_Horizontal"
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", layer_name, "memory")
+v_layer_provider = v_layer.dataProvider()
+v_layer_provider.addAttributes([
+    QgsField("surface_type", QVariant.String),
+    QgsField("adg", QVariant.String),
+    QgsField("radius_m", QVariant.Double),
+    QgsField("height_m", QVariant.Double),
+    QgsField("aerodrome_elevation_m", QVariant.Double),
+    QgsField("rule_set", QVariant.String),
+])
+v_layer.updateFields()
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('New OLS OES Horizontal Surface', {
+    'adg': adg,
+    'aerodrome_elevation_m': round(aerodrome_elevation_m, 3),
+    'rings': rings,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
+features = []
+for feat in selection:
+    line_pts = _normalize_polyline_points(feat.geometry())
+    start_point = QgsPoint(line_pts[0].x(), line_pts[0].y())
+    end_point = QgsPoint(line_pts[-1].x(), line_pts[-1].y())
+    angle0 = start_point.azimuth(end_point) + 180
+    if angle0 >= 360:
+        angle0 -= 360
+    if direction == -1:
+        angle0 = (angle0 + 180) % 360
+    back_angle0 = (angle0 + 180) % 360
+
+    # Draw largest ring first (bottom of the layer's render order) down to
+    # smallest last (on top) — every smaller/nearer ring's own fill+outline
+    # then stays visible on top of the larger ones instead of being covered
+    # by them, matching Figure 4-4's clearly bounded concentric zones.
+    for ring in reversed(rings):
+        radius_m = ring['radius_m']
+        height_m = ring['height_m']
+        z_absolute = aerodrome_elevation_m + height_m
+
+        wkt_points = _racetrack_ring(start_point, end_point, angle0, back_angle0, radius_m, z_absolute, trto, trfm)
+        polygon_geometry = QgsGeometry.fromWkt(f"POLYGONZ(({', '.join(wkt_points)}))")
+
+        feature = QgsFeature()
+        feature.setGeometry(polygon_geometry)
+        feature.setAttributes([
+            "New OLS OES Horizontal",
+            adg,
+            radius_m,
+            height_m,
+            aerodrome_elevation_m,
+            _active_rule_set,
+            _params_json,
+        ])
+        features.append(feature)
+        print(f"NewOLS_OES_Horizontal: Ring radius={radius_m}m height={height_m}m -> Z={z_absolute}m")
+
+v_layer_provider.addFeatures(features)
+v_layer.updateExtents()
+print(f"NewOLS_OES_Horizontal: Created {len(features)} ring feature(s)")
+
+register_parameters_action(v_layer)
+
+QgsProject.instance().addMapLayers([v_layer])
+
+symbol = QgsFillSymbol.createSimple({
+    'color': '32,178,170,90',  # Light sea green / teal, transparent
+    'style': 'solid',
+    'outline_color': '32,178,170,220',
+    'outline_style': 'solid',
+    'outline_width': '0.7',
+})
+v_layer.renderer().setSymbol(symbol)
+v_layer.triggerRepaint()
+
+if features:
+    v_layer.selectAll()
+    canvas = iface.mapCanvas()
+    canvas.zoomToSelected(v_layer)
+    v_layer.removeSelection()
+    sc = canvas.scale()
+    if sc < 50000:
+        sc = 50000
+    canvas.zoomScale(sc)
+
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+
+iface.messageBar().pushMessage(
+    "QOLS Success",
+    f"New OLS OES Horizontal Surface (ADG {adg}, {len(rings)} ring(s)) calculated successfully",
+    level=MSG_SUCCESS,
+)
+
+_script_success = True
+
+for _g in set(globals().keys()).difference(myglobals):
+    if _g not in ('myglobals', '_script_success'):
+        del globals()[_g]

--- a/qols/surfaces/new_ols_horizontal.py
+++ b/qols/surfaces/new_ols_horizontal.py
@@ -1,0 +1,75 @@
+"""New OLS concept — Horizontal Surface ICAO defaults.
+
+Table 4-10 (Dimensions of horizontal surface), keyed by Aeroplane Design
+Group (ADG). Unlike the Approach surface's Tables 4-1/4-2
+(``new_ols_approach.py``), which merge IIA and IIB into a single value
+set, Table 4-10 splits I/IIA into one tier and IIB into another — so ADG
+groups are kept fully separate here (``"I"``, ``"IIA"``, ``"IIB"``, ...)
+rather than reusing the OFS tab's merged ``"IIA-IIB"`` combo value.
+
+Per the ICAO note under the table: selecting a higher ADG group does not
+replace the lower groups' surfaces — all rings up to and including the
+selected group's tier are retained, each at its own height above the
+aerodrome elevation. Table 4-10 collapses to exactly 3 distinct
+radius/height tiers (IIC, III, IV and V all share the same values), so a
+single feature covers all of them rather than repeating identical rings.
+"""
+from typing import Dict, List
+
+# ---------------------------------------------------------------------------
+# ADG group constants
+# ---------------------------------------------------------------------------
+ADG_I = "I"
+ADG_IIA = "IIA"
+ADG_IIB = "IIB"
+ADG_IIC = "IIC"
+ADG_III = "III"
+ADG_IV = "IV"
+ADG_V = "V"
+
+ADG_GROUPS = [ADG_I, ADG_IIA, ADG_IIB, ADG_IIC, ADG_III, ADG_IV, ADG_V]
+
+# ---------------------------------------------------------------------------
+# Table 4-10  Dimensions of horizontal surface — 3 distinct tiers,
+# ascending radius/height, each retained by every higher ADG group.
+# ---------------------------------------------------------------------------
+_TIERS: List[Dict[str, float]] = [
+    {"radius_m": 3350.0, "height_m": 45.0},    # I, IIA
+    {"radius_m": 5350.0, "height_m": 60.0},    # IIB
+    {"radius_m": 10750.0, "height_m": 90.0},   # IIC, III, IV, V
+]
+
+_ADG_TIER_INDEX: Dict[str, int] = {
+    ADG_I: 0,
+    ADG_IIA: 0,
+    ADG_IIB: 1,
+    ADG_IIC: 2,
+    ADG_III: 2,
+    ADG_IV: 2,
+    ADG_V: 2,
+}
+
+
+def get_horizontal_surface_rings(adg: str) -> List[Dict[str, float]]:
+    """Return the cumulative list of rings for the given ADG group.
+
+    Args:
+        adg: Aeroplane Design Group (``"I"``, ``"IIA"``, ``"IIB"``,
+             ``"IIC"``, ``"III"``, ``"IV"``, or ``"V"``).
+
+    Returns:
+        A list of ``{"radius_m": float, "height_m": float}`` dicts,
+        ordered from smallest to largest, including every tier up to and
+        including the one for ``adg`` — e.g. ``"IIB"`` returns 2 rings
+        (I/IIA's tier and IIB's own), ``"IIC"`` returns all 3. An
+        unrecognized ``adg`` falls back to the largest (3-ring) tier.
+    """
+    idx = _ADG_TIER_INDEX.get(adg, 2)
+    return [dict(tier) for tier in _TIERS[: idx + 1]]
+
+
+__all__ = [
+    "ADG_I", "ADG_IIA", "ADG_IIB", "ADG_IIC", "ADG_III", "ADG_IV", "ADG_V",
+    "ADG_GROUPS",
+    "get_horizontal_surface_rings",
+]

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -74,6 +74,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     spin_ZE_oes: QLineEdit
     spin_ARPH_oes: QLineEdit
     spin_slope_oes: QLineEdit
+    combo_adg_horizontal_oes: QComboBox
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
 
@@ -660,6 +661,10 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                     'divergence_ratio': self.get_numeric_value('spin_divergence_ofs') / 100.0,
                     'distance_from_threshold_m': self.get_numeric_value('spin_distThr_ofs'),
                     'direction': s_value,
+                    # Horizontal Surface (#134) — ADG-driven ring set;
+                    # reuses highest_thr_elev_m (above) as its aerodrome
+                    # elevation datum instead of a separate field.
+                    'adg': self.combo_adg_horizontal_oes.currentText(),
                 }
 
             return {

--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -422,7 +422,27 @@
          </widget>
         </item>
 
-        <item row="5" column="0" colspan="2">
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_adg_horizontal_oes">
+          <property name="text"><string>ADG (Horizontal Surface):</string></property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QComboBox" name="combo_adg_horizontal_oes">
+          <property name="minimumHeight"><number>22</number></property>
+          <property name="currentIndex"><number>3</number></property>
+          <property name="toolTip"><string>Aeroplane Design Group for the Horizontal Surface (Table 4-10). Independent of the OFS tab's ADG Group — I/IIA, IIB, and IIC-V are distinct dimension tiers here.</string></property>
+          <item><property name="text"><string>I</string></property></item>
+          <item><property name="text"><string>IIA</string></property></item>
+          <item><property name="text"><string>IIB</string></property></item>
+          <item><property name="text"><string>IIC</string></property></item>
+          <item><property name="text"><string>III</string></property></item>
+          <item><property name="text"><string>IV</string></property></item>
+          <item><property name="text"><string>V</string></property></item>
+         </widget>
+        </item>
+
+        <item row="6" column="0" colspan="2">
          <widget class="QLabel" name="label_oes_note">
           <property name="text">
            <string>Upper edge at 60 m above the highest threshold elevation. Lateral extent = 60 / (slope/100) from approach edge.</string>


### PR DESCRIPTION
# feature(#134): Horizontal Surface (New OLS) — OES tab

## Summary

Closes #134.

Issue #134 "Include in OES tab. Surface similar to
the current horizontal surface (racetrack)... Use the parameters of
table 4-10 if the ADG is IIC, III, IV or V all the previous need to be
done, if its IIB then IIB and I-IIA if I-IIA then just that one... you
will not repeat IIC, III, IV and V but a single feature will cover it.
Put all in a single layer."

Adds a multi-ring racetrack surface to the New OLS panel's OES tab, per
ICAO Annex 14 Table 4-10 ("Dimensions of horizontal surface"). Selecting
a higher Aeroplane Design Group (ADG) retains every lower tier's ring:
ADG I/IIA → 1 ring (3350 m / 45 m), IIB → 2 rings (adds 5350 m / 60 m),
IIC/III/IV/V → 3 rings (adds 10750 m / 90 m — a single feature covers
all four of those groups since they share identical dimensions). All
rings are written to one `NewOLS_OES_Horizontal` memory layer.

---

## Changes

### `qols/surfaces/new_ols_horizontal.py` (new)
Pure-Python ADG → ring lookup, mirroring `new_ols_approach.py`'s shape
(constants + dict tables + one public function, no QGIS dependency).
Table 4-10 collapses to 3 distinct radius/height tiers; `ADG_IIA` and
`ADG_IIB` are kept as **separate** constants (unlike `new_ols_approach.py`'s
merged `ADG_IIA_IIB`), since Table 4-10 assigns them different tiers.
`get_horizontal_surface_rings(adg)` returns the cumulative ring list for
a given ADG, ordered smallest→largest, falling back to the largest tier
for an unrecognized value.

### `qols/ui/new_ols_panel.ui`
Added a new row to the OES tab: label + `combo_adg_horizontal_oes`
(items `I, IIA, IIB, IIC, III, IV, V`, default IIC). This is
**intentionally a separate combo** from the OFS tab's `combo_adg_ofs`
(which merges IIA/IIB into one item — correct for Tables 4-1/4-2, wrong
for Table 4-10, which needs the IIA/IIB distinction). No new elevation
field was added — reuses the tab's existing "Highest THR Elev (m)"
(`spin_ARPH_oes`) as the aerodrome-elevation datum, per the issue's
"height is above aerodrome elevation" requirement (confirmed with user:
reuse rather than add a second, easily-confused elevation field on the
same tab).

### `qols/ui/new_ols_dockwidget.py`
`get_parameters()`'s OES branch adds `'adg':
self.combo_adg_horizontal_oes.currentText()` to `specific_params`.

### `qols/plugin.py`
New `execute_new_ols_oes_horizontal(params)` method. `on_calculate_new_ols()`'s
`NEW_OLS_OES_TRANSITIONAL` branch (the OES tab's dispatch) now calls
**only** this method — Transitional is an OFS-only concept (it flanks
the OFS Approach surface and already runs from that tab's Calculate via
`execute_new_ols_ofs_approach`'s own inline `execute_script` call); the
OES tab never needed to compute it independently. `execute_new_ols_oes_transitional`
itself is left in place unchanged, but is no longer called from this
dispatch path. No new `SurfaceType` member needed — New OLS dispatch is
already tab-index-based, so Horizontal Surface is calculated whenever
Calculate is clicked while the OES tab is active, matching "Include in
OES tab" literally.

### `qols/scripts/new-ols-oes-horizontal-UTM.py` (new)
Adapts `inner-horizontal-racetrack.py`'s racetrack construction (same
`coord()`/`coord2()` trig closures, same 2-arc/2-line closed polygon via
`QgsCircularString` interpolation + `POLYGONZ` WKT) to loop once per
ring instead of once total: the runway centerline is normalized once,
then each ring from `get_horizontal_surface_rings(adg)` gets its own
feature at `Z = aerodrome_elevation_m + ring['height_m']`, all added to
a single `NewOLS_OES_Horizontal` memory layer in one `addFeatures()`
call. Styled distinctly (teal/light-sea-green) from both the classic
Inner Horizontal layer (magenta) and the New OLS Transitional layer (sky
blue) to avoid confusion. No geometric trimming/differencing between
rings — matches the issue's literal "single layer" ask without the more
involved hole-punching #124 added for Inner Horizontal + Conical.

### `tests/test_dockwidget_logic.py`
Added `TestGetHorizontalSurfaceRings` (10 new tests): each ADG value
returns the correct cumulative ring list, IIC/III/IV/V all collapse to
the identical 3-ring set, rings are ordered smallest→largest, unknown
ADG falls back to the largest tier, and returned rings are independent
copies (mutating one call's result doesn't corrupt the module table).

**Also reverted stale #131-era edits** to this same (gitignored, so
not git-tracked — edits persist across branch checkouts) fixture file:
since this branch is cut from `main` (pre-#131), `qols/ui/dockwidget.py`
here still reads `spin_ARPH`/`spin_ARPH_ofz`/`spin_ARPH_transitional`
directly and has no `arpLayerCombo` — the test file's `_make_wgt()`
fixture needed to match that, not #131's later ARP-consolidation state.

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 561 passed (551 baseline + 10 new get_horizontal_surface_rings tests)

flake8 qols/surfaces/new_ols_horizontal.py qols/scripts/new-ols-oes-horizontal-UTM.py qols/ui/new_ols_dockwidget.py qols/plugin.py
# new_ols_horizontal.py: 0 issues
# new-ols-oes-horizontal-UTM.py: F403/F405/E402 star-import findings —
#   same pre-existing class every other qols/scripts/*.py file carries
#   (confirmed by running flake8 on its sibling
#   new-ols-oes-transitional-UTM.py, which has ~45 of the same kind)
# new_ols_dockwidget.py: 2 pre-existing findings (F401 unused
#   QPushButton import, F821 show_project_parameters_table), confirmed
#   byte-identical via `git stash` before/after — none introduced here
# plugin.py: 0 issues
```

Manual QGIS check (pending): on the New OLS OES tab, select each ADG
value and confirm 1/2/3 concentric racetrack rings are drawn at the
correct radius/height relative to "Highest THR Elev (m)", all in a
single `NewOLS_OES_Horizontal` layer; confirm re-running Calculate
replaces the layer's rings; confirm the OFS tab and classic panel are
unaffected.

---

## Risk / notes

- New, isolated code paths — no existing script's math changed.
- `combo_adg_ofs` (OFS tab) is untouched; `combo_adg_horizontal_oes` is
  a deliberately separate, more granular selector used only for this
  calculation.
- This branch is based on `main` (pre-#131) — it does not include #131's
  ARP-layer consolidation, since that work lives on its own unmerged
  branch (`task/131-arp-layer-elevation-global`).
