### PR TITLE
feature(#136, #159): Instrument Departure Surface + OES subtab split

### DIFF
--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -197,14 +197,14 @@ class QOLS:
 
             if st == SurfaceType.NEW_OLS_OFS_APPROACH:
                 self.execute_new_ols_ofs_approach(params)
-            elif st == SurfaceType.NEW_OLS_OES_TRANSITIONAL:
-                # #134: Transitional is an OFS-only concept (it flanks the
-                # OFS Approach surface and already runs from that tab's
-                # Calculate via execute_new_ols_ofs_approach). The OES tab
-                # computes Horizontal Surface (#134) and the Surface for
-                # Precision Approaches (#135) — two distinct surfaces,
-                # each with its own dispatch method.
+            elif st == SurfaceType.NEW_OLS_OES_HORIZONTAL:
+                # #159 — OES surfaces are each calculated individually from
+                # their own subtab now, instead of bundled behind one
+                # shared Calculate click.
                 self.execute_new_ols_oes_horizontal(params)
+            elif st == SurfaceType.NEW_OLS_OES_DEPARTURE:
+                self.execute_new_ols_oes_departure(params)
+            elif st == SurfaceType.NEW_OLS_OES_PRECISION_APPROACH:
                 self.execute_new_ols_oes_precision_approach(params)
             else:
                 raise ValueError(f"Unhandled New OLS surface type: {st!r}")
@@ -396,23 +396,26 @@ class QOLS:
         self.execute_script(script_path, params)
 
     def execute_new_ols_oes_horizontal(self, params):
-        """Horizontal Surface (#134) — a distinct surface from Transitional,
-        just sharing the OES tab's inputs (ADG, aerodrome elevation)."""
-        oes = params.get('specific_params', {})
-        horiz_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-horizontal-UTM.py')
-        horiz_params = params.copy()
-        horiz_params['specific_params'] = {
-            'adg': oes.get('adg', 'IIC'),
-            'aerodrome_elevation_m': oes.get('highest_thr_elev_m', 0.0),
-            'direction': oes.get('direction', 0),
-        }
-        self.execute_script(horiz_path, horiz_params)
+        """Horizontal Surface (#134) — its own OES subtab (#159), triggered
+        individually; get_parameters() already shapes specific_params as
+        adg/aerodrome_elevation_m/direction, no remapping needed."""
+        script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-horizontal-UTM.py')
+        self.execute_script(script_path, params)
+
+    def execute_new_ols_oes_departure(self, params):
+        """Instrument Departure Surface (#136) — its own OES subtab (#159),
+        triggered individually; get_parameters() already shapes
+        specific_params as start_elevation_m/direction, no remapping
+        needed (Table 4-13 needs no ADG)."""
+        script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-departure-UTM.py')
+        self.execute_script(script_path, params)
 
     def execute_new_ols_oes_precision_approach(self, params):
-        """Surface for Precision Approaches (#135) — a distinct surface
-        from Transitional and Horizontal; reuses the OES tab's existing
-        start_elevation_m/runway_layer/threshold_layer/direction as-is,
-        no param remapping needed (Table 4-12 needs no ADG)."""
+        """Surface for Precision Approaches (#135) — its own OES subtab
+        (#159), triggered individually; get_parameters() already shapes
+        specific_params as start_elevation_m/direction, no remapping
+        needed (Table 4-12 needs no ADG; runway_layer/threshold_layer
+        are already shared at the top level of params)."""
         script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-precision-approach-UTM.py')
         self.execute_script(script_path, params)
 

--- a/qols/scripts/new-ols-oes-departure-UTM.py
+++ b/qols/scripts/new-ols-oes-departure-UTM.py
@@ -1,0 +1,280 @@
+"""
+New OLS Concept — OES Instrument Departure Surface
+ICAO Annex 14 Table 4-13 / Figure 4-7 (#136). Ported from qpansopy's
+Omnidirectional SID module
+(Q_Pansopy/modules/departures/omnidirectional_sid.py::run_omnidirectional_sid),
+per the issue's own "similar to the OMNI SID without Area 3" request:
+qpansopy's Area 1 (15 deg splay) / Area 2 (30 deg splay) match this
+table's section_1/section_2 shape exactly; Area 3 (a circular MSA
+buffer, specific to a real departure procedure) has no equivalent in
+Table 4-13 and is not built here.
+
+Value differences found and kept as documented (see
+qols/surfaces/new_ols_departure.py's module docstring for the full
+comparison against qpansopy): the table's own 26.8%/57.8% divergence
+percentages are used directly (qpansopy's 15deg/30deg splays give the
+same values, just rounded); the table's fixed section lengths
+(3500 m/8300 m) and flat 2.5% slope are used as-is, since qpansopy
+instead derives its Area 1/2 lengths and effective slope from a
+user-supplied Procedure Design Gradient for a specific procedure -- not
+applicable to this generic protection surface.
+
+DER (Departure End of Runway) is the runway centerline's own far
+endpoint in the direction of travel -- no separate DER point layer is
+requested or needed. der_azimuth points away from the runway, in the
+takeoff/climb-out direction (the same direction
+new-ols-oes-precision-approach-UTM.py calls missed_azimuth).
+
+Per #159, every Table 4-13 value is UI-editable
+(initial_height_above_der_m/inner_edge_m/slope_pct/s1_length_m/
+s1_divergence_pct/s2_length_m/s2_divergence_pct), defaulting to the
+ICAO table when not overridden.
+
+Procedure to be used in Projected Coordinate System Only.
+"""
+myglobals = set(globals().keys())
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from math import sqrt
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+from qols.surfaces.new_ols_departure import get_departure_surface_dimensions
+
+_script_success = False
+
+
+def _normalize_polyline_points(geometry):
+    if geometry is None or geometry.isEmpty():
+        raise Exception("Empty geometry provided for runway centerline.")
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            raise Exception("Empty MultiLineString geometry.")
+
+        def part_len(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                dx = pts[i].x() - pts[i - 1].x()
+                dy = pts[i].y() - pts[i - 1].y()
+                total += sqrt(dx * dx + dy * dy)
+            return total
+
+        return [QgsPoint(p) for p in max(parts, key=part_len)]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [QgsPoint(p) for p in poly]
+    raise Exception("Line geometry cannot be converted to a polyline.")
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+_defaults = get_departure_surface_dimensions()  # Table 4-13, used as fallback only
+
+try:
+    start_elevation_m = globals().get('start_elevation_m', 0.0)
+    direction = globals().get('direction', 0)
+    runway_layer = globals().get('runway_layer', None)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    initial_height_above_der_m = globals().get(
+        'initial_height_above_der_m', _defaults['initial_height_above_der_m'])
+    inner_edge_m = globals().get('inner_edge_m', _defaults['inner_edge_m'])
+    slope_pct = globals().get('slope_pct', _defaults['slope_pct'])
+    s1_length_m = globals().get('s1_length_m', _defaults['section_1']['length_m'])
+    s1_divergence_pct = globals().get('s1_divergence_pct', _defaults['section_1']['divergence_pct'])
+    s2_length_m = globals().get('s2_length_m', _defaults['section_2']['length_m'])
+    s2_divergence_pct = globals().get('s2_divergence_pct', _defaults['section_2']['divergence_pct'])
+except Exception as e:
+    print(f"NewOLS_OES_Departure: Error getting parameters, using defaults: {e}")
+    start_elevation_m = 0.0
+    direction = 0
+    runway_layer = None
+    use_runway_selected = True
+    initial_height_above_der_m = _defaults['initial_height_above_der_m']
+    inner_edge_m = _defaults['inner_edge_m']
+    slope_pct = _defaults['slope_pct']
+    s1_length_m = _defaults['section_1']['length_m']
+    s1_divergence_pct = _defaults['section_1']['divergence_pct']
+    s2_length_m = _defaults['section_2']['length_m']
+    s2_divergence_pct = _defaults['section_2']['divergence_pct']
+
+# #159 — "expose all the parameters": every Table 4-13 value above is
+# UI-editable, defaulting to the ICAO table when not overridden.
+dims = {
+    'initial_height_above_der_m': initial_height_above_der_m,
+    'inner_edge_m': inner_edge_m,
+    'slope_pct': slope_pct,
+    'section_1': {'length_m': s1_length_m, 'divergence_pct': s1_divergence_pct},
+    'section_2': {'length_m': s2_length_m, 'divergence_pct': s2_divergence_pct},
+}
+s1 = dims['section_1']
+s2 = dims['section_2']
+slope = dims['slope_pct'] / 100.0
+
+map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+
+# ---------------------------------------------------------------------------
+# Runway layer
+# ---------------------------------------------------------------------------
+try:
+    if runway_layer is None:
+        raise Exception("No Runway Layer Centerline provided.")
+    if use_runway_selected:
+        selection = runway_layer.selectedFeatures()
+        if not selection:
+            raise Exception("No runway features selected.")
+    else:
+        selection = runway_layer.selectedFeatures() or list(runway_layer.getFeatures())
+        if not selection:
+            raise Exception("No features found in Runway Layer.")
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+for feat in selection:
+    line_pts = _normalize_polyline_points(feat.geometry())
+    break
+
+# direction picks the runway-centerline endpoint (0 = Start to End,
+# -1 = End to Start), same convention as the other New OLS OES scripts.
+# DER is the far endpoint itself -- the physical end of the runway in
+# the direction of takeoff travel.
+s = direction
+near_end_pt = line_pts[s]
+far_end_pt = line_pts[-1 - s]
+der_azimuth = near_end_pt.azimuth(far_end_pt)  # away from the runway, takeoff/climb-out direction
+
+der_point = QgsPoint(far_end_pt.x(), far_end_pt.y())
+der_point.addZValue(start_elevation_m + dims['initial_height_above_der_m'])
+
+print(f"NewOLS_OES_Departure: der_azimuth={der_azimuth:.2f}")
+
+# ---------------------------------------------------------------------------
+# Geometry -- ported from run_omnidirectional_sid()'s Area 1 / Area 2,
+# using Table 4-13's fixed lengths/divergence/slope instead of a
+# PDG-derived climb profile.
+# ---------------------------------------------------------------------------
+half_inner = dims['inner_edge_m'] / 2.0  # 150 m
+
+der_a = der_point.project(half_inner, der_azimuth - 90)
+der_b = der_point.project(half_inner, der_azimuth + 90)
+
+s1_len = s1['length_m']
+s1_div = s1['divergence_pct'] / 100.0
+s1_height = s1_len * slope  # 87.5 m
+s1_half_width = half_inner + s1_len * s1_div
+s1_center = der_point.project(s1_len, der_azimuth)
+s1_a = s1_center.project(s1_half_width, der_azimuth - 90)
+s1_b = s1_center.project(s1_half_width, der_azimuth + 90)
+
+# Section 2's divergence differs from section 1's, so the boundary
+# genuinely kinks -- widen incrementally from section 1's own edge
+# (mirrors qpansopy's width_area_2 = width_area_1 + distance_area_2 *
+# tan(...)), not cumulatively from DER.
+s2_len = s2['length_m']
+s2_div = s2['divergence_pct'] / 100.0
+s2_height = s1_height + s2_len * slope  # 295 m
+s2_half_width = s1_half_width + s2_len * s2_div
+s2_center = s1_center.project(s2_len, der_azimuth)
+s2_a = s2_center.project(s2_half_width, der_azimuth - 90)
+s2_b = s2_center.project(s2_half_width, der_azimuth + 90)
+
+# ---------------------------------------------------------------------------
+# Elevations
+# ---------------------------------------------------------------------------
+z0 = start_elevation_m + dims['initial_height_above_der_m']
+z1 = z0 + s1_height
+z2 = z0 + s2_height
+
+
+def _pz(pt, z):
+    p = QgsPoint(pt.x(), pt.y())
+    p.addZValue(z)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Memory layer
+# ---------------------------------------------------------------------------
+layer_name = "NewOLS_OES_Departure"
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", layer_name, "memory")
+v_layer_provider = v_layer.dataProvider()
+v_layer_provider.addAttributes([
+    QgsField("surface_type", QVariant.String),
+    QgsField("component", QVariant.String),
+    QgsField("slope_pct", QVariant.Double),
+    QgsField("rule_set", QVariant.String),
+])
+v_layer.updateFields()
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('New OLS OES Instrument Departure Surface', {
+    'start_elevation_m': round(start_elevation_m, 3),
+    'direction': direction,
+    'dimensions': dims,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
+features = []
+
+
+def _add_feature(component, slope_pct, ring_pts_with_z):
+    f = QgsFeature()
+    f.setGeometry(QgsPolygon(QgsLineString(ring_pts_with_z)))
+    f.setAttributes(["Instrument Departure Surface", component, slope_pct, _active_rule_set, _params_json])
+    features.append(f)
+
+
+_add_feature('section 1', dims['slope_pct'], [
+    _pz(der_a, z0), _pz(der_b, z0), _pz(s1_b, z1), _pz(s1_a, z1),
+])
+_add_feature('section 2', dims['slope_pct'], [
+    _pz(s1_a, z1), _pz(s1_b, z1), _pz(s2_b, z2), _pz(s2_a, z2),
+])
+
+v_layer_provider.addFeatures(features)
+v_layer.updateExtents()
+print(f"NewOLS_OES_Departure: Created {len(features)} feature(s)")
+
+register_parameters_action(v_layer)
+
+QgsProject.instance().addMapLayers([v_layer])
+
+symbol = QgsFillSymbol.createSimple({
+    'color': '220,20,60,90',  # crimson, transparent
+    'style': 'solid',
+    'outline_color': '178,10,46,220',
+    'outline_style': 'solid',
+    'outline_width': '0.7',
+})
+v_layer.renderer().setSymbol(symbol)
+v_layer.triggerRepaint()
+
+if features:
+    v_layer.selectAll()
+    canvas = iface.mapCanvas()
+    canvas.zoomToSelected(v_layer)
+    v_layer.removeSelection()
+    sc = canvas.scale()
+    if sc < 50000:
+        sc = 50000
+    canvas.zoomScale(sc)
+
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+
+iface.messageBar().pushMessage(
+    "QOLS Success",
+    "New OLS OES Instrument Departure Surface calculated successfully",
+    level=MSG_SUCCESS,
+)
+
+_script_success = True
+
+for _g in set(globals().keys()).difference(myglobals):
+    if _g not in ('myglobals', '_script_success'):
+        del globals()[_g]

--- a/qols/scripts/new-ols-oes-horizontal-UTM.py
+++ b/qols/scripts/new-ols-oes-horizontal-UTM.py
@@ -17,6 +17,11 @@ Conical vs. Inner Horizontal, via get_ring_hole_pairs() pairing each
 tier with the immediately-smaller tier whose disc must be subtracted
 from it.
 
+Per #159, each of the 3 tiers' radius/height is UI-editable
+(tier{1,2,3}_{radius,height}_m); ADG only selects how many of the
+(possibly-edited) tiers are drawn via get_adg_tier_count(), it does
+not change their values.
+
 Procedure to be used in Projected Coordinate System Only.
 """
 myglobals = set(globals().keys())
@@ -28,7 +33,7 @@ from qgis.gui import *
 import math
 from math import sqrt
 from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
-from qols.surfaces.new_ols_horizontal import get_horizontal_surface_rings, get_ring_hole_pairs
+from qols.surfaces.new_ols_horizontal import get_horizontal_surface_rings, get_ring_hole_pairs, get_adg_tier_count
 from qols.geometry_difference import difference_flat, flatten_ring_z
 
 _script_success = False
@@ -126,12 +131,20 @@ def _ring_polygon_2d(ring_xy):
 # ---------------------------------------------------------------------------
 # Parameter extraction
 # ---------------------------------------------------------------------------
+_default_tiers = get_horizontal_surface_rings('V')  # full 3-tier list, used as fallback only
+
 try:
     adg = globals().get('adg', 'IIC')
     aerodrome_elevation_m = globals().get('aerodrome_elevation_m', 0.0)
     direction = globals().get('direction', 0)
     runway_layer = globals().get('runway_layer', None)
     use_runway_selected = globals().get('use_runway_selected', True)
+    tier1_radius_m = globals().get('tier1_radius_m', _default_tiers[0]['radius_m'])
+    tier1_height_m = globals().get('tier1_height_m', _default_tiers[0]['height_m'])
+    tier2_radius_m = globals().get('tier2_radius_m', _default_tiers[1]['radius_m'])
+    tier2_height_m = globals().get('tier2_height_m', _default_tiers[1]['height_m'])
+    tier3_radius_m = globals().get('tier3_radius_m', _default_tiers[2]['radius_m'])
+    tier3_height_m = globals().get('tier3_height_m', _default_tiers[2]['height_m'])
 except Exception as e:
     print(f"NewOLS_OES_Horizontal: Error getting parameters, using defaults: {e}")
     adg = 'IIC'
@@ -139,8 +152,19 @@ except Exception as e:
     direction = 0
     runway_layer = None
     use_runway_selected = True
+    tier1_radius_m, tier1_height_m = _default_tiers[0]['radius_m'], _default_tiers[0]['height_m']
+    tier2_radius_m, tier2_height_m = _default_tiers[1]['radius_m'], _default_tiers[1]['height_m']
+    tier3_radius_m, tier3_height_m = _default_tiers[2]['radius_m'], _default_tiers[2]['height_m']
 
-rings = get_horizontal_surface_rings(adg)
+# UI-editable tiers (defaulted from Table 4-10, overridable per-tier);
+# ADG only selects how many of them apply (#159 — "expose all the
+# parameters", not just ADG).
+all_tiers = [
+    {'radius_m': tier1_radius_m, 'height_m': tier1_height_m},
+    {'radius_m': tier2_radius_m, 'height_m': tier2_height_m},
+    {'radius_m': tier3_radius_m, 'height_m': tier3_height_m},
+]
+rings = all_tiers[:get_adg_tier_count(adg)]
 print(f"NewOLS_OES_Horizontal: ADG={adg} -> {len(rings)} ring(s): {rings}")
 
 map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
@@ -203,8 +227,15 @@ for feat in selection:
     # the racetracks must not include the inner tier's area, mirroring
     # #124's Conical-vs-Inner-Horizontal fix). True non-overlapping
     # annuli don't need a specific draw order.
+    #
+    # #134 follow-up #2: unlike Conical (a genuine sloped frustum, whose
+    # inner/outer boundaries sit at different elevations by design),
+    # each Horizontal Surface ring is flat — every vertex, both its
+    # outer edge and its inner hole edge, sits at that ring's own
+    # height above the aerodrome elevation. So exterior_z and
+    # interior_z below must be the SAME value (z_absolute), not the
+    # previous (smaller) ring's height.
     prev_disc_geom = None
-    prev_z = None
     for ring, hole_source in get_ring_hole_pairs(rings):
         radius_m = ring['radius_m']
         height_m = ring['height_m']
@@ -221,11 +252,10 @@ for feat in selection:
             polygon_geometry = QgsGeometry(QgsPolygon(QgsLineString(ext_pts)))
         else:
             polygon_geometry = difference_flat(
-                disc_geom, prev_disc_geom, exterior_z=z_absolute, interior_z=prev_z
+                disc_geom, prev_disc_geom, exterior_z=z_absolute, interior_z=z_absolute
             )
 
         prev_disc_geom = disc_geom
-        prev_z = z_absolute
 
         feature = QgsFeature()
         feature.setGeometry(polygon_geometry)

--- a/qols/scripts/new-ols-oes-precision-approach-UTM.py
+++ b/qols/scripts/new-ols-oes-precision-approach-UTM.py
@@ -27,6 +27,17 @@ of always offsetting from ``back_azimuth``), so "left" stays the same
 physical side across the whole surface; using ``missed_azimuth ± 90``
 for the missed-approach half would silently swap left/right there.
 
+Per #159, every genuinely-used Table 4-12 value is UI-editable
+(appr_*/missed_*/trans_slope_pct — see the Parameters section below),
+defaulting to the ICAO table when not overridden.
+``missed_approach.inner_edge_m`` and
+``missed_approach.section_1.divergence_pct`` are intentionally not
+exposed: this script never reads them (both approach and missed-
+approach inner edges reuse ``half_inner`` from ``appr.inner_edge_m``
+only, and the missed-approach 1st-section half-width is derived from
+the transitional slope, not this divergence percentage — see
+qols/surfaces/new_ols_precision_approach.py's module docstring).
+
 Procedure to be used in Projected Coordinate System Only.
 """
 myglobals = set(globals().keys())
@@ -77,6 +88,10 @@ def _closest_feature(features, pt):
 # ---------------------------------------------------------------------------
 # Parameters
 # ---------------------------------------------------------------------------
+_defaults = get_precision_approach_dimensions()  # Table 4-12, used as fallback only
+_d_appr = _defaults['approach']
+_d_missed = _defaults['missed_approach']
+
 try:
     start_elevation_m = globals().get('start_elevation_m', 0.0)
     direction = globals().get('direction', 0)
@@ -84,6 +99,23 @@ try:
     threshold_layer = globals().get('threshold_layer', None)
     use_runway_selected = globals().get('use_runway_selected', True)
     use_threshold_selected = globals().get('use_threshold_selected', True)
+    appr_distance_from_threshold_m = globals().get(
+        'appr_distance_from_threshold_m', _d_appr['distance_from_threshold_m'])
+    appr_inner_edge_m = globals().get('appr_inner_edge_m', _d_appr['inner_edge_m'])
+    appr_s1_length_m = globals().get('appr_s1_length_m', _d_appr['section_1']['length_m'])
+    appr_s1_divergence_pct = globals().get('appr_s1_divergence_pct', _d_appr['section_1']['divergence_pct'])
+    appr_s1_slope_pct = globals().get('appr_s1_slope_pct', _d_appr['section_1']['slope_pct'])
+    appr_s2_length_m = globals().get('appr_s2_length_m', _d_appr['section_2']['length_m'])
+    appr_s2_divergence_pct = globals().get('appr_s2_divergence_pct', _d_appr['section_2']['divergence_pct'])
+    appr_s2_slope_pct = globals().get('appr_s2_slope_pct', _d_appr['section_2']['slope_pct'])
+    missed_distance_after_threshold_m = globals().get(
+        'missed_distance_after_threshold_m', _d_missed['distance_after_threshold_m'])
+    missed_s1_length_m = globals().get('missed_s1_length_m', _d_missed['section_1']['length_m'])
+    missed_s1_slope_pct = globals().get('missed_s1_slope_pct', _d_missed['section_1']['slope_pct'])
+    missed_s2_length_m = globals().get('missed_s2_length_m', _d_missed['section_2']['length_m'])
+    missed_s2_divergence_pct = globals().get('missed_s2_divergence_pct', _d_missed['section_2']['divergence_pct'])
+    missed_s2_slope_pct = globals().get('missed_s2_slope_pct', _d_missed['section_2']['slope_pct'])
+    trans_slope_pct = globals().get('trans_slope_pct', _defaults['transitional']['slope_pct'])
 except Exception as e:
     print(f"NewOLS_OES_PrecisionApproach: Error getting parameters, using defaults: {e}")
     start_elevation_m = 0.0
@@ -92,11 +124,47 @@ except Exception as e:
     threshold_layer = None
     use_runway_selected = True
     use_threshold_selected = True
+    appr_distance_from_threshold_m = _d_appr['distance_from_threshold_m']
+    appr_inner_edge_m = _d_appr['inner_edge_m']
+    appr_s1_length_m = _d_appr['section_1']['length_m']
+    appr_s1_divergence_pct = _d_appr['section_1']['divergence_pct']
+    appr_s1_slope_pct = _d_appr['section_1']['slope_pct']
+    appr_s2_length_m = _d_appr['section_2']['length_m']
+    appr_s2_divergence_pct = _d_appr['section_2']['divergence_pct']
+    appr_s2_slope_pct = _d_appr['section_2']['slope_pct']
+    missed_distance_after_threshold_m = _d_missed['distance_after_threshold_m']
+    missed_s1_length_m = _d_missed['section_1']['length_m']
+    missed_s1_slope_pct = _d_missed['section_1']['slope_pct']
+    missed_s2_length_m = _d_missed['section_2']['length_m']
+    missed_s2_divergence_pct = _d_missed['section_2']['divergence_pct']
+    missed_s2_slope_pct = _d_missed['section_2']['slope_pct']
+    trans_slope_pct = _defaults['transitional']['slope_pct']
 
-dims = get_precision_approach_dimensions()
+# #159 — "expose all the parameters": every genuinely-used Table 4-12
+# value above is UI-editable, defaulting to the ICAO table when not
+# overridden. missed_approach.inner_edge_m and
+# missed_approach.section_1.divergence_pct are intentionally excluded
+# (not read by this script at all — see module docstring — exposing
+# them as editable would mislead).
+dims = {
+    'approach': {
+        'distance_from_threshold_m': appr_distance_from_threshold_m,
+        'inner_edge_m': appr_inner_edge_m,
+        'section_1': {'length_m': appr_s1_length_m, 'divergence_pct': appr_s1_divergence_pct,
+                      'slope_pct': appr_s1_slope_pct},
+        'section_2': {'length_m': appr_s2_length_m, 'divergence_pct': appr_s2_divergence_pct,
+                      'slope_pct': appr_s2_slope_pct},
+    },
+    'missed_approach': {
+        'distance_after_threshold_m': missed_distance_after_threshold_m,
+        'section_1': {'length_m': missed_s1_length_m, 'slope_pct': missed_s1_slope_pct},
+        'section_2': {'length_m': missed_s2_length_m, 'divergence_pct': missed_s2_divergence_pct,
+                      'slope_pct': missed_s2_slope_pct},
+    },
+    'transitional': {'slope_pct': trans_slope_pct},
+}
 appr = dims['approach']
 missed = dims['missed_approach']
-trans_slope_pct = dims['transitional']['slope_pct']
 
 map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 

--- a/qols/surface_types.py
+++ b/qols/surface_types.py
@@ -33,6 +33,10 @@ class SurfaceType(str, Enum):
     # New OLS concept (ICAO approved) — dispatched by concept-tab index, not tab text
     NEW_OLS_OFS_APPROACH = "New OLS - Approach"
     NEW_OLS_OES_TRANSITIONAL = "New OLS - Transitional"
+    # #159 — OES tab split into individually-calculated subtabs, one
+    # SurfaceType per surface instead of the single shared token above.
+    NEW_OLS_OES_HORIZONTAL = "New OLS - OES Horizontal"
+    NEW_OLS_OES_DEPARTURE = "New OLS - OES Departure"
 
     @classmethod
     def from_tab_text(cls, text: str) -> "SurfaceType":

--- a/qols/surface_types.py
+++ b/qols/surface_types.py
@@ -37,6 +37,7 @@ class SurfaceType(str, Enum):
     # SurfaceType per surface instead of the single shared token above.
     NEW_OLS_OES_HORIZONTAL = "New OLS - OES Horizontal"
     NEW_OLS_OES_DEPARTURE = "New OLS - OES Departure"
+    NEW_OLS_OES_PRECISION_APPROACH = "New OLS - OES Precision Approach"
 
     @classmethod
     def from_tab_text(cls, text: str) -> "SurfaceType":

--- a/qols/surfaces/new_ols_departure.py
+++ b/qols/surfaces/new_ols_departure.py
@@ -1,0 +1,62 @@
+"""New OLS concept — Instrument Departure Surface ICAO defaults.
+
+Table 4-13 (Dimensions of instrument departure surface). Like Table
+4-12 (``new_ols_precision_approach.py``), this table has a single
+"I to V" column — no Aeroplane Design Group variation.
+
+Ported from qpansopy's Omnidirectional SID module
+(``Q_Pansopy/modules/departures/omnidirectional_sid.py``), per #136's
+own request ("similar to the OMNI SID without Area 3"): qpansopy's
+Area 1 (15 deg splay) / Area 2 (30 deg splay) match this table's
+``section_1``/``section_2`` shape exactly, and its
+``INITIAL_HEIGHT_ABOVE_DER = 5`` m / ``INITIAL_SEMI_WIDTH = 150`` m
+constants match ``initial_height_above_der_m`` / half of
+``inner_edge_m`` here exactly.
+
+Two differences found (values, not shape) — reported per the issue's
+own "let me know" request:
+
+* qpansopy's Area 1/Area 2 splay angles (15 deg / 30 deg) give
+  ``tan(15) = 26.79%`` / ``tan(30) = 57.735%`` — the table's own
+  published ``26.8%`` / ``57.8%`` are the same values rounded. Small
+  difference, so (per the issue's own criterion) the table's literal
+  percentages are used directly here rather than re-deriving them from
+  degrees.
+* qpansopy's Area 1/Area 2 *lengths* are derived from a user-supplied
+  Procedure Design Gradient and target altitudes (120 m AGL, then
+  TNA) — it models one specific departure procedure's climb profile.
+  This table instead gives fixed lengths (``3500``/``8300`` m) for the
+  generic OLS protection surface, independent of aircraft performance
+  — intentionally different tools, so the table's fixed lengths are
+  used as-is. Likewise qpansopy subtracts a 0.8% obstacle-clearance
+  margin from the PDG to get its effective climb slope; this table
+  publishes the final surface slope directly (``2.5%``), no margin
+  subtraction needed.
+"""
+from typing import Dict
+
+
+def get_departure_surface_dimensions() -> Dict[str, object]:
+    """Return ICAO Annex 14 Table 4-13 as a nested dict.
+
+    Returns:
+        Dict with:
+
+        * ``initial_height_above_der_m`` — height of the surface's
+          start above DER elevation.
+        * ``inner_edge_m`` — full width of the surface at DER.
+        * ``slope_pct`` — constant slope shared by both sections.
+        * ``section_1``/``section_2`` — ``length_m``/``divergence_pct``
+          dicts (divergence is each side, incremental from the
+          previous section's own edge).
+    """
+    return {
+        'initial_height_above_der_m': 5.0,
+        'inner_edge_m': 300.0,
+        'slope_pct': 2.5,
+        'section_1': {'length_m': 3500.0, 'divergence_pct': 26.8},
+        'section_2': {'length_m': 8300.0, 'divergence_pct': 57.8},
+    }
+
+
+__all__ = ['get_departure_surface_dimensions']

--- a/qols/surfaces/new_ols_horizontal.py
+++ b/qols/surfaces/new_ols_horizontal.py
@@ -77,6 +77,20 @@ def get_ring_hole_pairs(
     return [(ring, rings[i - 1] if i > 0 else None) for i, ring in enumerate(rings)]
 
 
+def get_adg_tier_count(adg: str) -> int:
+    """Return how many of the 3 cumulative tiers apply to ``adg``.
+
+    Args:
+        adg: Aeroplane Design Group (``"I"``, ``"IIA"``, ``"IIB"``,
+             ``"IIC"``, ``"III"``, ``"IV"``, or ``"V"``).
+
+    Returns:
+        ``1`` for I/IIA, ``2`` for IIB, ``3`` for IIC-V. An
+        unrecognized ``adg`` falls back to ``3``.
+    """
+    return _ADG_TIER_INDEX.get(adg, 2) + 1
+
+
 def get_horizontal_surface_rings(adg: str) -> List[Dict[str, float]]:
     """Return the cumulative list of rings for the given ADG group.
 
@@ -100,4 +114,5 @@ __all__ = [
     "ADG_GROUPS",
     "get_horizontal_surface_rings",
     "get_ring_hole_pairs",
+    "get_adg_tier_count",
 ]

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -47,8 +47,40 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         'spin_Z0_ofs':            2548.0,
         'spin_ZE_ofs':            2546.5,
         'spin_contour_interval_ofs': 10.0,
-        # OES Instrument Departure Surface (#136/#159) — DER elevation.
-        'spin_Z0_oes':            2548.0,
+        # OES Horizontal Surface (#134/#159) — Table 4-10 ring tiers,
+        # shared across all ADG selections (ADG only picks how many are drawn).
+        'spin_tier1Radius_oes_horizontal':  3350.0,
+        'spin_tier1Height_oes_horizontal':    45.0,
+        'spin_tier2Radius_oes_horizontal':  5350.0,
+        'spin_tier2Height_oes_horizontal':    60.0,
+        'spin_tier3Radius_oes_horizontal': 10750.0,
+        'spin_tier3Height_oes_horizontal':    90.0,
+        # OES Instrument Departure Surface (#136/#159) — Table 4-13.
+        'spin_Z0_oes':                      2548.0,
+        'spin_initHeight_oes_departure':       5.0,
+        'spin_innerEdge_oes_departure':      300.0,
+        'spin_slope_oes_departure':            2.5,
+        'spin_s1Len_oes_departure':         3500.0,
+        'spin_s1Div_oes_departure':           26.8,
+        'spin_s2Len_oes_departure':         8300.0,
+        'spin_s2Div_oes_departure':           57.8,
+        # OES Surface for Precision Approaches (#135/#159) — Table 4-12.
+        'spin_Z0_oes_precision':            2548.0,
+        'spin_apprDistThr_oes_precision':     60.0,
+        'spin_apprInnerEdge_oes_precision':  300.0,
+        'spin_apprS1Len_oes_precision':     3000.0,
+        'spin_apprS1Div_oes_precision':       15.0,
+        'spin_apprS1Slope_oes_precision':      2.0,
+        'spin_apprS2Len_oes_precision':     9600.0,
+        'spin_apprS2Div_oes_precision':       15.0,
+        'spin_apprS2Slope_oes_precision':      2.5,
+        'spin_missedDistThr_oes_precision':  900.0,
+        'spin_missedS1Len_oes_precision':   1800.0,
+        'spin_missedS1Slope_oes_precision':    2.5,
+        'spin_missedS2Len_oes_precision':  10200.0,
+        'spin_missedS2Div_oes_precision':     25.0,
+        'spin_missedS2Slope_oes_precision':    2.5,
+        'spin_transSlope_oes_precision':      14.3,
         # ARP (Aerodrome Reference Point) — shared by both tabs, moved to
         # a single top-level field (#131).
         'spin_ARP_elevation':     2548.0,
@@ -66,10 +98,40 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     spin_ZE_ofs: QLineEdit
     spin_contour_interval_ofs: QLineEdit
     oesSubTabWidget: QTabWidget
-    spin_Z0_oes: QLineEdit
     combo_adg_horizontal_oes: QComboBox
+    spin_tier1Radius_oes_horizontal: QLineEdit
+    spin_tier1Height_oes_horizontal: QLineEdit
+    spin_tier2Radius_oes_horizontal: QLineEdit
+    spin_tier2Height_oes_horizontal: QLineEdit
+    spin_tier3Radius_oes_horizontal: QLineEdit
+    spin_tier3Height_oes_horizontal: QLineEdit
+    spin_Z0_oes: QLineEdit
+    spin_initHeight_oes_departure: QLineEdit
+    spin_innerEdge_oes_departure: QLineEdit
+    spin_slope_oes_departure: QLineEdit
+    spin_s1Len_oes_departure: QLineEdit
+    spin_s1Div_oes_departure: QLineEdit
+    spin_s2Len_oes_departure: QLineEdit
+    spin_s2Div_oes_departure: QLineEdit
+    spin_Z0_oes_precision: QLineEdit
+    spin_apprDistThr_oes_precision: QLineEdit
+    spin_apprInnerEdge_oes_precision: QLineEdit
+    spin_apprS1Len_oes_precision: QLineEdit
+    spin_apprS1Div_oes_precision: QLineEdit
+    spin_apprS1Slope_oes_precision: QLineEdit
+    spin_apprS2Len_oes_precision: QLineEdit
+    spin_apprS2Div_oes_precision: QLineEdit
+    spin_apprS2Slope_oes_precision: QLineEdit
+    spin_missedDistThr_oes_precision: QLineEdit
+    spin_missedS1Len_oes_precision: QLineEdit
+    spin_missedS1Slope_oes_precision: QLineEdit
+    spin_missedS2Len_oes_precision: QLineEdit
+    spin_missedS2Div_oes_precision: QLineEdit
+    spin_missedS2Slope_oes_precision: QLineEdit
+    spin_transSlope_oes_precision: QLineEdit
     calculateButton_oes_horizontal: QPushButton
     calculateButton_oes_departure: QPushButton
+    calculateButton_oes_precision_approach: QPushButton
     spin_ARP_elevation: QLineEdit
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
@@ -142,6 +204,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             # oesSubTabWidget page to build the right specific_params.
             self._connect(self.calculateButton_oes_horizontal.clicked, self.on_calculate_clicked)
             self._connect(self.calculateButton_oes_departure.clicked, self.on_calculate_clicked)
+            self._connect(self.calculateButton_oes_precision_approach.clicked, self.on_calculate_clicked)
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
             self._connect(self.directionButton.clicked, self.toggle_direction)
 
@@ -175,7 +238,23 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             'spin_rwyWidth_ofs', 'spin_distThr_ofs', 'spin_innerEdge_ofs',
             'spin_divergence_ofs', 'spin_length_ofs', 'spin_slope_ofs',
             'spin_Z0_ofs', 'spin_ZE_ofs', 'spin_contour_interval_ofs',
+            'spin_tier1Radius_oes_horizontal', 'spin_tier1Height_oes_horizontal',
+            'spin_tier2Radius_oes_horizontal', 'spin_tier2Height_oes_horizontal',
+            'spin_tier3Radius_oes_horizontal', 'spin_tier3Height_oes_horizontal',
             'spin_Z0_oes',
+            'spin_initHeight_oes_departure', 'spin_innerEdge_oes_departure',
+            'spin_slope_oes_departure', 'spin_s1Len_oes_departure',
+            'spin_s1Div_oes_departure', 'spin_s2Len_oes_departure',
+            'spin_s2Div_oes_departure',
+            'spin_Z0_oes_precision',
+            'spin_apprDistThr_oes_precision', 'spin_apprInnerEdge_oes_precision',
+            'spin_apprS1Len_oes_precision', 'spin_apprS1Div_oes_precision',
+            'spin_apprS1Slope_oes_precision', 'spin_apprS2Len_oes_precision',
+            'spin_apprS2Div_oes_precision', 'spin_apprS2Slope_oes_precision',
+            'spin_missedDistThr_oes_precision', 'spin_missedS1Len_oes_precision',
+            'spin_missedS1Slope_oes_precision', 'spin_missedS2Len_oes_precision',
+            'spin_missedS2Div_oes_precision', 'spin_missedS2Slope_oes_precision',
+            'spin_transSlope_oes_precision',
             'spin_ARP_elevation',  # #131 — shared ARP elevation field
         ]
         decimal_pattern = r'^-?\d*(?:\.\d*)?$'
@@ -709,12 +788,47 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                         'adg': self.combo_adg_horizontal_oes.currentText(),
                         'aerodrome_elevation_m': arp_elevation_m,
                         'direction': s_value,
+                        'tier1_radius_m': self.get_numeric_value('spin_tier1Radius_oes_horizontal'),
+                        'tier1_height_m': self.get_numeric_value('spin_tier1Height_oes_horizontal'),
+                        'tier2_radius_m': self.get_numeric_value('spin_tier2Radius_oes_horizontal'),
+                        'tier2_height_m': self.get_numeric_value('spin_tier2Height_oes_horizontal'),
+                        'tier3_radius_m': self.get_numeric_value('spin_tier3Radius_oes_horizontal'),
+                        'tier3_height_m': self.get_numeric_value('spin_tier3Height_oes_horizontal'),
                     }
-                else:
+                elif oes_sub_index == 1:
                     surface_type = SurfaceType.NEW_OLS_OES_DEPARTURE
                     specific_params = {
                         'start_elevation_m': self.get_numeric_value('spin_Z0_oes'),
                         'direction': s_value,
+                        'initial_height_above_der_m': self.get_numeric_value('spin_initHeight_oes_departure'),
+                        'inner_edge_m': self.get_numeric_value('spin_innerEdge_oes_departure'),
+                        'slope_pct': self.get_numeric_value('spin_slope_oes_departure'),
+                        's1_length_m': self.get_numeric_value('spin_s1Len_oes_departure'),
+                        's1_divergence_pct': self.get_numeric_value('spin_s1Div_oes_departure'),
+                        's2_length_m': self.get_numeric_value('spin_s2Len_oes_departure'),
+                        's2_divergence_pct': self.get_numeric_value('spin_s2Div_oes_departure'),
+                    }
+                else:
+                    surface_type = SurfaceType.NEW_OLS_OES_PRECISION_APPROACH
+                    specific_params = {
+                        'start_elevation_m': self.get_numeric_value('spin_Z0_oes_precision'),
+                        'direction': s_value,
+                        'appr_distance_from_threshold_m': self.get_numeric_value('spin_apprDistThr_oes_precision'),
+                        'appr_inner_edge_m': self.get_numeric_value('spin_apprInnerEdge_oes_precision'),
+                        'appr_s1_length_m': self.get_numeric_value('spin_apprS1Len_oes_precision'),
+                        'appr_s1_divergence_pct': self.get_numeric_value('spin_apprS1Div_oes_precision'),
+                        'appr_s1_slope_pct': self.get_numeric_value('spin_apprS1Slope_oes_precision'),
+                        'appr_s2_length_m': self.get_numeric_value('spin_apprS2Len_oes_precision'),
+                        'appr_s2_divergence_pct': self.get_numeric_value('spin_apprS2Div_oes_precision'),
+                        'appr_s2_slope_pct': self.get_numeric_value('spin_apprS2Slope_oes_precision'),
+                        'missed_distance_after_threshold_m':
+                            self.get_numeric_value('spin_missedDistThr_oes_precision'),
+                        'missed_s1_length_m': self.get_numeric_value('spin_missedS1Len_oes_precision'),
+                        'missed_s1_slope_pct': self.get_numeric_value('spin_missedS1Slope_oes_precision'),
+                        'missed_s2_length_m': self.get_numeric_value('spin_missedS2Len_oes_precision'),
+                        'missed_s2_divergence_pct': self.get_numeric_value('spin_missedS2Div_oes_precision'),
+                        'missed_s2_slope_pct': self.get_numeric_value('spin_missedS2Slope_oes_precision'),
+                        'trans_slope_pct': self.get_numeric_value('spin_transSlope_oes_precision'),
                     }
 
             return {

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -7,7 +7,6 @@ Runs as an independent dock widget with its own toolbar button.
 import os
 import traceback
 from ..surfaces.new_ols_approach import get_new_ols_approach_defaults
-from ..surfaces.new_ols_transitional import get_new_ols_transitional_defaults
 from ..surface_types import SurfaceType
 from .. import logger
 from ..direction_marker import build_marker_geometry
@@ -15,7 +14,7 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QColor, QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
-    QApplication, QComboBox, QDialog, QDockWidget,
+    QApplication, QComboBox, QDialog, QDockWidget, QTabWidget,
     QLabel, QLineEdit, QMessageBox, QPushButton, QTextBrowser, QToolTip, QVBoxLayout,
 )
 from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL, GEOM_TYPE_POLYGON
@@ -48,11 +47,8 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         'spin_Z0_ofs':            2548.0,
         'spin_ZE_ofs':            2546.5,
         'spin_contour_interval_ofs': 10.0,
-        # OES Transitional
-        'spin_widthApp_oes':        155.0,
+        # OES Instrument Departure Surface (#136/#159) — DER elevation.
         'spin_Z0_oes':            2548.0,
-        'spin_ZE_oes':            2546.5,
-        'spin_slope_oes':            20.0,
         # ARP (Aerodrome Reference Point) — shared by both tabs, moved to
         # a single top-level field (#131).
         'spin_ARP_elevation':     2548.0,
@@ -69,11 +65,11 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     spin_Z0_ofs: QLineEdit
     spin_ZE_ofs: QLineEdit
     spin_contour_interval_ofs: QLineEdit
-    spin_widthApp_oes: QLineEdit
+    oesSubTabWidget: QTabWidget
     spin_Z0_oes: QLineEdit
-    spin_ZE_oes: QLineEdit
-    spin_slope_oes: QLineEdit
     combo_adg_horizontal_oes: QComboBox
+    calculateButton_oes_horizontal: QPushButton
+    calculateButton_oes_departure: QPushButton
     spin_ARP_elevation: QLineEdit
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
@@ -123,7 +119,6 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
 
             try:
                 self.apply_ofs_approach_defaults()
-                self.apply_oes_transitional_defaults()
             except Exception as e:
                 logger.warning(f"Could not apply initial New OLS defaults: {e}")
 
@@ -141,8 +136,20 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(self.arpLayerCombo.layerChanged, self.validate_layer_change)  # #131
 
             self._connect(self.calculateButton.clicked, self.on_calculate_clicked)
+            # #159 — each OES subtab gets its own Calculate button, wired
+            # to the same slot: validate_layers() + calculateClicked.emit()
+            # is surface-agnostic, get_parameters() reads the active
+            # oesSubTabWidget page to build the right specific_params.
+            self._connect(self.calculateButton_oes_horizontal.clicked, self.on_calculate_clicked)
+            self._connect(self.calculateButton_oes_departure.clicked, self.on_calculate_clicked)
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
             self._connect(self.directionButton.clicked, self.toggle_direction)
+
+            # #159 — the shared Calculate button only applies to the OFS
+            # tab now; OES surfaces are triggered individually from their
+            # own subtab buttons.
+            self._connect(self.newOlsTabWidget.currentChanged, self._update_calculate_button_visibility)
+            self._update_calculate_button_visibility()
 
             # Live direction-preview marker: update on layer change and zoom (#117)
             self._connect(self.runwayLayerCombo.layerChanged, self._update_direction_marker)
@@ -168,7 +175,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             'spin_rwyWidth_ofs', 'spin_distThr_ofs', 'spin_innerEdge_ofs',
             'spin_divergence_ofs', 'spin_length_ofs', 'spin_slope_ofs',
             'spin_Z0_ofs', 'spin_ZE_ofs', 'spin_contour_interval_ofs',
-            'spin_widthApp_oes', 'spin_Z0_oes', 'spin_ZE_oes', 'spin_slope_oes',
+            'spin_Z0_oes',
             'spin_ARP_elevation',  # #131 — shared ARP elevation field
         ]
         decimal_pattern = r'^-?\d*(?:\.\d*)?$'
@@ -435,23 +442,16 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self.set_numeric_value('spin_divergence_ofs', d['divergence_pct'])
             self.set_numeric_value('spin_length_ofs', d['length_m'])
             self.set_numeric_value('spin_slope_ofs', d['slope_pct'])
-            self.apply_oes_transitional_defaults()
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
-    @pyqtSlot()
-    def apply_oes_transitional_defaults(self):
-        """Populate OES Transitional fields. OES width tracks the OFS inner edge."""
+    @pyqtSlot(int)
+    def _update_calculate_button_visibility(self, _index=None):
+        """Shared Calculate button drives the OFS tab only (#159) — OES
+        surfaces are each triggered from their own subtab button."""
         try:
-            d = get_new_ols_transitional_defaults()
-            self.set_numeric_value('spin_slope_oes', d['slope_pct'])
-            inner_edge_widget = getattr(self, 'spin_innerEdge_ofs', None)
-            if inner_edge_widget and hasattr(inner_edge_widget, 'text'):
-                try:
-                    inner_val = float(inner_edge_widget.text() or "155")
-                    self.set_numeric_value('spin_widthApp_oes', inner_val)
-                except ValueError:
-                    pass
+            is_ofs = self.newOlsTabWidget.currentIndex() == 0
+            self.calculateButton.setVisible(is_ofs)
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
@@ -697,26 +697,25 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                     'contour_interval_m': int(round(self.get_numeric_value('spin_contour_interval_ofs'))),
                 }
             else:
-                surface_type = SurfaceType.NEW_OLS_OES_TRANSITIONAL
+                # #159 — OES subtabs are each calculated individually;
+                # oesSubTabWidget.currentIndex() picks which surface's own
+                # isolated params to build, mirroring the OFS/OES split
+                # above instead of bundling every OES surface into one dict.
                 s_value = direction
-                specific_params = {
-                    'width_m': self.get_numeric_value('spin_widthApp_oes'),
-                    'start_elevation_m': self.get_numeric_value('spin_Z0_oes'),
-                    # highest_thr_elev_m: this script's own name for the Z
-                    # ceiling, now sourced from the shared ARP elevation (#131)
-                    # instead of its own spin_ARPH_oes field.
-                    'highest_thr_elev_m': arp_elevation_m,
-                    'slope_pct': self.get_numeric_value('spin_slope_oes'),
-                    'cap_height_m': 60.0,
-                    'approach_slope_pct': self.get_numeric_value('spin_slope_ofs'),
-                    'divergence_ratio': self.get_numeric_value('spin_divergence_ofs') / 100.0,
-                    'distance_from_threshold_m': self.get_numeric_value('spin_distThr_ofs'),
-                    'direction': s_value,
-                    # Horizontal Surface (#134) — ADG-driven ring set;
-                    # reuses highest_thr_elev_m (above) as its aerodrome
-                    # elevation datum instead of a separate field.
-                    'adg': self.combo_adg_horizontal_oes.currentText(),
-                }
+                oes_sub_index = self.oesSubTabWidget.currentIndex()
+                if oes_sub_index == 0:
+                    surface_type = SurfaceType.NEW_OLS_OES_HORIZONTAL
+                    specific_params = {
+                        'adg': self.combo_adg_horizontal_oes.currentText(),
+                        'aerodrome_elevation_m': arp_elevation_m,
+                        'direction': s_value,
+                    }
+                else:
+                    surface_type = SurfaceType.NEW_OLS_OES_DEPARTURE
+                    specific_params = {
+                        'start_elevation_m': self.get_numeric_value('spin_Z0_oes'),
+                        'direction': s_value,
+                    }
 
             return {
                 'surface_type': surface_type,

--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -415,85 +415,107 @@
       <!-- OES TAB -->
       <widget class="QWidget" name="tab_oes">
        <attribute name="title"><string>OES</string></attribute>
-       <layout class="QFormLayout" name="formLayout_oes">
-        <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
-        <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
-        <property name="horizontalSpacing"><number>15</number></property>
-        <property name="verticalSpacing"><number>6</number></property>
+       <layout class="QVBoxLayout" name="verticalLayout_oes">
 
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_widthApp_oes">
-          <property name="text"><string>Width App (m):</string></property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="spin_widthApp_oes">
-          <property name="text"><string>155.00</string></property>
-          <property name="toolTip"><string>Approach inner edge width from OFS tab. Auto-populated; editable.</string></property>
-         </widget>
-        </item>
-
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_Z0_oes">
-          <property name="text"><string>Start Elevation (m):</string></property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="spin_Z0_oes">
-          <property name="text"><string>2548.00</string></property>
-         </widget>
-        </item>
-
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_ZE_oes">
-          <property name="text"><string>End Elevation (m):</string></property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="spin_ZE_oes">
-          <property name="text"><string>2546.50</string></property>
-         </widget>
-        </item>
-
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_slope_oes">
-          <property name="text"><string>Slope (%):</string></property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="spin_slope_oes">
-          <property name="text"><string>20.00</string></property>
-          <property name="toolTip"><string>Transitional surface slope in percent. Default 20%.</string></property>
-         </widget>
-        </item>
-
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_adg_horizontal_oes">
-          <property name="text"><string>ADG (Horizontal Surface):</string></property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="combo_adg_horizontal_oes">
-          <property name="minimumHeight"><number>22</number></property>
-          <property name="currentIndex"><number>3</number></property>
-          <property name="toolTip"><string>Aeroplane Design Group for the Horizontal Surface (Table 4-10). Independent of the OFS tab's ADG Group — I/IIA, IIB, and IIC-V are distinct dimension tiers here.</string></property>
-          <item><property name="text"><string>I</string></property></item>
-          <item><property name="text"><string>IIA</string></property></item>
-          <item><property name="text"><string>IIB</string></property></item>
-          <item><property name="text"><string>IIC</string></property></item>
-          <item><property name="text"><string>III</string></property></item>
-          <item><property name="text"><string>IV</string></property></item>
-          <item><property name="text"><string>V</string></property></item>
-         </widget>
-        </item>
-
-        <item row="5" column="0" colspan="2">
-         <widget class="QLabel" name="label_oes_note">
-          <property name="text">
-           <string>Upper edge at 60 m above the highest threshold elevation. Lateral extent = 60 / (slope/100) from approach edge.</string>
+        <!-- #159 — each OES surface is its own subtab with its own
+             Calculate button and only its own parameters, instead of
+             one shared Calculate bundling every OES surface together. -->
+        <item>
+         <widget class="QTabWidget" name="oesSubTabWidget">
+          <property name="tabPosition">
+           <enum>QTabWidget::North</enum>
           </property>
-          <property name="wordWrap"><bool>true</bool></property>
-          <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
+
+          <!-- HORIZONTAL SURFACE SUBTAB (#134) -->
+          <widget class="QWidget" name="oes_sub_horizontal">
+           <attribute name="title"><string>Horizontal Surface</string></attribute>
+           <layout class="QFormLayout" name="formLayout_oes_horizontal">
+            <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
+            <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+            <property name="horizontalSpacing"><number>15</number></property>
+            <property name="verticalSpacing"><number>6</number></property>
+
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_adg_horizontal_oes">
+              <property name="text"><string>ADG (Horizontal Surface):</string></property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="combo_adg_horizontal_oes">
+              <property name="minimumHeight"><number>22</number></property>
+              <property name="currentIndex"><number>3</number></property>
+              <property name="toolTip"><string>Aeroplane Design Group for the Horizontal Surface (Table 4-10). Independent of the OFS tab's ADG Group — I/IIA, IIB, and IIC-V are distinct dimension tiers here.</string></property>
+              <item><property name="text"><string>I</string></property></item>
+              <item><property name="text"><string>IIA</string></property></item>
+              <item><property name="text"><string>IIB</string></property></item>
+              <item><property name="text"><string>IIC</string></property></item>
+              <item><property name="text"><string>III</string></property></item>
+              <item><property name="text"><string>IV</string></property></item>
+              <item><property name="text"><string>V</string></property></item>
+             </widget>
+            </item>
+
+            <item row="1" column="0" colspan="2">
+             <widget class="QLabel" name="label_oes_horizontal_note">
+              <property name="text">
+               <string>Uses the shared ARP Elevation and Direction fields above. Table 4-10 ring set, keyed by ADG.</string>
+              </property>
+              <property name="wordWrap"><bool>true</bool></property>
+              <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="2" column="0" colspan="2">
+             <widget class="QPushButton" name="calculateButton_oes_horizontal">
+              <property name="text"><string>Calculate Horizontal Surface</string></property>
+              <property name="minimumHeight"><number>30</number></property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+
+          <!-- INSTRUMENT DEPARTURE SURFACE SUBTAB (#136) -->
+          <widget class="QWidget" name="oes_sub_departure">
+           <attribute name="title"><string>Instrument Departure Surface</string></attribute>
+           <layout class="QFormLayout" name="formLayout_oes_departure">
+            <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
+            <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+            <property name="horizontalSpacing"><number>15</number></property>
+            <property name="verticalSpacing"><number>6</number></property>
+
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_Z0_oes">
+              <property name="text"><string>DER Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="spin_Z0_oes">
+              <property name="text"><string>2548.00</string></property>
+              <property name="toolTip"><string>Departure End of Runway elevation. Surface starts 5 m above this value (Table 4-13).</string></property>
+             </widget>
+            </item>
+
+            <item row="1" column="0" colspan="2">
+             <widget class="QLabel" name="label_oes_departure_note">
+              <property name="text">
+               <string>Uses the shared Runway Layer and Direction fields above. Table 4-13 fixed dimensions, no ADG.</string>
+              </property>
+              <property name="wordWrap"><bool>true</bool></property>
+              <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="2" column="0" colspan="2">
+             <widget class="QPushButton" name="calculateButton_oes_departure">
+              <property name="text"><string>Calculate Instrument Departure Surface</string></property>
+              <property name="minimumHeight"><number>30</number></property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+
          </widget>
         </item>
 

--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -455,17 +455,83 @@
              </widget>
             </item>
 
-            <item row="1" column="0" colspan="2">
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_tier1Radius_oes_horizontal">
+              <property name="text"><string>Tier 1 Radius, I/IIA (m):</string></property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="spin_tier1Radius_oes_horizontal">
+              <property name="text"><string>3350.00</string></property>
+             </widget>
+            </item>
+
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_tier1Height_oes_horizontal">
+              <property name="text"><string>Tier 1 Height, I/IIA (m):</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="spin_tier1Height_oes_horizontal">
+              <property name="text"><string>45.00</string></property>
+             </widget>
+            </item>
+
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_tier2Radius_oes_horizontal">
+              <property name="text"><string>Tier 2 Radius, IIB (m):</string></property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="spin_tier2Radius_oes_horizontal">
+              <property name="text"><string>5350.00</string></property>
+             </widget>
+            </item>
+
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_tier2Height_oes_horizontal">
+              <property name="text"><string>Tier 2 Height, IIB (m):</string></property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="spin_tier2Height_oes_horizontal">
+              <property name="text"><string>60.00</string></property>
+             </widget>
+            </item>
+
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_tier3Radius_oes_horizontal">
+              <property name="text"><string>Tier 3 Radius, IIC-V (m):</string></property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="spin_tier3Radius_oes_horizontal">
+              <property name="text"><string>10750.00</string></property>
+             </widget>
+            </item>
+
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_tier3Height_oes_horizontal">
+              <property name="text"><string>Tier 3 Height, IIC-V (m):</string></property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="spin_tier3Height_oes_horizontal">
+              <property name="text"><string>90.00</string></property>
+             </widget>
+            </item>
+
+            <item row="7" column="0" colspan="2">
              <widget class="QLabel" name="label_oes_horizontal_note">
               <property name="text">
-               <string>Uses the shared ARP Elevation and Direction fields above. Table 4-10 ring set, keyed by ADG.</string>
+               <string>Uses the shared ARP Elevation and Direction fields above. ADG selects how many tiers (rings) are drawn, from the bottom up; tier values themselves are editable.</string>
               </property>
               <property name="wordWrap"><bool>true</bool></property>
               <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
              </widget>
             </item>
 
-            <item row="2" column="0" colspan="2">
+            <item row="8" column="0" colspan="2">
              <widget class="QPushButton" name="calculateButton_oes_horizontal">
               <property name="text"><string>Calculate Horizontal Surface</string></property>
               <property name="minimumHeight"><number>30</number></property>
@@ -496,19 +562,324 @@
              </widget>
             </item>
 
-            <item row="1" column="0" colspan="2">
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_initHeight_oes_departure">
+              <property name="text"><string>Initial Height Above DER (m):</string></property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="spin_initHeight_oes_departure">
+              <property name="text"><string>5.00</string></property>
+             </widget>
+            </item>
+
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_innerEdge_oes_departure">
+              <property name="text"><string>Inner Edge (m):</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="spin_innerEdge_oes_departure">
+              <property name="text"><string>300.00</string></property>
+             </widget>
+            </item>
+
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_slope_oes_departure">
+              <property name="text"><string>Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="spin_slope_oes_departure">
+              <property name="text"><string>2.50</string></property>
+             </widget>
+            </item>
+
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_s1Len_oes_departure">
+              <property name="text"><string>Section 1 Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="spin_s1Len_oes_departure">
+              <property name="text"><string>3500.00</string></property>
+             </widget>
+            </item>
+
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_s1Div_oes_departure">
+              <property name="text"><string>Section 1 Divergence (%):</string></property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="spin_s1Div_oes_departure">
+              <property name="text"><string>26.80</string></property>
+             </widget>
+            </item>
+
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_s2Len_oes_departure">
+              <property name="text"><string>Section 2 Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="spin_s2Len_oes_departure">
+              <property name="text"><string>8300.00</string></property>
+             </widget>
+            </item>
+
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_s2Div_oes_departure">
+              <property name="text"><string>Section 2 Divergence (%):</string></property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QLineEdit" name="spin_s2Div_oes_departure">
+              <property name="text"><string>57.80</string></property>
+             </widget>
+            </item>
+
+            <item row="8" column="0" colspan="2">
              <widget class="QLabel" name="label_oes_departure_note">
               <property name="text">
-               <string>Uses the shared Runway Layer and Direction fields above. Table 4-13 fixed dimensions, no ADG.</string>
+               <string>Uses the shared Runway Layer and Direction fields above. No ADG (Table 4-13 is a single dimension set).</string>
               </property>
               <property name="wordWrap"><bool>true</bool></property>
               <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
              </widget>
             </item>
 
-            <item row="2" column="0" colspan="2">
+            <item row="9" column="0" colspan="2">
              <widget class="QPushButton" name="calculateButton_oes_departure">
               <property name="text"><string>Calculate Instrument Departure Surface</string></property>
+              <property name="minimumHeight"><number>30</number></property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+
+          <!-- SURFACE FOR PRECISION APPROACHES SUBTAB (#135) -->
+          <widget class="QWidget" name="oes_sub_precision_approach">
+           <attribute name="title"><string>Surface for Precision Approaches</string></attribute>
+           <layout class="QFormLayout" name="formLayout_oes_precision_approach">
+            <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
+            <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+            <property name="horizontalSpacing"><number>15</number></property>
+            <property name="verticalSpacing"><number>6</number></property>
+
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_Z0_oes_precision">
+              <property name="text"><string>Threshold Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="spin_Z0_oes_precision">
+              <property name="text"><string>2548.00</string></property>
+              <property name="toolTip"><string>Threshold elevation used as the datum for the Approach/Missed Approach/Transitional components (Table 4-12).</string></property>
+             </widget>
+            </item>
+
+            <item row="1" column="0" colspan="2">
+             <widget class="QLabel" name="label_appr_header_oes_precision">
+              <property name="text"><string>Approach</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 6px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_apprDistThr_oes_precision">
+              <property name="text"><string>Distance from THR (m):</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="spin_apprDistThr_oes_precision">
+              <property name="text"><string>60.00</string></property>
+             </widget>
+            </item>
+
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_apprInnerEdge_oes_precision">
+              <property name="text"><string>Inner Edge (m):</string></property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="spin_apprInnerEdge_oes_precision">
+              <property name="text"><string>300.00</string></property>
+             </widget>
+            </item>
+
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_apprS1Len_oes_precision">
+              <property name="text"><string>Section 1 Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="spin_apprS1Len_oes_precision">
+              <property name="text"><string>3000.00</string></property>
+             </widget>
+            </item>
+
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_apprS1Div_oes_precision">
+              <property name="text"><string>Section 1 Divergence (%):</string></property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="spin_apprS1Div_oes_precision">
+              <property name="text"><string>15.00</string></property>
+             </widget>
+            </item>
+
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_apprS1Slope_oes_precision">
+              <property name="text"><string>Section 1 Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="spin_apprS1Slope_oes_precision">
+              <property name="text"><string>2.00</string></property>
+             </widget>
+            </item>
+
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_apprS2Len_oes_precision">
+              <property name="text"><string>Section 2 Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QLineEdit" name="spin_apprS2Len_oes_precision">
+              <property name="text"><string>9600.00</string></property>
+             </widget>
+            </item>
+
+            <item row="8" column="0">
+             <widget class="QLabel" name="label_apprS2Div_oes_precision">
+              <property name="text"><string>Section 2 Divergence (%):</string></property>
+             </widget>
+            </item>
+            <item row="8" column="1">
+             <widget class="QLineEdit" name="spin_apprS2Div_oes_precision">
+              <property name="text"><string>15.00</string></property>
+             </widget>
+            </item>
+
+            <item row="9" column="0">
+             <widget class="QLabel" name="label_apprS2Slope_oes_precision">
+              <property name="text"><string>Section 2 Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <widget class="QLineEdit" name="spin_apprS2Slope_oes_precision">
+              <property name="text"><string>2.50</string></property>
+             </widget>
+            </item>
+
+            <item row="10" column="0" colspan="2">
+             <widget class="QLabel" name="label_missed_header_oes_precision">
+              <property name="text"><string>Missed Approach</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 6px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="11" column="0">
+             <widget class="QLabel" name="label_missedDistThr_oes_precision">
+              <property name="text"><string>Distance after THR (m):</string></property>
+             </widget>
+            </item>
+            <item row="11" column="1">
+             <widget class="QLineEdit" name="spin_missedDistThr_oes_precision">
+              <property name="text"><string>900.00</string></property>
+             </widget>
+            </item>
+
+            <item row="12" column="0">
+             <widget class="QLabel" name="label_missedS1Len_oes_precision">
+              <property name="text"><string>Section 1 Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="12" column="1">
+             <widget class="QLineEdit" name="spin_missedS1Len_oes_precision">
+              <property name="text"><string>1800.00</string></property>
+             </widget>
+            </item>
+
+            <item row="13" column="0">
+             <widget class="QLabel" name="label_missedS1Slope_oes_precision">
+              <property name="text"><string>Section 1 Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="13" column="1">
+             <widget class="QLineEdit" name="spin_missedS1Slope_oes_precision">
+              <property name="text"><string>2.50</string></property>
+              <property name="toolTip"><string>Section 1's divergence is not a separate input: its half-width is derived from the Transitional slope reaching this section's height of rise (Table 4-12 note; see new_ols_precision_approach.py).</string></property>
+             </widget>
+            </item>
+
+            <item row="14" column="0">
+             <widget class="QLabel" name="label_missedS2Len_oes_precision">
+              <property name="text"><string>Section 2 Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="14" column="1">
+             <widget class="QLineEdit" name="spin_missedS2Len_oes_precision">
+              <property name="text"><string>10200.00</string></property>
+             </widget>
+            </item>
+
+            <item row="15" column="0">
+             <widget class="QLabel" name="label_missedS2Div_oes_precision">
+              <property name="text"><string>Section 2 Divergence (%):</string></property>
+             </widget>
+            </item>
+            <item row="15" column="1">
+             <widget class="QLineEdit" name="spin_missedS2Div_oes_precision">
+              <property name="text"><string>25.00</string></property>
+             </widget>
+            </item>
+
+            <item row="16" column="0">
+             <widget class="QLabel" name="label_missedS2Slope_oes_precision">
+              <property name="text"><string>Section 2 Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="16" column="1">
+             <widget class="QLineEdit" name="spin_missedS2Slope_oes_precision">
+              <property name="text"><string>2.50</string></property>
+             </widget>
+            </item>
+
+            <item row="17" column="0" colspan="2">
+             <widget class="QLabel" name="label_trans_header_oes_precision">
+              <property name="text"><string>Transitional</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 6px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="18" column="0">
+             <widget class="QLabel" name="label_transSlope_oes_precision">
+              <property name="text"><string>Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="18" column="1">
+             <widget class="QLineEdit" name="spin_transSlope_oes_precision">
+              <property name="text"><string>14.30</string></property>
+             </widget>
+            </item>
+
+            <item row="19" column="0" colspan="2">
+             <widget class="QLabel" name="label_oes_precision_approach_note">
+              <property name="text">
+               <string>Uses the shared Runway Layer, Threshold Layer, and Direction fields above. No ADG (Table 4-12 is a single dimension set).</string>
+              </property>
+              <property name="wordWrap"><bool>true</bool></property>
+              <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="20" column="0" colspan="2">
+             <widget class="QPushButton" name="calculateButton_oes_precision_approach">
+              <property name="text"><string>Calculate Surface for Precision Approaches</string></property>
               <property name="minimumHeight"><number>30</number></property>
              </widget>
             </item>


### PR DESCRIPTION
# feature(#136): Instrument departure surface (OES, New OLS)

## Summary

Closes #136.

Issue #136 "Include in OES tab. Should be similar
to the OMNI SID without Area 3." Adds ICAO Annex 14 **Table 4-13 /
Figure 4-7** "Instrument departure surface" to the New OLS panel's OES
tab: two trapezoid sections widening from the DER (Departure End of
Runway) line, each at its own divergence rate, sharing one constant
2.5% slope — all in one output layer.

---

## Difference found (reported per the issue's request)

qpansopy's reference implementation
(`Q_Pansopy/modules/departures/omnidirectional_sid.py::run_omnidirectional_sid`)
was read in full. "Similar to the OMNI SID without Area 3" checks out:
its Area 1 (15° splay, DER to 120 m AGL) and Area 2 (30° splay, 120 m
to TNA) match Table 4-13's section 1/section 2 shape exactly; Area 3
(a circular buffer out to MSA, subtracted from Areas 1/2) has no
equivalent in Table 4-13 and is not built here — exactly the "without
Area 3" the issue asks for.

**Two value differences found, both small/intentional**:

- **Splay angle vs. table's literal divergence %**: qpansopy's 15°/30°
  splays give `tan(15°) = 26.79%` / `tan(30°) = 57.735%`. Table 4-13
  publishes `26.8%` / `57.8%` directly — pure rounding, under 0.07
  percentage points. **Small, per the issue's own criterion** ("if
  small we keep PANS-OPS values instead") — but since the table already
  hands us the intended percentage, the port uses Table 4-13's own
  **26.8%** / **57.8%** literally, no trig needed, matching the
  approach already used for #134/#135's own literal-percentage tables.
- **Section lengths and slope — structural, not rounding**: qpansopy
  *derives* Area 1/2's lengths from a user-supplied Procedure Design
  Gradient and target altitudes (120 m AGL, then TNA) and applies a
  0.8% obstacle-clearance margin to get its effective slope — it's
  modelling one specific departure procedure's real climb profile.
  Table 4-13 instead gives **fixed** lengths (**3500 m** / **8300 m**)
  and a flat **2.5%** slope for the generic OLS protection surface,
  independent of any aircraft's performance. Intentionally different
  tools for different purposes — Table 4-13's fixed values are what
  #136 asks for, used directly.

**Exact matches, reused as-is**: qpansopy's `INITIAL_HEIGHT_ABOVE_DER =
5` m matches "the surface starts 5 m above DER elev" exactly;
`INITIAL_SEMI_WIDTH = 150` m matches Table 4-13's "Length of inner
edge" (300 m) / 2 exactly.

The "60 m" callout in the issue's Cross-section A-A figure reads as a
drawing-scale annotation (showing where the 5 m step sits relative to
the runway end), not a literal distance — not modelled as geometry,
same treatment as other illustrative-only ICAO figure callouts this
session.

---

## Changes

### `qols/surfaces/new_ols_departure.py` (new)
Pure-Python Table 4-13 as a dict (`initial_height_above_der_m`,
`inner_edge_m`, `slope_pct`, `section_1`/`section_2`), no QGIS
dependency, no ADG lookup (single "I to V" column).

### `qols/scripts/new-ols-oes-departure-UTM.py` (new)
Geometry, ported from `run_omnidirectional_sid()`'s Area 1/Area 2
construction. DER is resolved as the runway centerline's own far
endpoint (`near_end_pt`/`far_end_pt` convention shared with
`new-ols-oes-precision-approach-UTM.py`) — no separate DER point layer
requested or needed; `der_azimuth = near_end_pt.azimuth(far_end_pt)`
points away from the runway in the takeoff/climb-out direction (the
same direction #135 calls `missed_azimuth`). Section 2 widens
*incrementally* from section 1's own edge (mirrors qpansopy's
`width_area_2 = width_area_1 + distance_area_2 * tan(...)`), not
cumulatively from DER, since the two sections' divergence rates differ
and the boundary genuinely kinks. No new UI: reuses the OES tab's
existing `start_elevation_m` (`spin_Z0_oes`) as the DER elevation
input, plus `runway_layer`/`direction`/`use_runway_selected`.

### `qols/plugin.py`
New `execute_new_ols_oes_departure(params)` — its own dispatch method
(not folded into Horizontal or Transitional), called from
`on_calculate_new_ols()`'s OES branch alongside
`execute_new_ols_oes_horizontal`. No param remapping needed.

### `tests/test_dockwidget_logic.py`
New `TestGetDepartureSurfaceDimensions` (5 tests): asserts every Table
4-13 value, top-level key set, mutation-independence of the returned
dict.

---

## Verification

```bash
pytest -q -p no:pytest-qt --ignore=tests/test_conical_contour_radius.py --ignore=tests/test_geometry_difference.py --ignore=tests/test_tab_row_selector.py
# 566 passed (561 baseline + 5 new dimension tests)

flake8 qols/surfaces/new_ols_departure.py qols/plugin.py qols/scripts/new-ols-oes-departure-UTM.py
# new_ols_departure.py: 0 issues
# plugin.py: 0 issues
# new-ols-oes-departure-UTM.py: 33 findings, all F403/F405/E402
# (star imports) — same accepted class every qols/scripts/*.py file carries
```
