### PR TITLE
Add ring hole pairing logic for horizontal surface annuli and update …

### DIFF
--- a/qols/scripts/new-ols-oes-horizontal-UTM.py
+++ b/qols/scripts/new-ols-oes-horizontal-UTM.py
@@ -7,8 +7,15 @@ concentric racetrack rings — each at its own height above the aerodrome
 elevation — are drawn into a single output layer.
 
 Geometry construction mirrors qols/scripts/inner-horizontal-racetrack.py
-exactly (same coord()/coord2() trig closures, same 2-arc/2-line closed
-racetrack), just repeated once per ring instead of once total.
+(same coord()/coord2() trig closures, same 2-arc/2-line closed racetrack),
+repeated once per ring. Per the ICAO figure (and per #134's own
+follow-up report), only the smallest tier is a full disc — every larger
+tier's polygon is the ring beyond the next-smaller tier's edge, not a
+second full disc stacked on top of it. This reuses the same
+difference_flat() 2D-difference-plus-flat-Z pattern #124 established for
+Conical vs. Inner Horizontal, via get_ring_hole_pairs() pairing each
+tier with the immediately-smaller tier whose disc must be subtracted
+from it.
 
 Procedure to be used in Projected Coordinate System Only.
 """
@@ -21,7 +28,8 @@ from qgis.gui import *
 import math
 from math import sqrt
 from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
-from qols.surfaces.new_ols_horizontal import get_horizontal_surface_rings
+from qols.surfaces.new_ols_horizontal import get_horizontal_surface_rings, get_ring_hole_pairs
+from qols.geometry_difference import difference_flat, flatten_ring_z
 
 _script_success = False
 
@@ -50,10 +58,13 @@ def _normalize_polyline_points(geometry):
     raise Exception("Line geometry cannot be converted to a polyline.")
 
 
-def _racetrack_ring(start_point, end_point, angle0, back_angle0, radius, z_absolute, trto, trfm):
-    """Builds one closed racetrack ring (list of WKT 'x y z' strings) at
-    the given radius/Z, using the same coord()/coord2() trig + circular-arc
-    interpolation as inner-horizontal-racetrack.py."""
+def _racetrack_ring_xy(start_point, end_point, angle0, back_angle0, radius, trto, trfm):
+    """Builds one closed racetrack ring boundary (list of (x, y) tuples,
+    first == last) at the given radius, in flat 2D — using the same
+    coord()/coord2() trig + circular-arc interpolation as
+    inner-horizontal-racetrack.py. No Z is applied here: callers either
+    apply a single flat Z directly (smallest tier) or feed this into
+    difference_flat() for boolean ops, which applies Z afterwards."""
 
     def coord(angle0, dist1, off):
         bearing = angle0 + off
@@ -78,7 +89,7 @@ def _racetrack_ring(start_point, end_point, angle0, back_angle0, radius, z_absol
     x5 = coord2(back_angle0, radius, 0)       # Ending center point
     x6 = coord2(back_angle0, radius, -90)     # Ending point left
 
-    polygon_points = []
+    ring_xy = []
 
     def _append_arc(p1, p2, p3, skip_first):
         cstring = QgsCircularString()
@@ -96,14 +107,20 @@ def _racetrack_ring(start_point, end_point, angle0, back_angle0, radius, z_absol
         for i, pt in enumerate(pts):
             if skip_first and i == 0:
                 continue
-            polygon_points.append(QgsPoint(pt.x(), pt.y(), z_absolute))
+            ring_xy.append((pt.x(), pt.y()))
 
     _append_arc(pro_coords, xc, x2, skip_first=False)
-    polygon_points.append(QgsPoint(x6[0], x6[1], z_absolute))
+    ring_xy.append((x6[0], x6[1]))
     _append_arc(x6, x5, x4, skip_first=True)
-    polygon_points.append(QgsPoint(pro_coords[0], pro_coords[1], z_absolute))
+    ring_xy.append((pro_coords[0], pro_coords[1]))
 
-    return [f"{pt.x()} {pt.y()} {pt.z()}" for pt in polygon_points]
+    return ring_xy
+
+
+def _ring_polygon_2d(ring_xy):
+    """Flat 2D QgsGeometry polygon (no Z) from a closed point ring, for
+    use as input to QgsGeometry.difference()."""
+    return QgsGeometry(QgsPolygon(QgsLineString([QgsPoint(x, y) for x, y in ring_xy])))
 
 
 # ---------------------------------------------------------------------------
@@ -181,17 +198,34 @@ for feat in selection:
         angle0 = (angle0 + 180) % 360
     back_angle0 = (angle0 + 180) % 360
 
-    # Draw largest ring first (bottom of the layer's render order) down to
-    # smallest last (on top) — every smaller/nearer ring's own fill+outline
-    # then stays visible on top of the larger ones instead of being covered
-    # by them, matching Figure 4-4's clearly bounded concentric zones.
-    for ring in reversed(rings):
+    # Smallest tier stays a full disc; every larger tier is trimmed down
+    # to the ring beyond the next-smaller tier's edge (#134 follow-up —
+    # the racetracks must not include the inner tier's area, mirroring
+    # #124's Conical-vs-Inner-Horizontal fix). True non-overlapping
+    # annuli don't need a specific draw order.
+    prev_disc_geom = None
+    prev_z = None
+    for ring, hole_source in get_ring_hole_pairs(rings):
         radius_m = ring['radius_m']
         height_m = ring['height_m']
         z_absolute = aerodrome_elevation_m + height_m
 
-        wkt_points = _racetrack_ring(start_point, end_point, angle0, back_angle0, radius_m, z_absolute, trto, trfm)
-        polygon_geometry = QgsGeometry.fromWkt(f"POLYGONZ(({', '.join(wkt_points)}))")
+        disc_geom = _ring_polygon_2d(
+            _racetrack_ring_xy(start_point, end_point, angle0, back_angle0, radius_m, trto, trfm)
+        )
+
+        if hole_source is None:
+            exterior = disc_geom.constGet().exteriorRing()
+            ext_xy = [(exterior.pointN(i).x(), exterior.pointN(i).y()) for i in range(exterior.numPoints())]
+            ext_pts = [QgsPoint(x, y, z) for x, y, z in flatten_ring_z(ext_xy, z_absolute)]
+            polygon_geometry = QgsGeometry(QgsPolygon(QgsLineString(ext_pts)))
+        else:
+            polygon_geometry = difference_flat(
+                disc_geom, prev_disc_geom, exterior_z=z_absolute, interior_z=prev_z
+            )
+
+        prev_disc_geom = disc_geom
+        prev_z = z_absolute
 
         feature = QgsFeature()
         feature.setGeometry(polygon_geometry)

--- a/qols/surfaces/new_ols_horizontal.py
+++ b/qols/surfaces/new_ols_horizontal.py
@@ -14,7 +14,7 @@ aerodrome elevation. Table 4-10 collapses to exactly 3 distinct
 radius/height tiers (IIC, III, IV and V all share the same values), so a
 single feature covers all of them rather than repeating identical rings.
 """
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------
 # ADG group constants
@@ -50,6 +50,33 @@ _ADG_TIER_INDEX: Dict[str, int] = {
 }
 
 
+def get_ring_hole_pairs(
+    rings: List[Dict[str, float]],
+) -> List[Tuple[Dict[str, float], Optional[Dict[str, float]]]]:
+    """Pair each ring with the immediately-smaller ring whose footprint
+    must be subtracted from it to form an annulus.
+
+    Table 4-10's tiers are always nested (each successive tier's
+    ``radius_m`` is >= the previous one's), so the immediately-smaller
+    ring's full disc already covers every ring below it — subtracting
+    just that one ring, not the union of all smaller ones, is enough.
+    The smallest ring (index 0) has no hole source and stays a full
+    disc, matching the reported behaviour ("similar to the conical but
+    flat" — only the innermost tier is solid; #124 already established
+    this same nested-annulus shape for Conical vs. Inner Horizontal).
+
+    Args:
+        rings: Rings ordered smallest to largest, as returned by
+            :func:`get_horizontal_surface_rings`.
+
+    Returns:
+        A list of ``(ring, hole_source)`` tuples, one per input ring,
+        in the same order; ``hole_source`` is ``None`` for the first
+        ring and the previous ring otherwise.
+    """
+    return [(ring, rings[i - 1] if i > 0 else None) for i, ring in enumerate(rings)]
+
+
 def get_horizontal_surface_rings(adg: str) -> List[Dict[str, float]]:
     """Return the cumulative list of rings for the given ADG group.
 
@@ -72,4 +99,5 @@ __all__ = [
     "ADG_I", "ADG_IIA", "ADG_IIB", "ADG_IIC", "ADG_III", "ADG_IV", "ADG_V",
     "ADG_GROUPS",
     "get_horizontal_surface_rings",
+    "get_ring_hole_pairs",
 ]


### PR DESCRIPTION
# fix(#134 followup): Horizontal Surface rings must be annuli, not stacked full discs

## Summary

Issue #134 ("Horizontal Surface (New OLS)") was implemented and merged
via PR #154. The issue author  reopened it with a
follow-up comment (screenshots attached): *"actually the racetracks are
not supposed to have the inner part, similar to the conical but flat.
Currently it has the inner part also is included, only the first
[ring] should [stay a full disc]."*

Table 4-10 gives up to 3 concentric radius/height tiers per ADG. The
original script drew every tier as a **full solid racetrack disc** and
relied on draw order (largest first, smallest last) to make the result
*look* like nested rings in a 2D view. The features themselves still
fully overlapped — wrong for anything beyond a screenshot (area/volume
queries, obstacle-clearance analysis, exporting the layer). This is the
exact same shape bug #124 already fixed for Conical vs. Inner
Horizontal in the classic panel.

## Changes

### `qols/surfaces/new_ols_horizontal.py`
Added `get_ring_hole_pairs(rings)` — a small pure function pairing each
ring with the immediately-smaller ring whose disc must be subtracted
from it (`None` for the smallest ring, which stays a full disc). Table
4-10's tiers are always nested (each successive radius >= the previous
one's), so subtracting just the immediately-smaller tier is sufficient
— the same assumption `plugin.py::_trim_conical_to_ring` already relies
on for Conical vs. Inner Horizontal.

### `qols/scripts/new-ols-oes-horizontal-UTM.py`
- `_racetrack_ring` was split into `_racetrack_ring_xy` (flat 2D point
  builder, no Z) and `_ring_polygon_2d` (wraps those points into a
  `QgsGeometry` polygon for boolean ops) — same trig/circular-arc
  construction as before, just no longer baking Z in up front.
- The ring loop now iterates `get_ring_hole_pairs(rings)`: the smallest
  tier gets its flat Z applied directly to its own disc (no hole); every
  larger tier calls `qols/geometry_difference.py::difference_flat()` —
  already used and proven by `_trim_conical_to_ring` — subtracting the
  previous tier's disc and applying `exterior_z`/`interior_z` so the
  ring's own top surface and its inner (hole) edge each sit at the
  correct absolute elevation.
- Removed the now-obsolete "draw largest first" reversed iteration and
  its comment — true non-overlapping annuli don't depend on draw order.

### `tests/test_dockwidget_logic.py`
New `TestGetRingHolePairs` (3 tests): a single ring has no hole source;
a 3-ring set pairs each ring with its immediate predecessor; empty
input returns `[]`.

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 564 passed (561 baseline + 3 new get_ring_hole_pairs tests)

flake8 qols/surfaces/new_ols_horizontal.py qols/scripts/new-ols-oes-horizontal-UTM.py
# new_ols_horizontal.py: 0 issues
# new-ols-oes-horizontal-UTM.py: same pre-existing accepted class of
# findings every qols/scripts/*.py file carries (F403/F405 star imports,
# E402) — no new findings introduced
```