### PR TITLE
feature(#137): Straight-in Instrument Approach surface (New OLS OES 4th subtab)

### DIFF
--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -206,6 +206,8 @@ class QOLS:
                 self.execute_new_ols_oes_departure(params)
             elif st == SurfaceType.NEW_OLS_OES_PRECISION_APPROACH:
                 self.execute_new_ols_oes_precision_approach(params)
+            elif st == SurfaceType.NEW_OLS_OES_STRAIGHT_IN_APPROACH:
+                self.execute_new_ols_oes_straight_in_approach(params)
             else:
                 raise ValueError(f"Unhandled New OLS surface type: {st!r}")
 
@@ -417,6 +419,14 @@ class QOLS:
         needed (Table 4-12 needs no ADG; runway_layer/threshold_layer
         are already shared at the top level of params)."""
         script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-precision-approach-UTM.py')
+        self.execute_script(script_path, params)
+
+    def execute_new_ols_oes_straight_in_approach(self, params):
+        """Surface for Straight-in Instrument Approaches (#137) — its own
+        OES subtab, triggered individually; get_parameters() already
+        shapes specific_params as aerodrome_elevation_m/direction/lower_*/
+        upper_*, no remapping needed (Table 4-11 needs no ADG)."""
+        script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-straight-in-approach-UTM.py')
         self.execute_script(script_path, params)
 
     def execute_combined_inner_conical_surface(self, params):

--- a/qols/scripts/new-ols-oes-straight-in-approach-UTM.py
+++ b/qols/scripts/new-ols-oes-straight-in-approach-UTM.py
@@ -1,0 +1,341 @@
+"""
+New OLS Concept — OES Surface for Straight-in Instrument Approaches
+ICAO Annex 14 Table 4-11 / Figure 4-5 (#137). Single "I to V" column —
+no Aeroplane Design Group variation, so this surface is always drawn
+the same way regardless of the runway's ADG (per the issue's own
+"this surface is always done for all ADG" note).
+
+Table 4-11's Lower section is an explicit cross-reference to the
+Horizontal OES surface's ADG-I ring ("Length: Horizontal OES as per
+ADG I") — its racetrack radius comes from
+qols.surfaces.new_ols_horizontal.get_horizontal_surface_rings('I')
+rather than a hardcoded value, so it stays in sync with Table 4-10.
+
+Geometry, per Figure 4-5 (a rectangle enclosing the whole runway, with
+a racetrack drawn inside it) and this codebase's established flat-tier
+convention (#134/#134-followup2 — OES tiers are flat annuli, not
+sloped cones, each at its own height above the aerodrome elevation):
+
+* Lower section — the ADG-I Horizontal racetrack itself (full disc,
+  no hole), reusing the exact racetrack-ring construction from
+  new-ols-oes-horizontal-UTM.py (same coord()/coord2() trig closures).
+* Upper section — a runway-azimuth-aligned rectangle (half-width =
+  upper_shorter_side_m / 2 across the runway, extended
+  upper_longer_side_from_threshold_m beyond each runway end), minus
+  the Lower section's racetrack as a hole — a flat annulus built with
+  the same difference_flat() utility #124/#134 established for
+  Conical/Horizontal.
+
+Both sections go on one output layer, distinguished by a `component`
+attribute ("lower_section"/"upper_section") — mirroring how the other
+OES scripts identify their own sub-parts on a shared layer.
+
+Per #159, every Table 4-11 value is UI-editable
+(lower_height_m/lower_length_m/upper_height_m/upper_shorter_side_m/
+upper_longer_side_from_threshold_m), defaulting to the ICAO table when
+not overridden.
+
+Procedure to be used in Projected Coordinate System Only.
+"""
+myglobals = set(globals().keys())
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+import math
+from math import sqrt
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+from qols.surfaces.new_ols_straight_in_approach import get_straight_in_approach_dimensions
+from qols.geometry_difference import difference_flat, flatten_ring_z
+
+_script_success = False
+
+
+def _normalize_polyline_points(geometry):
+    if geometry is None or geometry.isEmpty():
+        raise Exception("Empty geometry provided for runway centerline.")
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            raise Exception("Empty MultiLineString geometry.")
+
+        def length_of(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                dx = pts[i].x() - pts[i - 1].x()
+                dy = pts[i].y() - pts[i - 1].y()
+                total += sqrt(dx * dx + dy * dy)
+            return total
+        return [QgsPoint(p) for p in max(parts, key=length_of)]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [QgsPoint(p) for p in poly]
+    raise Exception("Line geometry cannot be converted to a polyline.")
+
+
+def _racetrack_ring_xy(start_point, end_point, angle0, back_angle0, radius, trto, trfm):
+    """Builds one closed racetrack ring boundary (list of (x, y) tuples,
+    first == last) at the given radius, in flat 2D. Verbatim copy of
+    new-ols-oes-horizontal-UTM.py's helper of the same name (this
+    codebase's established convention: duplicate per-script rather
+    than extract a shared racetrack-geometry module)."""
+
+    def coord(angle0, dist1, off):
+        bearing = angle0 + off
+        angle = math.radians(90 - bearing)
+        bearing = math.radians(bearing)
+        dist_x, dist_y = (dist1 * math.cos(angle), dist1 * math.sin(angle))
+        xfinal, yfinal = (start_point.x() + dist_x, start_point.y() + dist_y)
+        return trto.transform(trfm.transform(xfinal, yfinal))
+
+    def coord2(angle0, dist1, off):
+        bearing = angle0 + off
+        angle = math.radians(90 - bearing)
+        bearing = math.radians(bearing)
+        dist_x, dist_y = (dist1 * math.cos(angle), dist1 * math.sin(angle))
+        xfinal, yfinal = (end_point.x() + dist_x, end_point.y() + dist_y)
+        return trto.transform(trfm.transform(xfinal, yfinal))
+
+    pro_coords = coord(angle0, radius, -90)   # Starting point left
+    x2 = coord(angle0, radius, 90)            # Starting point right
+    xc = coord(angle0, radius, 0)             # Starting center point
+    x4 = coord2(back_angle0, radius, 90)      # Ending point right
+    x5 = coord2(back_angle0, radius, 0)       # Ending center point
+    x6 = coord2(back_angle0, radius, -90)     # Ending point left
+
+    ring_xy = []
+
+    def _append_arc(p1, p2, p3, skip_first):
+        cstring = QgsCircularString()
+        cstring.setPoints([QgsPoint(p1[0], p1[1]), QgsPoint(p2[0], p2[1]), QgsPoint(p3[0], p3[1])])
+        segmented = QgsGeometry(cstring).convertToType(QgsWkbTypes.LineGeometry, True)
+        pts = []
+        if segmented:
+            if segmented.wkbType() == QgsWkbTypes.LineString:
+                pts = list(segmented.asPolyline())
+            elif segmented.wkbType() == QgsWkbTypes.MultiLineString:
+                for part in segmented.asMultiPolyline():
+                    pts.extend(part)
+        if not pts:
+            pts = [QgsPointXY(p1[0], p1[1]), QgsPointXY(p2[0], p2[1]), QgsPointXY(p3[0], p3[1])]
+        for i, pt in enumerate(pts):
+            if skip_first and i == 0:
+                continue
+            ring_xy.append((pt.x(), pt.y()))
+
+    _append_arc(pro_coords, xc, x2, skip_first=False)
+    ring_xy.append((x6[0], x6[1]))
+    _append_arc(x6, x5, x4, skip_first=True)
+    ring_xy.append((pro_coords[0], pro_coords[1]))
+
+    return ring_xy
+
+
+def _rectangle_ring_xy(start_point, end_point, angle0, back_angle0, half_width, extension):
+    """Builds one closed rectangle ring (list of (x, y) tuples, first ==
+    last) enclosing the whole runway: `extension` beyond each end along
+    the runway azimuth, `half_width` on either side across it."""
+    ext_start = start_point.project(extension, angle0)
+    ext_end = end_point.project(extension, back_angle0)
+    corner_start_a = ext_start.project(half_width, angle0 - 90)
+    corner_end_a = ext_end.project(half_width, back_angle0 + 90)
+    corner_end_b = ext_end.project(half_width, back_angle0 - 90)
+    corner_start_b = ext_start.project(half_width, angle0 + 90)
+    return [
+        (corner_start_a.x(), corner_start_a.y()),
+        (corner_end_a.x(), corner_end_a.y()),
+        (corner_end_b.x(), corner_end_b.y()),
+        (corner_start_b.x(), corner_start_b.y()),
+        (corner_start_a.x(), corner_start_a.y()),
+    ]
+
+
+def _ring_polygon_2d(ring_xy):
+    """Flat 2D QgsGeometry polygon (no Z) from a closed point ring, for
+    use as input to QgsGeometry.difference()."""
+    return QgsGeometry(QgsPolygon(QgsLineString([QgsPoint(x, y) for x, y in ring_xy])))
+
+
+# ---------------------------------------------------------------------------
+# Parameter extraction
+# ---------------------------------------------------------------------------
+_defaults = get_straight_in_approach_dimensions()  # Table 4-11, used as fallback only
+
+try:
+    aerodrome_elevation_m = globals().get('aerodrome_elevation_m', 0.0)
+    direction = globals().get('direction', 0)
+    runway_layer = globals().get('runway_layer', None)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    lower_height_m = globals().get('lower_height_m', _defaults['lower_section']['height_m'])
+    lower_length_m = globals().get('lower_length_m', _defaults['lower_section']['length_m'])
+    upper_height_m = globals().get('upper_height_m', _defaults['upper_section']['height_m'])
+    upper_shorter_side_m = globals().get(
+        'upper_shorter_side_m', _defaults['upper_section']['shorter_side_m'])
+    upper_longer_side_from_threshold_m = globals().get(
+        'upper_longer_side_from_threshold_m',
+        _defaults['upper_section']['longer_side_from_threshold_m'])
+except Exception as e:
+    print(f"NewOLS_OES_StraightInApproach: Error getting parameters, using defaults: {e}")
+    aerodrome_elevation_m = 0.0
+    direction = 0
+    runway_layer = None
+    use_runway_selected = True
+    lower_height_m = _defaults['lower_section']['height_m']
+    lower_length_m = _defaults['lower_section']['length_m']
+    upper_height_m = _defaults['upper_section']['height_m']
+    upper_shorter_side_m = _defaults['upper_section']['shorter_side_m']
+    upper_longer_side_from_threshold_m = _defaults['upper_section']['longer_side_from_threshold_m']
+
+# #159 — "expose all the parameters": every Table 4-11 value above is
+# UI-editable, defaulting to the ICAO table when not overridden.
+dims = {
+    'lower_section': {'height_m': lower_height_m, 'length_m': lower_length_m},
+    'upper_section': {
+        'height_m': upper_height_m,
+        'shorter_side_m': upper_shorter_side_m,
+        'longer_side_from_threshold_m': upper_longer_side_from_threshold_m,
+    },
+}
+
+map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+source_crs = QgsCoordinateReferenceSystem(4326)
+dest_crs = QgsCoordinateReferenceSystem(map_srid)
+trto = QgsCoordinateTransform(source_crs, dest_crs, QgsProject.instance())
+trfm = QgsCoordinateTransform(dest_crs, source_crs, QgsProject.instance())
+
+# ---------------------------------------------------------------------------
+# Runway layer
+# ---------------------------------------------------------------------------
+if runway_layer is None:
+    raise Exception("No Runway Layer Centerline provided. Please select a Runway Layer Centerline from the UI.")
+
+if use_runway_selected:
+    selection = runway_layer.selectedFeatures()
+    if not selection:
+        raise Exception("No runway features selected. Please select runway features.")
+else:
+    selection = list(runway_layer.getFeatures())
+    if not selection:
+        raise Exception("No features found in Runway Layer Centerline.")
+
+# ---------------------------------------------------------------------------
+# Memory layer — Lower + Upper section, both runway ends, all in one layer
+# ---------------------------------------------------------------------------
+layer_name = "NewOLS_OES_StraightInApproach"
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", layer_name, "memory")
+v_layer_provider = v_layer.dataProvider()
+v_layer_provider.addAttributes([
+    QgsField("surface_type", QVariant.String),
+    QgsField("component", QVariant.String),
+    QgsField("height_m", QVariant.Double),
+    QgsField("aerodrome_elevation_m", QVariant.Double),
+    QgsField("rule_set", QVariant.String),
+])
+v_layer.updateFields()
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('New OLS OES Surface for Straight-in Instrument Approaches', {
+    'aerodrome_elevation_m': round(aerodrome_elevation_m, 3),
+    'direction': direction,
+    'dimensions': dims,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
+features = []
+
+
+def _add_feature(component, height_m, polygon_geometry):
+    f = QgsFeature()
+    f.setGeometry(polygon_geometry)
+    f.setAttributes([
+        "Surface for Straight-in Instrument Approaches", component, height_m,
+        aerodrome_elevation_m, _active_rule_set, _params_json,
+    ])
+    features.append(f)
+
+
+for feat in selection:
+    line_pts = _normalize_polyline_points(feat.geometry())
+    start_point = QgsPoint(line_pts[0].x(), line_pts[0].y())
+    end_point = QgsPoint(line_pts[-1].x(), line_pts[-1].y())
+    angle0 = start_point.azimuth(end_point) + 180
+    if angle0 >= 360:
+        angle0 -= 360
+    if direction == -1:
+        angle0 = (angle0 + 180) % 360
+    back_angle0 = (angle0 + 180) % 360
+
+    lower_z = aerodrome_elevation_m + dims['lower_section']['height_m']
+    upper_z = aerodrome_elevation_m + dims['upper_section']['height_m']
+
+    lower_ring_xy = _racetrack_ring_xy(
+        start_point, end_point, angle0, back_angle0, dims['lower_section']['length_m'], trto, trfm)
+    lower_disc_geom = _ring_polygon_2d(lower_ring_xy)
+    lower_ext_pts = [
+        QgsPoint(x, y, z) for x, y, z in flatten_ring_z(lower_ring_xy, lower_z)
+    ]
+    _add_feature('lower_section', dims['lower_section']['height_m'],
+                 QgsGeometry(QgsPolygon(QgsLineString(lower_ext_pts))))
+
+    upper_ring_xy = _rectangle_ring_xy(
+        start_point, end_point, angle0, back_angle0,
+        dims['upper_section']['shorter_side_m'] / 2.0,
+        dims['upper_section']['longer_side_from_threshold_m'],
+    )
+    upper_disc_geom = _ring_polygon_2d(upper_ring_xy)
+    upper_polygon_geometry = difference_flat(
+        upper_disc_geom, lower_disc_geom, exterior_z=upper_z, interior_z=upper_z
+    )
+    _add_feature('upper_section', dims['upper_section']['height_m'], upper_polygon_geometry)
+
+    print(
+        f"NewOLS_OES_StraightInApproach: lower radius={dims['lower_section']['length_m']}m "
+        f"height={dims['lower_section']['height_m']}m -> Z={lower_z}m; "
+        f"upper height={dims['upper_section']['height_m']}m -> Z={upper_z}m"
+    )
+
+v_layer_provider.addFeatures(features)
+v_layer.updateExtents()
+print(f"NewOLS_OES_StraightInApproach: Created {len(features)} feature(s)")
+
+register_parameters_action(v_layer)
+
+QgsProject.instance().addMapLayers([v_layer])
+
+symbol = QgsFillSymbol.createSimple({
+    'color': '138,43,226,90',  # blueviolet, transparent
+    'style': 'solid',
+    'outline_color': '106,27,176,220',
+    'outline_style': 'solid',
+    'outline_width': '0.7',
+})
+v_layer.renderer().setSymbol(symbol)
+v_layer.triggerRepaint()
+
+if features:
+    v_layer.selectAll()
+    canvas = iface.mapCanvas()
+    canvas.zoomToSelected(v_layer)
+    v_layer.removeSelection()
+    sc = canvas.scale()
+    if sc < 50000:
+        sc = 50000
+    canvas.zoomScale(sc)
+
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+
+iface.messageBar().pushMessage(
+    "QOLS Success",
+    "New OLS OES Surface for Straight-in Instrument Approaches calculated successfully",
+    level=MSG_SUCCESS,
+)
+
+_script_success = True
+
+for _g in set(globals().keys()).difference(myglobals):
+    if _g not in ('myglobals', '_script_success'):
+        del globals()[_g]

--- a/qols/surface_types.py
+++ b/qols/surface_types.py
@@ -38,6 +38,7 @@ class SurfaceType(str, Enum):
     NEW_OLS_OES_HORIZONTAL = "New OLS - OES Horizontal"
     NEW_OLS_OES_DEPARTURE = "New OLS - OES Departure"
     NEW_OLS_OES_PRECISION_APPROACH = "New OLS - OES Precision Approach"
+    NEW_OLS_OES_STRAIGHT_IN_APPROACH = "New OLS - OES Straight-in Instrument Approach"
 
     @classmethod
     def from_tab_text(cls, text: str) -> "SurfaceType":

--- a/qols/surfaces/new_ols_straight_in_approach.py
+++ b/qols/surfaces/new_ols_straight_in_approach.py
@@ -1,0 +1,45 @@
+"""New OLS concept — Surface for straight-in instrument approaches.
+
+Table 4-11 (Dimensions of surface for straight-in instrument
+approaches). Like Table 4-12/4-13 (``new_ols_precision_approach.py``,
+``new_ols_departure.py``), this table has a single "I to V" column —
+no Aeroplane Design Group variation, so this surface is always drawn
+the same way regardless of the runway's ADG.
+
+The table's own "Length: Horizontal OES as per ADG I" note for the
+Lower section is an explicit cross-reference to the Horizontal OES
+surface's ADG-I ring (``new_ols_horizontal.py``'s ``_TIERS[0]``:
+radius 3350 m, height 45 m — matching this table's own Lower section
+height of 45 m). That radius is looked up via
+:func:`~qols.surfaces.new_ols_horizontal.get_horizontal_surface_rings`
+rather than hardcoded, so the two tables stay in sync if Table 4-10
+ever changes.
+"""
+from typing import Dict
+
+from qols.surfaces.new_ols_horizontal import ADG_I, get_horizontal_surface_rings
+
+
+def get_straight_in_approach_dimensions() -> Dict[str, dict]:
+    """Return ICAO Annex 14 Table 4-11 as a nested dict.
+
+    Returns:
+        Dict with:
+
+        * ``lower_section`` — ``height_m``/``length_m`` (the racetrack
+          radius, taken from the Horizontal OES surface's ADG-I ring).
+        * ``upper_section`` — ``height_m``/``shorter_side_m``/
+          ``longer_side_from_threshold_m``.
+    """
+    lower_ring = get_horizontal_surface_rings(ADG_I)[0]
+    return {
+        'lower_section': {'height_m': 45.0, 'length_m': lower_ring['radius_m']},
+        'upper_section': {
+            'height_m': 60.0,
+            'shorter_side_m': 7410.0,
+            'longer_side_from_threshold_m': 5350.0,
+        },
+    }
+
+
+__all__ = ['get_straight_in_approach_dimensions']

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -81,6 +81,14 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         'spin_missedS2Div_oes_precision':     25.0,
         'spin_missedS2Slope_oes_precision':    2.5,
         'spin_transSlope_oes_precision':      14.3,
+        # OES Surface for Straight-in Instrument Approaches (#137) —
+        # Table 4-11. lowerLength defaults to the Horizontal OES ADG-I
+        # ring radius (Table 4-10's own tier1_radius default above).
+        'spin_lowerHeight_oes_straightin':      45.0,
+        'spin_lowerLength_oes_straightin':    3350.0,
+        'spin_upperHeight_oes_straightin':      60.0,
+        'spin_upperShorterSide_oes_straightin': 7410.0,
+        'spin_upperLongerSideFromThreshold_oes_straightin': 5350.0,
         # ARP (Aerodrome Reference Point) — shared by both tabs, moved to
         # a single top-level field (#131).
         'spin_ARP_elevation':     2548.0,
@@ -129,9 +137,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     spin_missedS2Div_oes_precision: QLineEdit
     spin_missedS2Slope_oes_precision: QLineEdit
     spin_transSlope_oes_precision: QLineEdit
+    spin_lowerHeight_oes_straightin: QLineEdit
+    spin_lowerLength_oes_straightin: QLineEdit
+    spin_upperHeight_oes_straightin: QLineEdit
+    spin_upperShorterSide_oes_straightin: QLineEdit
+    spin_upperLongerSideFromThreshold_oes_straightin: QLineEdit
     calculateButton_oes_horizontal: QPushButton
     calculateButton_oes_departure: QPushButton
     calculateButton_oes_precision_approach: QPushButton
+    calculateButton_oes_straightin: QPushButton
     spin_ARP_elevation: QLineEdit
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
@@ -205,6 +219,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(self.calculateButton_oes_horizontal.clicked, self.on_calculate_clicked)
             self._connect(self.calculateButton_oes_departure.clicked, self.on_calculate_clicked)
             self._connect(self.calculateButton_oes_precision_approach.clicked, self.on_calculate_clicked)
+            self._connect(self.calculateButton_oes_straightin.clicked, self.on_calculate_clicked)
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
             self._connect(self.directionButton.clicked, self.toggle_direction)
 
@@ -255,6 +270,9 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             'spin_missedS1Slope_oes_precision', 'spin_missedS2Len_oes_precision',
             'spin_missedS2Div_oes_precision', 'spin_missedS2Slope_oes_precision',
             'spin_transSlope_oes_precision',
+            'spin_lowerHeight_oes_straightin', 'spin_lowerLength_oes_straightin',
+            'spin_upperHeight_oes_straightin', 'spin_upperShorterSide_oes_straightin',
+            'spin_upperLongerSideFromThreshold_oes_straightin',
             'spin_ARP_elevation',  # #131 — shared ARP elevation field
         ]
         decimal_pattern = r'^-?\d*(?:\.\d*)?$'
@@ -808,7 +826,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                         's2_length_m': self.get_numeric_value('spin_s2Len_oes_departure'),
                         's2_divergence_pct': self.get_numeric_value('spin_s2Div_oes_departure'),
                     }
-                else:
+                elif oes_sub_index == 2:
                     surface_type = SurfaceType.NEW_OLS_OES_PRECISION_APPROACH
                     specific_params = {
                         'start_elevation_m': self.get_numeric_value('spin_Z0_oes_precision'),
@@ -829,6 +847,18 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                         'missed_s2_divergence_pct': self.get_numeric_value('spin_missedS2Div_oes_precision'),
                         'missed_s2_slope_pct': self.get_numeric_value('spin_missedS2Slope_oes_precision'),
                         'trans_slope_pct': self.get_numeric_value('spin_transSlope_oes_precision'),
+                    }
+                else:
+                    surface_type = SurfaceType.NEW_OLS_OES_STRAIGHT_IN_APPROACH
+                    specific_params = {
+                        'aerodrome_elevation_m': arp_elevation_m,
+                        'direction': s_value,
+                        'lower_height_m': self.get_numeric_value('spin_lowerHeight_oes_straightin'),
+                        'lower_length_m': self.get_numeric_value('spin_lowerLength_oes_straightin'),
+                        'upper_height_m': self.get_numeric_value('spin_upperHeight_oes_straightin'),
+                        'upper_shorter_side_m': self.get_numeric_value('spin_upperShorterSide_oes_straightin'),
+                        'upper_longer_side_from_threshold_m':
+                            self.get_numeric_value('spin_upperLongerSideFromThreshold_oes_straightin'),
                     }
 
             return {

--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -266,6 +266,7 @@
         <item row="0" column="1">
          <widget class="QComboBox" name="combo_rwyType_ofs">
           <property name="minimumHeight"><number>22</number></property>
+          <property name="toolTip"><string>Selects which ICAO table this tab's defaults come from: Non-instrument (Table 4-1) or Instrument (Table 4-2).</string></property>
           <item><property name="text"><string>Non-instrument</string></property></item>
           <item><property name="text"><string>Instrument</string></property></item>
          </widget>
@@ -280,6 +281,7 @@
          <widget class="QComboBox" name="combo_adg_ofs">
           <property name="minimumHeight"><number>22</number></property>
           <property name="currentIndex"><number>2</number></property>
+          <property name="toolTip"><string>Aeroplane Design Group for the Approach surface (Tables 4-1/4-2). IIA and IIB share one value set here; the Horizontal Surface tab's Table 4-10 splits them into separate tiers instead.</string></property>
           <item><property name="text"><string>I</string></property></item>
           <item><property name="text"><string>IIA-IIB</string></property></item>
           <item><property name="text"><string>IIC</string></property></item>
@@ -309,6 +311,7 @@
         <item row="3" column="1">
          <widget class="QLineEdit" name="spin_distThr_ofs">
           <property name="text"><string>60.00</string></property>
+          <property name="toolTip"><string>Tables 4-1/4-2: distance from the threshold to the start (inner edge) of the Approach surface, measured along the runway centreline extended beyond the threshold.</string></property>
          </widget>
         </item>
 
@@ -332,6 +335,7 @@
         <item row="5" column="1">
          <widget class="QLineEdit" name="spin_divergence_ofs">
           <property name="text"><string>10.00</string></property>
+          <property name="toolTip"><string>Tables 4-1/4-2: each side's outward splay of the surface, added to the half inner-edge width per metre of length (10% for all ADG groups and both runway types).</string></property>
          </widget>
         </item>
 
@@ -343,6 +347,7 @@
         <item row="6" column="1">
          <widget class="QLineEdit" name="spin_length_ofs">
           <property name="text"><string>4500.00</string></property>
+          <property name="toolTip"><string>Tables 4-1/4-2: length of the Approach surface, measured from the inner edge outward along the runway centreline azimuth.</string></property>
          </widget>
         </item>
 
@@ -366,6 +371,7 @@
         <item row="8" column="1">
          <widget class="QLineEdit" name="spin_Z0_ofs">
           <property name="text"><string>2548.00</string></property>
+          <property name="toolTip"><string>Elevation of the surface's inner edge, typically the threshold elevation.</string></property>
          </widget>
         </item>
 
@@ -377,6 +383,7 @@
         <item row="9" column="1">
          <widget class="QLineEdit" name="spin_ZE_ofs">
           <property name="text"><string>2546.50</string></property>
+          <property name="toolTip"><string>Elevation of the surface's outer edge, at the far end of Length (m) along the surface slope from Start Elevation.</string></property>
          </widget>
         </item>
 
@@ -455,73 +462,100 @@
              </widget>
             </item>
 
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_tier1Radius_oes_horizontal">
-              <property name="text"><string>Tier 1 Radius, I/IIA (m):</string></property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="spin_tier1Radius_oes_horizontal">
-              <property name="text"><string>3350.00</string></property>
+            <item row="1" column="0" colspan="2">
+             <widget class="QLabel" name="label_tier1_header_oes_horizontal">
+              <property name="text"><string>Tier 1 (ADG I / IIA)</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
              </widget>
             </item>
 
             <item row="2" column="0">
-             <widget class="QLabel" name="label_tier1Height_oes_horizontal">
-              <property name="text"><string>Tier 1 Height, I/IIA (m):</string></property>
+             <widget class="QLabel" name="label_tier1Radius_oes_horizontal">
+              <property name="text"><string>Radius (m):</string></property>
              </widget>
             </item>
             <item row="2" column="1">
-             <widget class="QLineEdit" name="spin_tier1Height_oes_horizontal">
-              <property name="text"><string>45.00</string></property>
+             <widget class="QLineEdit" name="spin_tier1Radius_oes_horizontal">
+              <property name="text"><string>3350.00</string></property>
+              <property name="toolTip"><string>Table 4-10: outer radius of the first (innermost) horizontal surface tier, applying to ADG I and IIA, measured from the ARP.</string></property>
              </widget>
             </item>
 
             <item row="3" column="0">
-             <widget class="QLabel" name="label_tier2Radius_oes_horizontal">
-              <property name="text"><string>Tier 2 Radius, IIB (m):</string></property>
+             <widget class="QLabel" name="label_tier1Height_oes_horizontal">
+              <property name="text"><string>Height (m):</string></property>
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QLineEdit" name="spin_tier2Radius_oes_horizontal">
-              <property name="text"><string>5350.00</string></property>
+             <widget class="QLineEdit" name="spin_tier1Height_oes_horizontal">
+              <property name="text"><string>45.00</string></property>
+              <property name="toolTip"><string>Table 4-10: height of the first horizontal surface tier above the ARP elevation, applying to ADG I and IIA.</string></property>
              </widget>
             </item>
 
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_tier2Height_oes_horizontal">
-              <property name="text"><string>Tier 2 Height, IIB (m):</string></property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QLineEdit" name="spin_tier2Height_oes_horizontal">
-              <property name="text"><string>60.00</string></property>
+            <item row="4" column="0" colspan="2">
+             <widget class="QLabel" name="label_tier2_header_oes_horizontal">
+              <property name="text"><string>Tier 2 (ADG IIB)</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
              </widget>
             </item>
 
             <item row="5" column="0">
-             <widget class="QLabel" name="label_tier3Radius_oes_horizontal">
-              <property name="text"><string>Tier 3 Radius, IIC-V (m):</string></property>
+             <widget class="QLabel" name="label_tier2Radius_oes_horizontal">
+              <property name="text"><string>Radius (m):</string></property>
              </widget>
             </item>
             <item row="5" column="1">
-             <widget class="QLineEdit" name="spin_tier3Radius_oes_horizontal">
-              <property name="text"><string>10750.00</string></property>
+             <widget class="QLineEdit" name="spin_tier2Radius_oes_horizontal">
+              <property name="text"><string>5350.00</string></property>
+              <property name="toolTip"><string>Table 4-10: outer radius of the second horizontal surface tier, applying to ADG IIB. Selecting IIB or higher keeps the Tier 1 ring underneath it as a separate annulus.</string></property>
              </widget>
             </item>
 
             <item row="6" column="0">
-             <widget class="QLabel" name="label_tier3Height_oes_horizontal">
-              <property name="text"><string>Tier 3 Height, IIC-V (m):</string></property>
+             <widget class="QLabel" name="label_tier2Height_oes_horizontal">
+              <property name="text"><string>Height (m):</string></property>
              </widget>
             </item>
             <item row="6" column="1">
-             <widget class="QLineEdit" name="spin_tier3Height_oes_horizontal">
-              <property name="text"><string>90.00</string></property>
+             <widget class="QLineEdit" name="spin_tier2Height_oes_horizontal">
+              <property name="text"><string>60.00</string></property>
+              <property name="toolTip"><string>Table 4-10: height of the second horizontal surface tier above the ARP elevation, applying to ADG IIB.</string></property>
              </widget>
             </item>
 
             <item row="7" column="0" colspan="2">
+             <widget class="QLabel" name="label_tier3_header_oes_horizontal">
+              <property name="text"><string>Tier 3 (ADG IIC-V)</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="8" column="0">
+             <widget class="QLabel" name="label_tier3Radius_oes_horizontal">
+              <property name="text"><string>Radius (m):</string></property>
+             </widget>
+            </item>
+            <item row="8" column="1">
+             <widget class="QLineEdit" name="spin_tier3Radius_oes_horizontal">
+              <property name="text"><string>10750.00</string></property>
+              <property name="toolTip"><string>Table 4-10: outer radius of the third (outermost) horizontal surface tier, applying to ADG IIC through V. Selecting IIC or higher keeps both Tier 1 and Tier 2 rings underneath it.</string></property>
+             </widget>
+            </item>
+
+            <item row="9" column="0">
+             <widget class="QLabel" name="label_tier3Height_oes_horizontal">
+              <property name="text"><string>Height (m):</string></property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <widget class="QLineEdit" name="spin_tier3Height_oes_horizontal">
+              <property name="text"><string>90.00</string></property>
+              <property name="toolTip"><string>Table 4-10: height of the third horizontal surface tier above the ARP elevation, applying to ADG IIC through V.</string></property>
+             </widget>
+            </item>
+
+            <item row="10" column="0" colspan="2">
              <widget class="QLabel" name="label_oes_horizontal_note">
               <property name="text">
                <string>Uses the shared ARP Elevation and Direction fields above. ADG selects how many tiers (rings) are drawn, from the bottom up; tier values themselves are editable.</string>
@@ -531,7 +565,7 @@
              </widget>
             </item>
 
-            <item row="8" column="0" colspan="2">
+            <item row="11" column="0" colspan="2">
              <widget class="QPushButton" name="calculateButton_oes_horizontal">
               <property name="text"><string>Calculate Horizontal Surface</string></property>
               <property name="minimumHeight"><number>30</number></property>
@@ -570,6 +604,7 @@
             <item row="1" column="1">
              <widget class="QLineEdit" name="spin_initHeight_oes_departure">
               <property name="text"><string>5.00</string></property>
+              <property name="toolTip"><string>Table 4-13: height of the surface's inner edge above DER elevation, before the slope begins (5 m by the table).</string></property>
              </widget>
             </item>
 
@@ -581,6 +616,7 @@
             <item row="2" column="1">
              <widget class="QLineEdit" name="spin_innerEdge_oes_departure">
               <property name="text"><string>300.00</string></property>
+              <property name="toolTip"><string>Table 4-13: full width of the surface at the DER, centred on the extended runway centreline (300 m by the table).</string></property>
              </widget>
             </item>
 
@@ -592,54 +628,73 @@
             <item row="3" column="1">
              <widget class="QLineEdit" name="spin_slope_oes_departure">
               <property name="text"><string>2.50</string></property>
+              <property name="toolTip"><string>Table 4-13: constant upward slope shared by Section 1 and Section 2, applied from the DER along the runway azimuth (2.5% by the table).</string></property>
              </widget>
             </item>
 
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_s1Len_oes_departure">
-              <property name="text"><string>Section 1 Length (m):</string></property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QLineEdit" name="spin_s1Len_oes_departure">
-              <property name="text"><string>3500.00</string></property>
+            <item row="4" column="0" colspan="2">
+             <widget class="QLabel" name="label_section1_header_oes_departure">
+              <property name="text"><string>Section 1</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
              </widget>
             </item>
 
             <item row="5" column="0">
-             <widget class="QLabel" name="label_s1Div_oes_departure">
-              <property name="text"><string>Section 1 Divergence (%):</string></property>
+             <widget class="QLabel" name="label_s1Len_oes_departure">
+              <property name="text"><string>Length (m):</string></property>
              </widget>
             </item>
             <item row="5" column="1">
-             <widget class="QLineEdit" name="spin_s1Div_oes_departure">
-              <property name="text"><string>26.80</string></property>
+             <widget class="QLineEdit" name="spin_s1Len_oes_departure">
+              <property name="text"><string>3500.00</string></property>
+              <property name="toolTip"><string>Table 4-13: length of Section 1, measured from the DER along the extended runway centreline, in the takeoff/climb-out direction.</string></property>
              </widget>
             </item>
 
             <item row="6" column="0">
-             <widget class="QLabel" name="label_s2Len_oes_departure">
-              <property name="text"><string>Section 2 Length (m):</string></property>
+             <widget class="QLabel" name="label_s1Div_oes_departure">
+              <property name="text"><string>Divergence (%):</string></property>
              </widget>
             </item>
             <item row="6" column="1">
+             <widget class="QLineEdit" name="spin_s1Div_oes_departure">
+              <property name="text"><string>26.80</string></property>
+              <property name="toolTip"><string>Table 4-13: each side's outward splay in Section 1, added to the half inner-edge width per metre of Section 1 length (approx. 15 deg splay, 26.8% by the table).</string></property>
+             </widget>
+            </item>
+
+            <item row="7" column="0" colspan="2">
+             <widget class="QLabel" name="label_section2_header_oes_departure">
+              <property name="text"><string>Section 2</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="8" column="0">
+             <widget class="QLabel" name="label_s2Len_oes_departure">
+              <property name="text"><string>Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="8" column="1">
              <widget class="QLineEdit" name="spin_s2Len_oes_departure">
               <property name="text"><string>8300.00</string></property>
+              <property name="toolTip"><string>Table 4-13: length of Section 2, measured from the end of Section 1 continuing along the same azimuth.</string></property>
              </widget>
             </item>
 
-            <item row="7" column="0">
+            <item row="9" column="0">
              <widget class="QLabel" name="label_s2Div_oes_departure">
-              <property name="text"><string>Section 2 Divergence (%):</string></property>
+              <property name="text"><string>Divergence (%):</string></property>
              </widget>
             </item>
-            <item row="7" column="1">
+            <item row="9" column="1">
              <widget class="QLineEdit" name="spin_s2Div_oes_departure">
               <property name="text"><string>57.80</string></property>
+              <property name="toolTip"><string>Table 4-13: each side's outward splay in Section 2, added to Section 1's half-width per metre of Section 2 length (approx. 30 deg splay, 57.8% by the table).</string></property>
              </widget>
             </item>
 
-            <item row="8" column="0" colspan="2">
+            <item row="10" column="0" colspan="2">
              <widget class="QLabel" name="label_oes_departure_note">
               <property name="text">
                <string>Uses the shared Runway Layer and Direction fields above. No ADG (Table 4-13 is a single dimension set).</string>
@@ -649,7 +704,7 @@
              </widget>
             </item>
 
-            <item row="9" column="0" colspan="2">
+            <item row="11" column="0" colspan="2">
              <widget class="QPushButton" name="calculateButton_oes_departure">
               <property name="text"><string>Calculate Instrument Departure Surface</string></property>
               <property name="minimumHeight"><number>30</number></property>
@@ -683,7 +738,7 @@
             <item row="1" column="0" colspan="2">
              <widget class="QLabel" name="label_appr_header_oes_precision">
               <property name="text"><string>Approach</string></property>
-              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 6px; }</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
              </widget>
             </item>
 
@@ -695,6 +750,7 @@
             <item row="2" column="1">
              <widget class="QLineEdit" name="spin_apprDistThr_oes_precision">
               <property name="text"><string>60.00</string></property>
+              <property name="toolTip"><string>Table 4-12: distance from the threshold to the start (inner edge) of the Approach surface, measured along the runway centreline extended away from the runway (60 m by the table).</string></property>
              </widget>
             </item>
 
@@ -706,6 +762,7 @@
             <item row="3" column="1">
              <widget class="QLineEdit" name="spin_apprInnerEdge_oes_precision">
               <property name="text"><string>300.00</string></property>
+              <property name="toolTip"><string>Table 4-12: full width of the Approach surface's inner edge, centred on the extended runway centreline (300 m by the table); also reused as the Missed Approach surface's own inner-edge width.</string></property>
              </widget>
             </item>
 
@@ -717,6 +774,7 @@
             <item row="4" column="1">
              <widget class="QLineEdit" name="spin_apprS1Len_oes_precision">
               <property name="text"><string>3000.00</string></property>
+              <property name="toolTip"><string>Table 4-12: length of the Approach surface's Section 1, measured from the inner edge outward along the approach azimuth.</string></property>
              </widget>
             </item>
 
@@ -728,6 +786,7 @@
             <item row="5" column="1">
              <widget class="QLineEdit" name="spin_apprS1Div_oes_precision">
               <property name="text"><string>15.00</string></property>
+              <property name="toolTip"><string>Table 4-12: each side's outward splay in Section 1, added to the half inner-edge width per metre of Section 1 length.</string></property>
              </widget>
             </item>
 
@@ -739,6 +798,7 @@
             <item row="6" column="1">
              <widget class="QLineEdit" name="spin_apprS1Slope_oes_precision">
               <property name="text"><string>2.00</string></property>
+              <property name="toolTip"><string>Table 4-12: upward slope of Section 1, applied from the inner edge outward along the approach azimuth.</string></property>
              </widget>
             </item>
 
@@ -750,6 +810,7 @@
             <item row="7" column="1">
              <widget class="QLineEdit" name="spin_apprS2Len_oes_precision">
               <property name="text"><string>9600.00</string></property>
+              <property name="toolTip"><string>Table 4-12: length of the Approach surface's Section 2, measured from the end of Section 1 continuing along the approach azimuth.</string></property>
              </widget>
             </item>
 
@@ -761,6 +822,7 @@
             <item row="8" column="1">
              <widget class="QLineEdit" name="spin_apprS2Div_oes_precision">
               <property name="text"><string>15.00</string></property>
+              <property name="toolTip"><string>Table 4-12: each side's outward splay in Section 2, added to Section 1's half-width per metre of Section 2 length.</string></property>
              </widget>
             </item>
 
@@ -772,13 +834,14 @@
             <item row="9" column="1">
              <widget class="QLineEdit" name="spin_apprS2Slope_oes_precision">
               <property name="text"><string>2.50</string></property>
+              <property name="toolTip"><string>Table 4-12: upward slope of Section 2, applied from the end of Section 1 outward along the approach azimuth.</string></property>
              </widget>
             </item>
 
             <item row="10" column="0" colspan="2">
              <widget class="QLabel" name="label_missed_header_oes_precision">
               <property name="text"><string>Missed Approach</string></property>
-              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 6px; }</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
              </widget>
             </item>
 
@@ -790,6 +853,7 @@
             <item row="11" column="1">
              <widget class="QLineEdit" name="spin_missedDistThr_oes_precision">
               <property name="text"><string>900.00</string></property>
+              <property name="toolTip"><string>Table 4-12: distance from the threshold to the start of the Missed Approach surface, measured past the threshold in the landing direction of travel (900 m by the table).</string></property>
              </widget>
             </item>
 
@@ -801,6 +865,7 @@
             <item row="12" column="1">
              <widget class="QLineEdit" name="spin_missedS1Len_oes_precision">
               <property name="text"><string>1800.00</string></property>
+              <property name="toolTip"><string>Table 4-12: length of the Missed Approach surface's Section 1, measured from its inner edge continuing past the threshold.</string></property>
              </widget>
             </item>
 
@@ -824,6 +889,7 @@
             <item row="14" column="1">
              <widget class="QLineEdit" name="spin_missedS2Len_oes_precision">
               <property name="text"><string>10200.00</string></property>
+              <property name="toolTip"><string>Table 4-12: length of the Missed Approach surface's Section 2, measured from the end of Section 1 continuing in the same direction.</string></property>
              </widget>
             </item>
 
@@ -835,6 +901,7 @@
             <item row="15" column="1">
              <widget class="QLineEdit" name="spin_missedS2Div_oes_precision">
               <property name="text"><string>25.00</string></property>
+              <property name="toolTip"><string>Table 4-12: each side's outward splay of Section 2, added to Section 1's half-width per metre of Section 2 length.</string></property>
              </widget>
             </item>
 
@@ -846,13 +913,14 @@
             <item row="16" column="1">
              <widget class="QLineEdit" name="spin_missedS2Slope_oes_precision">
               <property name="text"><string>2.50</string></property>
+              <property name="toolTip"><string>Table 4-12: upward slope of the Missed Approach surface's Section 2.</string></property>
              </widget>
             </item>
 
             <item row="17" column="0" colspan="2">
              <widget class="QLabel" name="label_trans_header_oes_precision">
               <property name="text"><string>Transitional</string></property>
-              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 6px; }</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
              </widget>
             </item>
 
@@ -864,6 +932,7 @@
             <item row="18" column="1">
              <widget class="QLineEdit" name="spin_transSlope_oes_precision">
               <property name="text"><string>14.30</string></property>
+              <property name="toolTip"><string>Table 4-12: slope of the Transitional surface, rising outward from the sides of the Approach and Missed Approach inner edges up to the Horizontal surface elevation.</string></property>
              </widget>
             </item>
 
@@ -880,6 +949,109 @@
             <item row="20" column="0" colspan="2">
              <widget class="QPushButton" name="calculateButton_oes_precision_approach">
               <property name="text"><string>Calculate Surface for Precision Approaches</string></property>
+              <property name="minimumHeight"><number>30</number></property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+
+          <!-- SURFACE FOR STRAIGHT-IN INSTRUMENT APPROACHES SUBTAB (#137) -->
+          <widget class="QWidget" name="oes_sub_straight_in_approach">
+           <attribute name="title"><string>Straight-in Instrument Approaches</string></attribute>
+           <layout class="QFormLayout" name="formLayout_oes_straightin">
+            <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
+            <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+            <property name="horizontalSpacing"><number>15</number></property>
+            <property name="verticalSpacing"><number>6</number></property>
+
+            <item row="0" column="0" colspan="2">
+             <widget class="QLabel" name="label_lower_header_oes_straightin">
+              <property name="text"><string>Lower Section</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_lowerHeight_oes_straightin">
+              <property name="text"><string>Height (m):</string></property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="spin_lowerHeight_oes_straightin">
+              <property name="text"><string>45.00</string></property>
+              <property name="toolTip"><string>Table 4-11: height of the Lower section above the ARP elevation (45 m by the table, matching the Horizontal OES surface's ADG-I tier height).</string></property>
+             </widget>
+            </item>
+
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_lowerLength_oes_straightin">
+              <property name="text"><string>Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="spin_lowerLength_oes_straightin">
+              <property name="text"><string>3350.00</string></property>
+              <property name="toolTip"><string>Table 4-11: "Horizontal OES as per ADG I" — the Horizontal OES surface's ADG-I ring radius.</string></property>
+             </widget>
+            </item>
+
+            <item row="3" column="0" colspan="2">
+             <widget class="QLabel" name="label_upper_header_oes_straightin">
+              <property name="text"><string>Upper Section</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_upperHeight_oes_straightin">
+              <property name="text"><string>Height (m):</string></property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="spin_upperHeight_oes_straightin">
+              <property name="text"><string>60.00</string></property>
+              <property name="toolTip"><string>Table 4-11: height of the Upper section above the ARP elevation (60 m by the table).</string></property>
+             </widget>
+            </item>
+
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_upperShorterSide_oes_straightin">
+              <property name="text"><string>Shorter Side (m):</string></property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="spin_upperShorterSide_oes_straightin">
+              <property name="text"><string>7410.00</string></property>
+              <property name="toolTip"><string>Table 4-11: full width of the Upper section's rectangle, measured across the runway centreline (7410 m by the table).</string></property>
+             </widget>
+            </item>
+
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_upperLongerSideFromThreshold_oes_straightin">
+              <property name="text"><string>Longer Side From THR (m):</string></property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="spin_upperLongerSideFromThreshold_oes_straightin">
+              <property name="text"><string>5350.00</string></property>
+              <property name="toolTip"><string>Table 4-11: length the Upper section's rectangle extends beyond each threshold along the runway centreline (5350 m by the table).</string></property>
+             </widget>
+            </item>
+
+            <item row="7" column="0" colspan="2">
+             <widget class="QLabel" name="label_oes_straightin_note">
+              <property name="text">
+               <string>Uses the shared Runway Layer, ARP Elevation, and Direction fields above. No ADG (Table 4-11 is a single dimension set, always drawn for every ADG).</string>
+              </property>
+              <property name="wordWrap"><bool>true</bool></property>
+              <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="8" column="0" colspan="2">
+             <widget class="QPushButton" name="calculateButton_oes_straightin">
+              <property name="text"><string>Calculate Surface for Straight-in Instrument Approaches</string></property>
               <property name="minimumHeight"><number>30</number></property>
              </widget>
             </item>


### PR DESCRIPTION
# feature(#137): Straight-in Instrument Approach surface (New OLS OES 4th subtab)

## Context

Issue #137: add a 4th OES subtab, "Surface for straight-in instrument
approaches", alongside the existing Horizontal / Instrument Departure /
Precision Approach subtabs. The reporter's first paste of dimensions
was actually Table 4-13 (Instrument Departure — already implemented in
#136) pasted by mistake; the corrected table is **Table 4-11**:

| | | I to V |
|---|---|---|
| Lower section | Height | 45 m |
| Lower section | Length | Horizontal OES as per ADG I |
| Upper section | Height | 60 m |
| Upper section | Length of shorter side | 7 410 m |
| Upper section | Length of longer side from the threshold(s) | 5 350 m |

Single "I to V" column (no per-ADG variation), matching the flat-dict
pattern of Departure/Precision-Approach, not the tiered-by-ADG pattern
of Horizontal. This directly satisfies the reporter's note "this
surface is always done for all ADG ... not all subdivisions" — no ADG
combo is needed for this tab at all (Horizontal's combo with its
I/IIA/IIB/IIC/III/IV/V subdivisions doesn't apply here).

"Length: Horizontal OES as per ADG I" is an explicit cross-reference:
the Lower section's racetrack is literally the same shape as the
existing Horizontal OES surface's ADG-I ring (radius 3350 m, height
45 m — which is also, not coincidentally, `new_ols_horizontal.py`'s
own `_TIERS[0]`). The implementation should call
`get_horizontal_surface_rings('I')` rather than hardcode 3350, so the
two stay in sync if Table 4-10 ever changes.

**Geometric interpretation** (derived from Figure 4-5's plan view —
a gray rectangle with a racetrack outline inside it centered on the
runway — plus the stepped cross-sections/axonometric "wedding cake"
profile, and confirmed consistent with the codebase's established
flat-annulus convention for OES tiers, per the #134-followup2 fix this
session that flat rings must use their own height, not interpolate):
- **Lower section** = the ADG-I Horizontal racetrack itself (radius
  3350 m from `get_horizontal_surface_rings('I')`), a plain flat
  `PolygonZ` at `start_elevation_m + 45`.
- **Upper section** = a runway-azimuth-aligned rectangle (half-width =
  `shorter_side_m / 2` across the runway, extended
  `longer_side_from_threshold_m` beyond each threshold along the
  runway), **minus** the Lower section's racetrack as a hole — a flat
  annulus at `start_elevation_m + 60`, built with the same
  `difference_flat()` utility (`qols/geometry_difference.py`) already
  used for Horizontal's flat rings.

This is a plan-time interpretation, not something visible in code —
flag it explicitly for a manual QGIS visual check after implementation
(same caveat pattern used in every OES PR doc this session), in case
the actual rectangle orientation/extent needs adjusting once rendered.

"put both on same layer but identify each one" → both sections as 2
features on **one** output layer, distinguished by a `component`
attribute (`"lower_section"` / `"upper_section"`) — the exact pattern
already used by the other 3 OES scripts' `_add_feature(component, ...)`
closure.

"elevation uses aerodrome elevation to add to the heights" → confirmed
existing pattern in `new-ols-oes-departure-UTM.py:78,92,151,188`:
`start_elevation_m = globals().get('start_elevation_m', 0.0)`, then
`z = start_elevation_m + <table height>`. Mirror this exactly.

## Affected files

- **New** `qols/surfaces/new_ols_straight_in_approach.py` — Table 4-11
  pure module, mirrors `new_ols_departure.py`'s shape (flat dict,
  `__all__`). `get_straight_in_approach_dimensions()` returns
  `{'lower_section': {'height_m': 45.0, 'length_m': <from
  get_horizontal_surface_rings('I')>}, 'upper_section': {'height_m':
  60.0, 'shorter_side_m': 7410.0, 'longer_side_from_threshold_m':
  5350.0}}`. Imports `get_horizontal_surface_rings` from
  `qols.surfaces.new_ols_horizontal`.
- **New** `qols/scripts/new-ols-oes-straight-in-approach-UTM.py` —
  mirrors `new-ols-oes-departure-UTM.py`'s skeleton (myglobals/cleanup,
  `_normalize_polyline_points`, `globals().get(...)` overrides per
  #159's "every ICAO value editable" convention,
  `add_parameters_field`/`register_parameters_action`, styling, zoom,
  message bar). Geometry: reuse the racetrack-ring construction pattern
  from `new-ols-oes-horizontal-UTM.py`'s `_racetrack_ring_xy()`
  (lines 66-122) for the Lower section ring, plain rectangle corner
  math (via `QgsPoint.project()` along runway azimuth ±90°) for the
  Upper section outer boundary, and `difference_flat()` from
  `qols/geometry_difference.py` for the Upper section's flat annulus.
  Output layer name `"NewOLS_OES_StraightInApproach"`.
- `qols/surface_types.py` — add
  `NEW_OLS_OES_STRAIGHT_IN_APPROACH = "New OLS - OES Straight-in Instrument Approach"`
  next to the other 3 `NEW_OLS_OES_*` members.
- `qols/ui/new_ols_panel.ui` — add 4th page `oes_sub_straight_in_approach`
  inside `oesSubTabWidget`, `QFormLayout` of editable `spin_*` fields
  for all 4 table values (lower height, lower length, upper height,
  upper shorter-side, upper longer-side-from-threshold — 5 fields, all
  editable per #159's convention since this is a brand-new tab), no
  ADG combo, own `calculateButton_oes_straightin`.
- `qols/ui/new_ols_dockwidget.py` — `_WIDGET_DEFAULTS` entries for the
  5 new fields; type-hint block entries; wire the new calculate button
  to `self.on_calculate_clicked`; add a 4th branch in `get_parameters()`'s
  OES dispatch (currently `if 0 / elif 1 / else 2` — becomes
  `if 0 / elif 1 / elif 2 / else 3`), building an isolated
  `specific_params` dict and `SurfaceType.NEW_OLS_OES_STRAIGHT_IN_APPROACH`.
- `qols/plugin.py` — add `execute_new_ols_oes_straight_in_approach(params)`
  (mirrors `execute_new_ols_oes_departure`), resolve
  `new-ols-oes-straight-in-approach-UTM.py`; add the matching branch in
  `on_calculate_new_ols()`'s `SurfaceType` dispatch.
- `tests/test_dockwidget_logic.py` — new
  `TestGetStraightInApproachDimensions` (mirrors
  `TestGetDepartureSurfaceDimensions`: assert each Table 4-11 value,
  assert `lower_section['length_m']` equals
  `get_horizontal_surface_rings('I')`'s radius — proving the
  cross-reference stays in sync, assert mutation-safety independent
  copy); extend `_oes_params_subject` + `TestGetParametersOesSubtabDispatch`
  with a 4th `oes_sub_index=3` case asserting `surface_type` and the
  exact `specific_params` key set.

## Implementation steps

1. `qols/surfaces/new_ols_straight_in_approach.py` (pure module) + its
   test class first — smallest, independently verifiable unit.
2. `qols/surface_types.py` enum member.
3. `qols/scripts/new-ols-oes-straight-in-approach-UTM.py` — geometry +
   layer construction, following the Departure script's skeleton and
   the Horizontal script's racetrack builder.
4. `qols/ui/new_ols_panel.ui` — new subtab page + fields.
5. `qols/ui/new_ols_dockwidget.py` — defaults, type hints, button
   wiring, `get_parameters()` dispatch branch.
6. `qols/plugin.py` — `execute_new_ols_oes_straight_in_approach` +
   dispatch branch.
7. Extend `_oes_params_subject`/`TestGetParametersOesSubtabDispatch`
   for the dispatch integration test.
8. `pytest` + `flake8` on every changed/new file; write
   `doc/FEATURE_PLAN_137.md` (already effectively this file) and
   `doc/PR_137.md`.

## Test plan

- New `TestGetStraightInApproachDimensions` (pure module).
- Extended `TestGetParametersOesSubtabDispatch` (dispatch integration,
  4th branch).
- Full `pytest` suite must stay green (571+ baseline from this
  session's other work, allowing for the gitignored-test-drift
  temporary-strip pattern if this branch is based on a `main` that
  predates other unmerged branches).
- `flake8` clean on every new/changed file.
- Manual QGIS check (pending, no QGIS runtime available here): confirm
  the rectangle-minus-racetrack Upper section and racetrack-disc Lower
  section render as described in Figure 4-5 (stepped "wedding cake"
  profile, both features tagged and visible on one layer) — this is
  the step that validates or corrects this plan's geometric
  interpretation of "shorter side" / "longer side from the threshold".

## Risk / notes

- Branch: `feature/137-straight-in-approach-oes`, created fresh off
  `main` (per CLAUDE.md workflow step 1 — done immediately after plan
  approval, before any code edits).
- The rectangle-vs-racetrack geometric interpretation of Table 4-11's
  "shorter side" / "longer side from the threshold" wording is inferred
  from Figure 4-5 and the codebase's existing flat-annulus convention,
  not from an authoritative geometric spec in this repo — call this
  out clearly in `doc/PR_137.md` as needing visual confirmation.
- No shared-utility changes — `difference_flat()` and the racetrack
  builder are reused as-is, so no risk to Horizontal/Departure/
  Precision-Approach OES surfaces.
- Follows #159's "every ICAO parameter must be user-editable" precedent
  — all 5 Table 4-11 values get their own `QLineEdit` override, no
  silent-automatic-only fields.
