### PR TITLE
fix(#155): Transitional Surface contours must stay local to each ruled patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pyproject.toml
 .claude/
 skills-lock.json
 CLAUDE.md
+graphify-out/
 
 # Python cache
 __pycache__/

--- a/qols/scripts/TransitionalSurface_UTM.py
+++ b/qols/scripts/TransitionalSurface_UTM.py
@@ -469,11 +469,32 @@ if contour_interval_m > 0:
     # (pt_08*/pt_01T*/pt_02T*), not a straight chord between two points.
     _elevs = [e for e in _elevs if e < ZIH - 1e-6]
 
-    _verts_left = [(p.x(), p.y(), p.z()) for p in (pt_08L, pt_01TL, pt_02TL, pt_02L, pt_01AL)]
-    _verts_right = [(p.x(), p.y(), p.z()) for p in (pt_08R, pt_01TR, pt_02TR, pt_02R, pt_01AR)]
+    # #155 — the 5-vertex pentagon is NOT one flat surface: it is two
+    # ruled patches glued along the internal rib pt_01AL-pt_01TL.
+    #   - Strip patch (trapezoid): toe pt_02L(ZE)->pt_01AL(Z0) along the
+    #     runway strip, flat top pt_02TL(ZIH)->pt_01TL(ZIH).
+    #   - Fan patch (triangle): apex pt_01AL(Z0), flat top edge
+    #     pt_01TL(ZIH)->pt_08L(ZIH) - a genuine cone, so its own
+    #     per-level contour really is a straight chord.
+    # Slicing the whole pentagon in one call (the old behaviour) picks
+    # the fan patch's far edge and the strip patch's far end-cap for
+    # almost every level, skipping the shared rib and drawing one long
+    # diagonal across nearly the whole runway. Slicing each patch on
+    # its own fixes this: both rings close on the same rib edge
+    # pt_01AL->pt_01TL, so for any level between Z0 and ZIH both
+    # patches report the identical crossing point there, and the two
+    # segments chain into one connected, correctly-bent line with no
+    # stitching needed. Contours are naturally capped at ZIH, since no
+    # patch's top edge (flat) ever registers a crossing.
+    _verts_left_strip = [(p.x(), p.y(), p.z()) for p in (pt_01TL, pt_02TL, pt_02L, pt_01AL)]
+    _verts_left_fan = [(p.x(), p.y(), p.z()) for p in (pt_01TL, pt_08L, pt_01AL)]
+    _verts_right_strip = [(p.x(), p.y(), p.z()) for p in (pt_01TR, pt_02TR, pt_02R, pt_01AR)]
+    _verts_right_fan = [(p.x(), p.y(), p.z()) for p in (pt_01TR, pt_08R, pt_01AR)]
 
-    _specs_left = _cu.contour_specs_for_polygon_slice(_verts_left, _elevs)
-    _specs_right = _cu.contour_specs_for_polygon_slice(_verts_right, _elevs)
+    _specs_left = (_cu.contour_specs_for_polygon_slice(_verts_left_strip, _elevs)
+                   + _cu.contour_specs_for_polygon_slice(_verts_left_fan, _elevs))
+    _specs_right = (_cu.contour_specs_for_polygon_slice(_verts_right_strip, _elevs)
+                     + _cu.contour_specs_for_polygon_slice(_verts_right_fan, _elevs))
     _all_specs = _specs_left + _specs_right
 
     if _all_specs:


### PR DESCRIPTION
# fix(#155): Transitional Surface contours must stay local to each ruled patch

## Goal

Issue #155 : Transitional Surface contour lines
extend far outside the surface's true footprint, drawn as long
diagonal lines instead of short, locally-bent bands, and appear above
the plateau elevation when they shouldn't. Fix the underlying
elevation-slicing math (not a polygon clip — confirmed this is a
calculation bug, not a missing clip step, and no clip utility exists
in this codebase to reuse).

## Findings

Each side of the Transitional Surface is a 5-vertex pentagon
(`pt_08L, pt_01TL, pt_02TL, pt_02L, pt_01AL`, elevations
`ZIH, ZIH, ZIH, ZE, Z0`) fed whole to
`_contour_utils.py::contour_specs_for_polygon_slice()`, which connects
the 2 boundary edges a level crosses with one straight chord — valid
only for a flat interior. The pentagon is actually two ruled patches
glued along the internal rib `pt_01AL–pt_01TL`:
- **Strip patch** (trapezoid): toe `pt_02L(ZE)→pt_01AL(Z0)` along the
  runway strip, top `pt_02TL(ZIH)→pt_01TL(ZIH)` flat.
- **Fan patch** (triangle): apex `pt_01AL(Z0)`, flat top edge
  `pt_01TL(ZIH)→pt_08L(ZIH)`. Genuinely conical — every ray from the
  apex reaches elevation `Z0 + u·(ZIH−Z0)` at parameter `u` regardless
  of direction, so its own per-level contour *is* an exact straight
  chord (this patch alone isn't buggy).

For almost every level, the whole-pentagon slice picks the fan
patch's far edge and the strip patch's *far* end-cap, skipping the
shared rib and drawing one long diagonal across almost the whole
runway — exactly the screenshots. This also causes the known
corner-cutting at the plateau level (already documented, unfixed, in
`test_top_plateau_level_produces_a_chord_not_the_flat_chain`).

## Affected files

- `qols/scripts/TransitionalSurface_UTM.py` — slice the strip
  quadrilateral (`pt_01TL, pt_02TL, pt_02L, pt_01AL`) and the fan
  triangle (`pt_01TL, pt_08L, pt_01AL`) as two separate calls to the
  unchanged `contour_specs_for_polygon_slice()`, per side, instead of
  one whole-pentagon call. Both rings close on the same rib edge
  `pt_01AL→pt_01TL`, so their outputs share an exact endpoint for any
  level between `Z0` and `ZIH`, chaining into one connected line with
  no stitching code needed.
- `tests/test_contour_integration.py` — extend
  `TestTransitionalContourIntegration` with regression assertions: no
  segment spans further than the local patch's own extent; strip/fan
  segments share an exact endpoint for levels between `Z0` and `ZIH`;
  no contour at or above `ZIH`.

No changes to `_contour_utils.py` (function reused as-is) or to the
pentagon fill polygon (only contour lines are affected by this bug).

## Implementation steps

1. Update the contour block in `TransitionalSurface_UTM.py` to build
   the two per-side vertex sets (strip + fan) and concatenate their
   `contour_specs_for_polygon_slice()` results.
2. Add the regression tests described above.
3. Run `pytest` + `flake8`; write `doc/PR_155.md`.

## Test plan

- New pure-function-level regression tests in
  `test_contour_integration.py` (segment locality, rib-endpoint
  continuity, plateau cap).
- Full `pytest` suite must stay green.
- `flake8` clean on the changed script.
- Manual QGIS check (pending, no QGIS runtime available here): contour
  lines bend at the strip/fan seam, stay inside the surface, and
  disappear above the plateau elevation.