### PR TITLE
fix(#131 followup): ARP Layer/Elevation must be first, not third

### DIFF
--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -70,6 +70,74 @@
        <property name="spacing"><number>6</number></property>
        <property name="margin"><number>2</number></property>
 
+       <!-- ARP (Aerodrome Reference Point) LAYER + ELEVATION (#131) -->
+       <item>
+        <widget class="QFrame" name="arpFrame">
+         <property name="frameShape"><enum>QFrame::StyledPanel</enum></property>
+         <layout class="QVBoxLayout" name="arpCompactLayout">
+          <property name="spacing"><number>4</number></property>
+          <property name="margin"><number>4</number></property>
+          <item>
+           <widget class="QLabel" name="arpTitleLabel">
+            <property name="text"><string>ARP Layer</string></property>
+            <property name="styleSheet"><string>QLabel { font-weight: bold; }</string></property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="arpControlLayout">
+            <property name="spacing"><number>8</number></property>
+            <item>
+             <widget class="QgsMapLayerComboBox" name="arpLayerCombo">
+              <property name="minimumHeight"><number>24</number></property>
+              <property name="maximumHeight"><number>28</number></property>
+              <property name="toolTip"><string>Select the layer containing the Aerodrome Reference Point (ARP). Optional unless the active surface requires it.</string></property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch><verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="useSelectedArpCheckBox">
+              <property name="text"><string>Selected Only</string></property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch><verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="arpSelectionStatusLabel">
+            <property name="text"><string>No layer</string></property>
+            <property name="styleSheet"><string>QLabel { font-weight: bold; font-size: 11px; }</string></property>
+            <property name="minimumHeight"><number>16</number></property>
+            <property name="maximumHeight"><number>16</number></property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="arpElevationLayout">
+            <property name="spacing"><number>8</number></property>
+            <item>
+             <widget class="QLabel" name="label_ARP_elevation">
+              <property name="text"><string>ARP Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="spin_ARP_elevation">
+              <property name="text"><string>2548.00</string></property>
+              <property name="toolTip"><string>Aerodrome Reference Point elevation, shared by the OFS and OES tabs.</string></property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
        <item>
         <widget class="QFrame" name="runwayFrame">
          <property name="frameShape"><enum>QFrame::StyledPanel</enum></property>
@@ -165,74 +233,6 @@
             <property name="minimumHeight"><number>16</number></property>
             <property name="maximumHeight"><number>16</number></property>
            </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-
-       <!-- ARP (Aerodrome Reference Point) LAYER + ELEVATION (#131) -->
-       <item>
-        <widget class="QFrame" name="arpFrame">
-         <property name="frameShape"><enum>QFrame::StyledPanel</enum></property>
-         <layout class="QVBoxLayout" name="arpCompactLayout">
-          <property name="spacing"><number>4</number></property>
-          <property name="margin"><number>4</number></property>
-          <item>
-           <widget class="QLabel" name="arpTitleLabel">
-            <property name="text"><string>ARP Layer</string></property>
-            <property name="styleSheet"><string>QLabel { font-weight: bold; }</string></property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="arpControlLayout">
-            <property name="spacing"><number>8</number></property>
-            <item>
-             <widget class="QgsMapLayerComboBox" name="arpLayerCombo">
-              <property name="minimumHeight"><number>24</number></property>
-              <property name="maximumHeight"><number>28</number></property>
-              <property name="toolTip"><string>Select the layer containing the Aerodrome Reference Point (ARP). Optional unless the active surface requires it.</string></property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch><verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="useSelectedArpCheckBox">
-              <property name="text"><string>Selected Only</string></property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch><verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QLabel" name="arpSelectionStatusLabel">
-            <property name="text"><string>No layer</string></property>
-            <property name="styleSheet"><string>QLabel { font-weight: bold; font-size: 11px; }</string></property>
-            <property name="minimumHeight"><number>16</number></property>
-            <property name="maximumHeight"><number>16</number></property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="arpElevationLayout">
-            <property name="spacing"><number>8</number></property>
-            <item>
-             <widget class="QLabel" name="label_ARP_elevation">
-              <property name="text"><string>ARP Elevation (m):</string></property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="spin_ARP_elevation">
-              <property name="text"><string>2548.00</string></property>
-              <property name="toolTip"><string>Aerodrome Reference Point elevation, shared by the OFS and OES tabs.</string></property>
-             </widget>
-            </item>
-           </layout>
           </item>
          </layout>
         </widget>

--- a/qols/ui/qols_panel_base.ui
+++ b/qols/ui/qols_panel_base.ui
@@ -124,6 +124,120 @@
         <number>2</number>
        </property>
        
+       <!-- ARP (Aerodrome Reference Point) LAYER + ELEVATION (#131) -->
+       <item>
+        <widget class="QFrame" name="arpFrame">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+
+         <layout class="QVBoxLayout" name="arpCompactLayout">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="margin">
+           <number>4</number>
+          </property>
+
+          <!-- Title Row -->
+          <item>
+           <widget class="QLabel" name="arpTitleLabel">
+            <property name="text">
+             <string>ARP Layer</string>
+            </property>
+            <property name="styleSheet">
+             <string>QLabel { font-weight: bold; }</string>
+            </property>
+           </widget>
+          </item>
+
+          <!-- Horizontal Control Row -->
+          <item>
+           <layout class="QHBoxLayout" name="arpControlLayout">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <item>
+             <widget class="QgsMapLayerComboBox" name="arpLayerCombo">
+              <property name="minimumHeight">
+               <number>24</number>
+              </property>
+              <property name="maximumHeight">
+               <number>28</number>
+              </property>
+              <property name="toolTip">
+               <string>Select the layer containing the Aerodrome Reference Point (ARP). Optional unless the active surface requires it (e.g. Outer Horizontal). This layer should contain a point feature representing the ARP.</string>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="useSelectedArpCheckBox">
+              <property name="text">
+               <string>Selected Only</string>
+              </property>
+              <property name="toolTip">
+               <string>Check to use only the selected ARP feature instead of all features in the layer</string>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+
+          <!-- Status Row -->
+          <item>
+           <widget class="QLabel" name="arpSelectionStatusLabel">
+            <property name="text">
+             <string>No layer</string>
+            </property>
+            <property name="styleSheet">
+             <string>QLabel { font-weight: bold; font-size: 11px; }</string>
+            </property>
+            <property name="minimumHeight"><number>16</number></property>
+            <property name="maximumHeight"><number>16</number></property>
+           </widget>
+          </item>
+
+          <!-- ARP Elevation Row -->
+          <item>
+           <layout class="QHBoxLayout" name="arpElevationLayout">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_ARP_elevation">
+              <property name="text">
+               <string>ARP Elevation (m):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="spin_ARP_elevation">
+              <property name="text">
+               <string>2548.00</string>
+              </property>
+              <property name="toolTip">
+               <string>Aerodrome Reference Point elevation, shared by every surface that needs a Z datum (Approach, OFZ, Transitional, Take-Off, Outer Horizontal).</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
        <!-- IMPROVED RUNWAY SELECTION -->
        <item>
         <widget class="QFrame" name="runwayFrame">
@@ -295,120 +409,6 @@
             <property name="minimumHeight"><number>16</number></property>
             <property name="maximumHeight"><number>16</number></property>
            </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-
-       <!-- ARP (Aerodrome Reference Point) LAYER + ELEVATION (#131) -->
-       <item>
-        <widget class="QFrame" name="arpFrame">
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-
-         <layout class="QVBoxLayout" name="arpCompactLayout">
-          <property name="spacing">
-           <number>4</number>
-          </property>
-          <property name="margin">
-           <number>4</number>
-          </property>
-
-          <!-- Title Row -->
-          <item>
-           <widget class="QLabel" name="arpTitleLabel">
-            <property name="text">
-             <string>ARP Layer</string>
-            </property>
-            <property name="styleSheet">
-             <string>QLabel { font-weight: bold; }</string>
-            </property>
-           </widget>
-          </item>
-
-          <!-- Horizontal Control Row -->
-          <item>
-           <layout class="QHBoxLayout" name="arpControlLayout">
-            <property name="spacing">
-             <number>8</number>
-            </property>
-            <item>
-             <widget class="QgsMapLayerComboBox" name="arpLayerCombo">
-              <property name="minimumHeight">
-               <number>24</number>
-              </property>
-              <property name="maximumHeight">
-               <number>28</number>
-              </property>
-              <property name="toolTip">
-               <string>Select the layer containing the Aerodrome Reference Point (ARP). Optional unless the active surface requires it (e.g. Outer Horizontal). This layer should contain a point feature representing the ARP.</string>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="useSelectedArpCheckBox">
-              <property name="text">
-               <string>Selected Only</string>
-              </property>
-              <property name="toolTip">
-               <string>Check to use only the selected ARP feature instead of all features in the layer</string>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-
-          <!-- Status Row -->
-          <item>
-           <widget class="QLabel" name="arpSelectionStatusLabel">
-            <property name="text">
-             <string>No layer</string>
-            </property>
-            <property name="styleSheet">
-             <string>QLabel { font-weight: bold; font-size: 11px; }</string>
-            </property>
-            <property name="minimumHeight"><number>16</number></property>
-            <property name="maximumHeight"><number>16</number></property>
-           </widget>
-          </item>
-
-          <!-- ARP Elevation Row -->
-          <item>
-           <layout class="QHBoxLayout" name="arpElevationLayout">
-            <property name="spacing">
-             <number>8</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="label_ARP_elevation">
-              <property name="text">
-               <string>ARP Elevation (m):</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="spin_ARP_elevation">
-              <property name="text">
-               <string>2548.00</string>
-              </property>
-              <property name="toolTip">
-               <string>Aerodrome Reference Point elevation, shared by every surface that needs a Z datum (Approach, OFZ, Transitional, Take-Off, Outer Horizontal).</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
# fix(#131 followup): ARP Layer/Elevation must be first, not third

## Summary

Issue #131 asked for ARP Layer and ARP Elevation to be "requested at
the top" of the Input Layers section. The original implementation
(merged via PR #152) added the widget correctly but placed it **after**
Runway and Threshold (3rd position) instead of **before** them — the
user caught this directly after the merge.

## Changes

### `qols/ui/qols_panel_base.ui`
### `qols/ui/new_ols_panel.ui`

Moved the `arpFrame` block (ARP Layer combo, "Selected Only" checkbox,
status label, ARP Elevation field) from after `thresholdFrame` to
before `runwayFrame` in both panels' `layersGroup`/`layersMainLayout`.
Final order in both: **ARP → Runway → Threshold**.

Pure layout reposition — no widget names, IDs, or Python code changed.
Qt Designer widgets are looked up by `objectName` (`self.arpLayerCombo`,
etc.), not by position in the `.ui` layout tree, so none of the
signal-wiring, `get_parameters()`, or validation logic in
`qols/ui/dockwidget.py` / `qols/ui/new_ols_dockwidget.py` needed any
change.
