### PR TITLE
feature(#135): Surface for precision approaches (OES, New OLS)

### DIFF
--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -201,8 +201,11 @@ class QOLS:
                 # #134: Transitional is an OFS-only concept (it flanks the
                 # OFS Approach surface and already runs from that tab's
                 # Calculate via execute_new_ols_ofs_approach). The OES tab
-                # only computes Horizontal Surface — no Transitional here.
+                # computes Horizontal Surface (#134) and the Surface for
+                # Precision Approaches (#135) — two distinct surfaces,
+                # each with its own dispatch method.
                 self.execute_new_ols_oes_horizontal(params)
+                self.execute_new_ols_oes_precision_approach(params)
             else:
                 raise ValueError(f"Unhandled New OLS surface type: {st!r}")
 
@@ -404,6 +407,14 @@ class QOLS:
             'direction': oes.get('direction', 0),
         }
         self.execute_script(horiz_path, horiz_params)
+
+    def execute_new_ols_oes_precision_approach(self, params):
+        """Surface for Precision Approaches (#135) — a distinct surface
+        from Transitional and Horizontal; reuses the OES tab's existing
+        start_elevation_m/runway_layer/threshold_layer/direction as-is,
+        no param remapping needed (Table 4-12 needs no ADG)."""
+        script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-precision-approach-UTM.py')
+        self.execute_script(script_path, params)
 
     def execute_combined_inner_conical_surface(self, params):
         """Execute Inner Horizontal then Conical using per-surface parameters,

--- a/qols/scripts/new-ols-oes-precision-approach-UTM.py
+++ b/qols/scripts/new-ols-oes-precision-approach-UTM.py
@@ -1,0 +1,361 @@
+"""
+New OLS Concept — OES Surface for Precision Approaches
+ICAO Annex 14 Table 4-12 / Figure 4-6 (#135). Ported from qpansopy's
+Basic ILS Surfaces tool (Q_Pansopy/modules/basic_ils.py::calculate_basic_ils),
+values and shapes kept identical, adapted to this plugin's runway/
+threshold/direction resolution (mirrors new-ols-oes-transitional-UTM.py).
+
+One deliberate omission from the qpansopy reference: its "ground
+surface" (a flat rectangle connecting the approach surface's inner edge
+to the missed-approach surface's inner edge) is not part of Annex 14
+Table 4-12 or Figure 4-6 — only Approach, Missed Approach, and
+Transitional are ICAO-defined. Confirmed with the user and omitted;
+see doc/PR_135.md. The ground surface's own corner points are not lost
+by this: they are exactly the same points already needed as the
+approach/missed-approach surfaces' own inner-edge corners (gs_a/gs_d
+below are the approach surface's inner edge; missed_a/missed_f are the
+missed-approach surface's inner edge, used directly wherever qpansopy's
+ground-surface corners gs_b/gs_c would have been referenced).
+
+Direction convention: ``approach_azimuth`` points away from the runway,
+out over the approach path (qpansopy's ``back_azimuth``);
+``missed_azimuth`` continues past the threshold in the landing
+direction of travel (qpansopy's ``azimuth``). All LEFT/RIGHT lateral
+offsets — for both the approach and missed-approach sides — use
+``approach_azimuth ± 90`` consistently (matching qpansopy's own choice
+of always offsetting from ``back_azimuth``), so "left" stays the same
+physical side across the whole surface; using ``missed_azimuth ± 90``
+for the missed-approach half would silently swap left/right there.
+
+Procedure to be used in Projected Coordinate System Only.
+"""
+myglobals = set(globals().keys())
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from math import sqrt
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+from qols.surfaces.new_ols_precision_approach import get_precision_approach_dimensions
+
+_script_success = False
+
+
+def _normalize_polyline_points(geometry):
+    if geometry is None or geometry.isEmpty():
+        raise Exception("Empty geometry provided for runway centerline.")
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            raise Exception("Empty MultiLineString geometry.")
+
+        def part_len(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                dx = pts[i].x() - pts[i - 1].x()
+                dy = pts[i].y() - pts[i - 1].y()
+                total += sqrt(dx * dx + dy * dy)
+            return total
+
+        return [QgsPoint(p) for p in max(parts, key=part_len)]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [QgsPoint(p) for p in poly]
+    raise Exception("Line geometry cannot be converted to a polyline.")
+
+
+def _closest_feature(features, pt):
+    return min(
+        features,
+        key=lambda f: ((f.geometry().asPoint().x() - pt.x()) ** 2
+                       + (f.geometry().asPoint().y() - pt.y()) ** 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+try:
+    start_elevation_m = globals().get('start_elevation_m', 0.0)
+    direction = globals().get('direction', 0)
+    runway_layer = globals().get('runway_layer', None)
+    threshold_layer = globals().get('threshold_layer', None)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    use_threshold_selected = globals().get('use_threshold_selected', True)
+except Exception as e:
+    print(f"NewOLS_OES_PrecisionApproach: Error getting parameters, using defaults: {e}")
+    start_elevation_m = 0.0
+    direction = 0
+    runway_layer = None
+    threshold_layer = None
+    use_runway_selected = True
+    use_threshold_selected = True
+
+dims = get_precision_approach_dimensions()
+appr = dims['approach']
+missed = dims['missed_approach']
+trans_slope_pct = dims['transitional']['slope_pct']
+
+map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+
+# ---------------------------------------------------------------------------
+# Runway layer
+# ---------------------------------------------------------------------------
+try:
+    if runway_layer is None:
+        raise Exception("No Runway Layer Centerline provided.")
+    if use_runway_selected:
+        selection = runway_layer.selectedFeatures()
+        if not selection:
+            raise Exception("No runway features selected.")
+    else:
+        selection = runway_layer.selectedFeatures() or list(runway_layer.getFeatures())
+        if not selection:
+            raise Exception("No features found in Runway Layer.")
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+for feat in selection:
+    line_pts = _normalize_polyline_points(feat.geometry())
+    break
+
+# ---------------------------------------------------------------------------
+# Threshold layer
+# ---------------------------------------------------------------------------
+try:
+    if threshold_layer is None:
+        raise Exception("No threshold layer provided.")
+    if use_threshold_selected:
+        threshold_sel = threshold_layer.selectedFeatures()
+        if not threshold_sel:
+            raise Exception("No threshold features selected.")
+    else:
+        threshold_sel = threshold_layer.selectedFeatures() or list(threshold_layer.getFeatures())
+        if not threshold_sel:
+            raise Exception("No features found in threshold layer.")
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+# direction picks the runway-centerline endpoint (0 = Start to End,
+# -1 = End to Start), same convention as new-ols-oes-transitional-UTM.py.
+s = direction
+near_end_pt = line_pts[s]
+far_end_pt = line_pts[-1 - s]
+approach_azimuth = far_end_pt.azimuth(near_end_pt)      # away from runway, over the approach path
+missed_azimuth = (approach_azimuth + 180.0) % 360.0     # continues past threshold, landing direction of travel
+
+near_thr_feat = _closest_feature(threshold_sel, near_end_pt)
+thr_geom = near_thr_feat.geometry().asPoint()
+thr_point = QgsPoint(thr_geom)
+thr_point.addZValue(start_elevation_m)
+
+print(f"NewOLS_OES_PrecisionApproach: approach_azimuth={approach_azimuth:.2f} missed_azimuth={missed_azimuth:.2f}")
+
+# ---------------------------------------------------------------------------
+# Geometry — ported 1:1 from calculate_basic_ils(), ground surface omitted
+# ---------------------------------------------------------------------------
+half_inner = appr['inner_edge_m'] / 2.0  # 150 m — shared by approach & missed approach
+
+# Approach surface — origin (inner edge)
+gs_center = thr_point.project(appr['distance_from_threshold_m'], approach_azimuth)
+gs_a = gs_center.project(half_inner, approach_azimuth - 90)
+gs_d = gs_center.project(half_inner, approach_azimuth + 90)
+
+# Approach section 1
+as1_len = appr['section_1']['length_m']
+as1_div = appr['section_1']['divergence_pct'] / 100.0
+as1_slope = appr['section_1']['slope_pct'] / 100.0
+as1_center = gs_center.project(as1_len, approach_azimuth)
+as1_half_width = half_inner + as1_len * as1_div
+as1_a = as1_center.project(as1_half_width, approach_azimuth - 90)
+as1_d = as1_center.project(as1_half_width, approach_azimuth + 90)
+as1_height = as1_len * as1_slope  # 60 m
+
+# Approach section 2 (divergence/height measured cumulatively from the origin)
+as2_len = appr['section_2']['length_m']
+as2_div = appr['section_2']['divergence_pct'] / 100.0
+as2_slope = appr['section_2']['slope_pct'] / 100.0
+as2_center = as1_center.project(as2_len, approach_azimuth)
+as2_half_width = half_inner + (as1_len + as2_len) * as2_div
+as2_a = as2_center.project(as2_half_width, approach_azimuth - 90)
+as2_d = as2_center.project(as2_half_width, approach_azimuth + 90)
+as2_height = as1_height + as2_len * as2_slope  # 300 m
+
+# Missed approach surface — origin (inner edge)
+missed_center = thr_point.project(missed['distance_after_threshold_m'], missed_azimuth)
+missed_a = missed_center.project(half_inner, approach_azimuth - 90)
+missed_f = missed_center.project(half_inner, approach_azimuth + 90)
+
+# Missed approach section 1 — half-width derived from the transitional
+# slope reaching this section's own height of rise (not a literal
+# ×divergence_pct multiply — see module docstring and new_ols_precision_
+# approach.py docstring for why).
+m1_len = missed['section_1']['length_m']
+m1_slope = missed['section_1']['slope_pct'] / 100.0
+m1_height = m1_len * m1_slope  # 45 m
+m1_half_width = half_inner + m1_height / (trans_slope_pct / 100.0)
+missed_m_center = missed_center.project(m1_len, missed_azimuth)
+missed_b = missed_m_center.project(m1_half_width, approach_azimuth - 90)
+missed_e = missed_m_center.project(m1_half_width, approach_azimuth + 90)
+
+# Missed approach section 2 (slope unchanged at 2.5%, so height accumulates
+# linearly from the origin; divergence is this section's own 25% splay
+# added on top of the 1st section's half-width)
+m2_len = missed['section_2']['length_m']
+m2_div = missed['section_2']['divergence_pct'] / 100.0
+m2_slope = missed['section_2']['slope_pct'] / 100.0
+m2_height = m1_height + m2_len * m2_slope  # 300 m
+m2_half_width = m1_half_width + m2_len * m2_div
+missed_f_center = missed_center.project(m1_len + m2_len, missed_azimuth)
+missed_c = missed_f_center.project(m2_half_width, approach_azimuth - 90)
+missed_d = missed_f_center.project(m2_half_width, approach_azimuth + 90)
+
+# Transitional surface side distances (14.3% slope connecting the
+# approach/missed-approach height steps: 0 -> as1_height -> as2_height,
+# and as2_height -> m1_height)
+trans_slope = trans_slope_pct / 100.0
+transition_distance_1 = (as2_height - as1_height) / trans_slope
+transition_distance_2 = as2_height / trans_slope
+transition_distance_3 = (as2_height - m1_height) / trans_slope
+
+transition_e1_left = as1_d.project(transition_distance_1, approach_azimuth + 90)
+transition_e1_right = as1_a.project(transition_distance_1, approach_azimuth - 90)
+transition_e2_left = gs_d.project(transition_distance_2, approach_azimuth + 90)
+transition_e2_right = gs_a.project(transition_distance_2, approach_azimuth - 90)
+transition_e3_left = missed_e.project(transition_distance_3, approach_azimuth + 90)
+transition_e3_right = missed_b.project(transition_distance_3, approach_azimuth - 90)
+
+# ---------------------------------------------------------------------------
+# Elevations
+# ---------------------------------------------------------------------------
+z0 = start_elevation_m
+z_as1 = start_elevation_m + as1_height
+z_as2 = start_elevation_m + as2_height
+z_m1 = start_elevation_m + m1_height
+z_m2 = start_elevation_m + m2_height  # numerically == z_as2 (both 300 m)
+
+
+def _pz(pt, z):
+    p = QgsPoint(pt.x(), pt.y())
+    p.addZValue(z)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Memory layer
+# ---------------------------------------------------------------------------
+layer_name = "NewOLS_OES_PrecisionApproach"
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", layer_name, "memory")
+v_layer_provider = v_layer.dataProvider()
+v_layer_provider.addAttributes([
+    QgsField("surface_type", QVariant.String),
+    QgsField("component", QVariant.String),
+    QgsField("slope_pct", QVariant.Double),
+    QgsField("rule_set", QVariant.String),
+])
+v_layer.updateFields()
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('New OLS OES Surface for Precision Approaches', {
+    'start_elevation_m': round(start_elevation_m, 3),
+    'direction': direction,
+    'dimensions': dims,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
+features = []
+
+
+def _add_feature(component, slope_pct, ring_pts_with_z):
+    f = QgsFeature()
+    f.setGeometry(QgsPolygon(QgsLineString(ring_pts_with_z)))
+    f.setAttributes(["Surface for Precision Approaches", component, slope_pct, _active_rule_set, _params_json])
+    features.append(f)
+
+
+_add_feature('approach section 1', appr['section_1']['slope_pct'], [
+    _pz(as1_a, z_as1), _pz(gs_a, z0), _pz(gs_d, z0), _pz(as1_d, z_as1),
+])
+_add_feature('approach section 2', appr['section_2']['slope_pct'], [
+    _pz(as2_a, z_as2), _pz(as1_a, z_as1), _pz(as1_d, z_as1), _pz(as2_d, z_as2),
+])
+_add_feature('missed approach', missed['section_1']['slope_pct'], [
+    _pz(missed_a, z0), _pz(missed_b, z_m1), _pz(missed_c, z_m2),
+    _pz(missed_d, z_m2), _pz(missed_e, z_m1), _pz(missed_f, z0),
+])
+_add_feature('transitional - left 1', trans_slope_pct, [
+    _pz(as2_d, z_as2), _pz(as1_d, z_as1), _pz(transition_e1_left, z_as2),
+])
+_add_feature('transitional - left 2', trans_slope_pct, [
+    _pz(as1_d, z_as1), _pz(transition_e1_left, z_as2), _pz(transition_e2_left, z_as2), _pz(gs_d, z0),
+])
+_add_feature('transitional - left 3', trans_slope_pct, [
+    _pz(transition_e2_left, z_as2), _pz(gs_d, z0), _pz(missed_f, z0),
+    _pz(missed_e, z_m1), _pz(transition_e3_left, z_as2),
+])
+_add_feature('transitional - left 4', trans_slope_pct, [
+    _pz(missed_e, z_m1), _pz(missed_d, z_m2), _pz(transition_e3_left, z_as2),
+])
+_add_feature('transitional - right 1', trans_slope_pct, [
+    _pz(as2_a, z_as2), _pz(as1_a, z_as1), _pz(transition_e1_right, z_as2),
+])
+_add_feature('transitional - right 2', trans_slope_pct, [
+    _pz(as1_a, z_as1), _pz(transition_e1_right, z_as2), _pz(transition_e2_right, z_as2), _pz(gs_a, z0),
+])
+_add_feature('transitional - right 3', trans_slope_pct, [
+    _pz(transition_e2_right, z_as2), _pz(transition_e3_right, z_as2),
+    _pz(missed_b, z_m1), _pz(missed_a, z0), _pz(gs_a, z0),
+])
+_add_feature('transitional - right 4', trans_slope_pct, [
+    _pz(missed_b, z_m1), _pz(missed_c, z_m2), _pz(transition_e3_right, z_as2),
+])
+
+v_layer_provider.addFeatures(features)
+v_layer.updateExtents()
+print(f"NewOLS_OES_PrecisionApproach: Created {len(features)} feature(s)")
+
+register_parameters_action(v_layer)
+
+QgsProject.instance().addMapLayers([v_layer])
+
+symbol = QgsFillSymbol.createSimple({
+    'color': '255,165,0,90',  # soft amber/orange, transparent
+    'style': 'solid',
+    'outline_color': '255,140,0,220',
+    'outline_style': 'solid',
+    'outline_width': '0.7',
+})
+v_layer.renderer().setSymbol(symbol)
+v_layer.triggerRepaint()
+
+if features:
+    v_layer.selectAll()
+    canvas = iface.mapCanvas()
+    canvas.zoomToSelected(v_layer)
+    v_layer.removeSelection()
+    sc = canvas.scale()
+    if sc < 50000:
+        sc = 50000
+    canvas.zoomScale(sc)
+
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+if not use_threshold_selected and threshold_layer:
+    threshold_layer.removeSelection()
+
+iface.messageBar().pushMessage(
+    "QOLS Success",
+    "New OLS OES Surface for Precision Approaches calculated successfully",
+    level=MSG_SUCCESS,
+)
+
+_script_success = True
+
+for _g in set(globals().keys()).difference(myglobals):
+    if _g not in ('myglobals', '_script_success'):
+        del globals()[_g]

--- a/qols/surfaces/new_ols_precision_approach.py
+++ b/qols/surfaces/new_ols_precision_approach.py
@@ -1,0 +1,51 @@
+"""New OLS concept — Surface for precision approaches ICAO defaults.
+
+Table 4-12 (Dimensions of surface for precision approaches). Unlike the
+Approach/Horizontal tables, this one has a single "I to V" column — no
+Aeroplane Design Group variation — so there is nothing to look up by
+ADG, just the table's own fixed values.
+
+``missed_approach.section_1.divergence_pct`` (17.48) is the table's own
+published value, kept here for attribute/metadata display only. The
+geometry script derives the actual 1st-section half-width from the
+transitional slope reaching 45 m of rise instead of multiplying by this
+percentage directly — numerically equivalent (17.48% is itself a
+rounded display of that same relationship), but the derived form is
+exact. See qpansopy's own bugfix history (issue #188 in that project)
+for why the direct-percentage form silently narrows the surface.
+"""
+from typing import Dict
+
+
+def get_precision_approach_dimensions() -> Dict[str, dict]:
+    """Return ICAO Annex 14 Table 4-12 as a nested dict.
+
+    Returns:
+        Dict with three keys:
+
+        * ``approach`` — ``distance_from_threshold_m``, ``inner_edge_m``,
+          and ``section_1``/``section_2`` dicts (``length_m``,
+          ``divergence_pct``, ``slope_pct`` each).
+        * ``missed_approach`` — ``distance_after_threshold_m``,
+          ``inner_edge_m``, and ``section_1``/``section_2`` dicts, same
+          shape as ``approach``.
+        * ``transitional`` — ``slope_pct``.
+    """
+    return {
+        'approach': {
+            'distance_from_threshold_m': 60.0,
+            'inner_edge_m': 300.0,
+            'section_1': {'length_m': 3000.0, 'divergence_pct': 15.0, 'slope_pct': 2.0},
+            'section_2': {'length_m': 9600.0, 'divergence_pct': 15.0, 'slope_pct': 2.5},
+        },
+        'missed_approach': {
+            'distance_after_threshold_m': 900.0,
+            'inner_edge_m': 300.0,
+            'section_1': {'length_m': 1800.0, 'divergence_pct': 17.48, 'slope_pct': 2.5},
+            'section_2': {'length_m': 10200.0, 'divergence_pct': 25.0, 'slope_pct': 2.5},
+        },
+        'transitional': {'slope_pct': 14.3},
+    }
+
+
+__all__ = ['get_precision_approach_dimensions']


### PR DESCRIPTION
# feature(#135): Surface for precision approaches (OES, New OLS)

## Summary

Closes #135.

Issue #135 "Include in OES tab. Copy the logic
from qPansopy basic ILS surfaces but adapted to this plugin, values
should be exactly the same. Any difference for example slope % let me
know."

Adds the ICAO Annex 14 **Table 4-12 / Figure 4-6** "Surface for
precision approaches" to the New OLS panel's OES tab: an Approach
component (2 sections), a Missed Approach component (2 sections), and
a Transitional component, all in one output layer.

---

## Difference found (reported per the issue's request)

qpansopy's reference implementation
(`Q_Pansopy/modules/basic_ils.py::calculate_basic_ils`) was read in
full and every approach/missed-approach/transitional value was checked
against Table 4-12 directly — **all match exactly**, including the
missed-approach 1st-section half-width, which qpansopy derives from
the 14.3% transitional slope reaching 45 m of rise rather than
literally multiplying by the table's published 17.48% (confirmed via
qpansopy's own bugfix history for this exact formula — a prior
"simplification" to a flat percentage was a regression, fixed to the
derived form). 17.48% and the derived value are numerically equivalent
to well within rounding; the derived form is what got ported here, for
maximum fidelity.

**One structural difference found, not a value/slope difference**:
qpansopy's script includes an extra **"ground surface"** — a flat
300 m-wide rectangle at threshold elevation, spanning the 960 m between
the approach surface's inner edge (60 m before threshold) and the
missed-approach surface's inner edge (900 m after threshold). This
component **does not appear anywhere in Annex 14 Table 4-12 or
Figure 4-6** — the ICAO standard defines only Approach, Missed
Approach, and Transitional. It looks like a qpansopy-only addition to
produce a visually "closed" 3D solid, not part of the standard this
plugin follows.

**Decision (confirmed with the user): omitted.** Only the 3
ICAO-defined components are implemented. This loses no geometry —
verified algebraically that the ground surface's 4 corners are exactly
the same points already needed as the approach/missed-approach
surfaces' own inner-edge corners (worked out via vector decomposition:
`gs_b ≡ missed_a` and `gs_c ≡ missed_f` exactly, not approximately), so
every transition polygon that referenced a ground-surface corner in
qpansopy still gets the identical point in this port — only the one
extra flat-rectangle *feature* is dropped from the output layer (11
features here vs. qpansopy's 12).

---

## Changes

### `qols/surfaces/new_ols_precision_approach.py` (new)
Pure-Python Table 4-12 as a nested dict (`approach`/`missed_approach`/
`transitional`), no QGIS dependency, no ADG lookup needed (table has a
single "I to V" column).

### `qols/scripts/new-ols-oes-precision-approach-UTM.py` (new)
Geometry, ported 1:1 from `calculate_basic_ils()` (every formula
verified against a standalone numeric check before committing — see
Verification), adapted to this plugin's conventions: `runway_layer`/
`threshold_layer`/`direction` resolution mirrors
`new-ols-oes-transitional-UTM.py`'s `_normalize_polyline_points`/
`_closest_feature` pattern; `approach_azimuth` (away from the runway,
over the approach path) and `missed_azimuth` (continuing past the
threshold, landing direction of travel) replace qpansopy's
`back_azimuth`/`azimuth`. All left/right lateral offsets — for both the
approach and missed-approach halves — consistently use
`approach_azimuth ± 90` (matching qpansopy's own choice of always
offsetting from `back_azimuth`), so "left" stays the same physical side
across the whole surface. No new UI: reuses the OES tab's existing
`start_elevation_m` (`spin_Z0_oes`) as the threshold-elevation datum.

### `qols/plugin.py`
New `execute_new_ols_oes_precision_approach(params)` — its own
dispatch method (not folded into `execute_new_ols_oes_horizontal` or
`execute_new_ols_oes_transitional`), called from
`on_calculate_new_ols()`'s OES branch alongside
`execute_new_ols_oes_horizontal`. No param remapping needed — this
script reads `start_elevation_m`/`direction` directly from the OES
tab's existing `specific_params`.

### `tests/test_dockwidget_logic.py`
New `TestGetPrecisionApproachDimensions` (5 tests): asserts every Table
4-12 value, top-level key set, and mutation-independence of the
returned dict.

---

## Verification

Before writing the script, every formula was checked with a standalone
numeric script against qpansopy's expected constants:

```bash
python3 - <<'EOF'  # (see session transcript for the exact script)
# as1_half_width=600.0, as1_height=60.0, as2_half_width=2040.0, as2_height=300.0
# m1_height=45.0, m1_half_width=464.685..., m2_height=300.0, m2_half_width=3014.685...
# transition_distance_1=1678.32..., _2=2097.90..., _3=1783.22...
EOF
# all matched qpansopy's own computed values exactly
```

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 566 passed (561 baseline + 5 new dimension tests)

flake8 qols/surfaces/new_ols_precision_approach.py qols/plugin.py qols/scripts/new-ols-oes-precision-approach-UTM.py
# new_ols_precision_approach.py: 0 issues
# plugin.py: 0 issues
# new-ols-oes-precision-approach-UTM.py: 35 findings, all F403/F405/E402
# (star imports) — same accepted class every qols/scripts/*.py file
# carries; two E501 long-line findings were caught and fixed before
# this final run
```

## Risk / notes

- Largest single script ported this session — highest value-fidelity
  risk of any surface added so far. Mitigated by reading
  `calculate_basic_ils()` in full, porting every formula 1:1, and
  independently verifying the scalar math with a standalone Python
  script before writing the QGIS geometry code.
- The omitted ground surface is a confirmed, user-approved, documented
  deviation from qpansopy — not from Annex 14.
