### PR TITLE
fix(#164): Split OES into tabs up and down so you don't need to scroll so much

### DIFF
--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -10,11 +10,12 @@ from ..surfaces.new_ols_approach import get_new_ols_approach_defaults
 from ..surface_types import SurfaceType
 from .. import logger
 from ..direction_marker import build_marker_geometry
+from .tab_row_selector import TwoRowTabSelector
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot, QRegularExpression
 from qgis.PyQt.QtGui import QColor, QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import (
-    QApplication, QComboBox, QDialog, QDockWidget, QTabWidget,
+    QApplication, QComboBox, QDialog, QDockWidget, QHBoxLayout, QStackedWidget, QTabBar,
     QLabel, QLineEdit, QMessageBox, QPushButton, QTextBrowser, QToolTip, QVBoxLayout,
 )
 from ..compat import EVENT_MOUSE_MOVE, TOOLTIP_ROLE, MSG_INFO, MSG_CRITICAL, GEOM_TYPE_POLYGON
@@ -105,7 +106,17 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     spin_Z0_ofs: QLineEdit
     spin_ZE_ofs: QLineEdit
     spin_contour_interval_ofs: QLineEdit
-    oesSubTabWidget: QTabWidget
+    # Two-row OES tab bar (#164) — mirrors the classic panel's own #123
+    # fix. PyQt6's uic can't construct a bare QTabBar from .ui XML (not
+    # in its Designer-placeable widget table, unlike QTabWidget/
+    # QStackedWidget), so oesTabBarRow1/oesTabBarRow2 are built in
+    # Python in __init__ and inserted into the (XML-declared, empty)
+    # oesTabRow1Layout/oesTabRow2Layout — not setupUi() attributes
+    # either. oesSubTabWidget itself is a TwoRowTabSelector instance,
+    # also built in __init__.
+    oesTabRow1Layout: QHBoxLayout
+    oesTabRow2Layout: QHBoxLayout
+    oesSubTabStack: QStackedWidget
     combo_adg_horizontal_oes: QComboBox
     spin_tier1Radius_oes_horizontal: QLineEdit
     spin_tier1Height_oes_horizontal: QLineEdit
@@ -173,6 +184,43 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
 
         try:
             self.setupUi(self)
+
+            # Two-row OES tab selector (#164) — same fix as the classic
+            # panel's #123: PyQt6's uic can't build a bare QTabBar
+            # straight from .ui XML, so both bars are constructed here
+            # and inserted into the (empty) oesTabRow1Layout/
+            # oesTabRow2Layout declared in new_ols_panel.ui. Native
+            # look, no custom styling. oesSubTabStack's 4 pages stay in
+            # their original order (0=Horizontal ... 3=Straight-in) —
+            # get_parameters()'s oes_sub_index dispatch depends on that
+            # exact stack order, not on which row a tab visually sits
+            # in. Row 1: Horizontal, Departure. Row 2: Precision
+            # Approach, Straight-in.
+            self.oesTabBarRow1 = QTabBar(self)
+            self.oesTabBarRow2 = QTabBar(self)
+            self.oesTabRow1Layout.addWidget(self.oesTabBarRow1)
+            self.oesTabRow2Layout.addWidget(self.oesTabBarRow2)
+            for text in ("Horizontal Surface", "Instrument Departure Surface"):
+                self.oesTabBarRow1.addTab(text)
+            for text in ("Surface for Precision Approaches", "Straight-in Instrument Approaches"):
+                self.oesTabBarRow2.addTab(text)
+
+            # oesSubTabWidget itself is this shim, not a setupUi()
+            # attribute; it presents the same currentIndex()/tabText()/
+            # widget()/currentChanged surface a QTabWidget did, so the
+            # existing oesSubTabWidget.currentIndex() call in
+            # get_parameters() keeps working unchanged.
+            self.oesSubTabWidget = TwoRowTabSelector(
+                bars=[self.oesTabBarRow1, self.oesTabBarRow2],
+                stack_indices_per_bar=[[0, 1], [2, 3]],
+                tab_texts=[
+                    "Horizontal Surface", "Instrument Departure Surface",
+                    "Surface for Precision Approaches", "Straight-in Instrument Approaches",
+                ],
+                stack=self.oesSubTabStack,
+                parent=self,
+            )
+
             self.setup_numeric_lineedit_validation()
             self.setup_layer_filters()
             self.setup_enhanced_combos()

--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -428,14 +428,27 @@
              Calculate button and only its own parameters, instead of
              one shared Calculate bundling every OES surface together. -->
         <item>
-         <widget class="QTabWidget" name="oesSubTabWidget">
-          <property name="tabPosition">
-           <enum>QTabWidget::North</enum>
-          </property>
+         <widget class="QWidget" name="oesTabSelectorContainer">
+          <layout class="QVBoxLayout" name="oesTabSelectorLayout">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="margin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="oesTabRow1Layout"/>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="oesTabRow2Layout"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
 
-          <!-- HORIZONTAL SURFACE SUBTAB (#134) -->
+        <item>
+         <widget class="QStackedWidget" name="oesSubTabStack">
           <widget class="QWidget" name="oes_sub_horizontal">
-           <attribute name="title"><string>Horizontal Surface</string></attribute>
            <layout class="QFormLayout" name="formLayout_oes_horizontal">
             <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
             <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
@@ -577,7 +590,6 @@
 
           <!-- INSTRUMENT DEPARTURE SURFACE SUBTAB (#136) -->
           <widget class="QWidget" name="oes_sub_departure">
-           <attribute name="title"><string>Instrument Departure Surface</string></attribute>
            <layout class="QFormLayout" name="formLayout_oes_departure">
             <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
             <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
@@ -716,7 +728,6 @@
 
           <!-- SURFACE FOR PRECISION APPROACHES SUBTAB (#135) -->
           <widget class="QWidget" name="oes_sub_precision_approach">
-           <attribute name="title"><string>Surface for Precision Approaches</string></attribute>
            <layout class="QFormLayout" name="formLayout_oes_precision_approach">
             <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
             <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
@@ -958,7 +969,6 @@
 
           <!-- SURFACE FOR STRAIGHT-IN INSTRUMENT APPROACHES SUBTAB (#137) -->
           <widget class="QWidget" name="oes_sub_straight_in_approach">
-           <attribute name="title"><string>Straight-in Instrument Approaches</string></attribute>
            <layout class="QFormLayout" name="formLayout_oes_straightin">
             <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
             <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>


### PR DESCRIPTION
# fix(#164): Split OES into tabs up and down so you don't need to scroll so much

## Summary

Closes #164.

Issue #164 : with 4 OES subtabs now in the New OLS
panel (Horizontal Surface, Instrument Departure Surface, Surface for
Precision Approaches, Straight-in Instrument Approaches — the last one
just added for #137), the tab bar overflows horizontally and a small
`»` scroll arrow cuts it off, per the reporter's screenshot, forcing
users to scroll sideways to reach every subtab. Requested fix: split
the tab bar into two rows instead.

## Root cause / design notes

This is the identical symptom already solved once in this codebase,
for the classic panel's main 6-tab bar (issue #123):
`qols/ui/tab_row_selector.py::TwoRowTabSelector`, a `QObject`-based
shim wrapping two plain `QTabBar` rows + a shared `QStackedWidget`,
exposing the same `currentIndex()`/`setCurrentIndex()`/`tabText()`/
`widget()`/`currentChanged` surface a real `QTabWidget` does.

Confirmed by reading both `new_ols_dockwidget.py` and the shim
directly: `oesSubTabWidget` is only ever used via `.currentIndex()`
(in `get_parameters()`'s OES dispatch) plus a type-stub declaration —
no `count()`, `setTabText()`, or any other member `TwoRowTabSelector`
doesn't implement — so it's a clean drop-in reuse of #123's
already-tested widget, with **zero changes to the shim itself or its
20 existing tests**.

**Row split** (top-to-bottom, left-to-right — no reordering needed,
unlike #123's own split which reordered classic's tabs for other
reasons):
- Row 1: Horizontal Surface, Instrument Departure Surface
- Row 2: Surface for Precision Approaches, Straight-in Instrument Approaches

The underlying stack-index order (0=Horizontal, 1=Departure,
2=Precision Approach, 3=Straight-in) stays exactly as declared before
— `get_parameters()`'s `oes_sub_index == 0/1/2/3` branches depend on
that order, not on which row a tab visually sits in.

## Changes

### `qols/ui/new_ols_panel.ui`
Replaced the single `<widget class="QTabWidget" name="oesSubTabWidget">`
block (wrapping all 4 `oes_sub_*` pages) with two sibling `<item>`s in
`verticalLayout_oes`, mirroring `qols_panel_base.ui`'s
`tabSelectorContainer`/`scriptTabStack` pattern exactly:
- `oesTabSelectorContainer` (`QWidget` + `QVBoxLayout`, margin/spacing
  0) holding two empty `QHBoxLayout`s: `oesTabRow1Layout`,
  `oesTabRow2Layout`.
- `oesSubTabStack` (`QStackedWidget`) holding the same 4 `oes_sub_*`
  pages, content unchanged, with each page's now-meaningless
  `<attribute name="title">` removed (stack pages don't use titles).

No `<customwidget>`/promotion entry — `QTabBar` isn't
Designer-placeable (PyQt6's `uic` raises `NoSuchWidgetError` for it),
so both bars are built manually in Python, exactly as #123 does.

### `qols/ui/new_ols_dockwidget.py`
- Imported `TwoRowTabSelector`, plus `QTabBar`/`QStackedWidget`/
  `QHBoxLayout` (added to the existing `QtWidgets` import line;
  removed the now-unused `QTabWidget` import).
- Type-stub block: `oesSubTabWidget: QTabWidget` replaced with
  `oesTabRow1Layout`/`oesTabRow2Layout: QHBoxLayout` and
  `oesSubTabStack: QStackedWidget` (the real `setupUi()` attributes
  now) — `oesSubTabWidget` itself becomes a plain instance attribute
  built in `__init__`, matching how `scriptTabWidget` is documented
  and handled on the classic panel.
- In `__init__`, right after `self.setupUi(self)`: construct
  `self.oesTabBarRow1`/`self.oesTabBarRow2`, add them into the two
  empty layouts, add the 2 tab texts per row, then build
  `self.oesSubTabWidget = TwoRowTabSelector(bars=[...],
  stack_indices_per_bar=[[0, 1], [2, 3]], tab_texts=[...],
  stack=self.oesSubTabStack, parent=self)`. The one existing call site
  (`oesSubTabWidget.currentIndex()` in `get_parameters()`) needed no
  changes.

No changes to `get_parameters()`, `_WIDGET_DEFAULTS`,
`setup_numeric_lineedit_validation()`, or any OES field wiring.

### `tests/test_tab_row_selector.py`
New `TestOesSubtabRowSplit` (9 tests, `_make_oes_selector()` helper
mirroring the file's existing `_make_selector()` pattern) — pins the
stack-index-to-tab-text mapping and verifies each row's tabs activate
the correct stack index. A regression guard against the OES row split
silently drifting out of sync with `get_parameters()`'s hardcoded
`oes_sub_index` branches, since nothing else in the codebase enforces
that relationship once the mapping lives only in Python.

`tests/test_dockwidget_logic.py` needed **no changes** — its
`_oes_params_subject()` fixture already injects `oesSubTabWidget` as a
bare `MagicMock()` with `.currentIndex.return_value` set directly,
bypassing real `TwoRowTabSelector` construction entirely.

## Verification

```bash
xmllint --noout qols/ui/new_ols_panel.ui
# valid

pytest -q -p no:pytest-qt
# 633 passed (624 baseline + 9 new TestOesSubtabRowSplit tests)

flake8 --max-line-length=119 qols/ui/new_ols_dockwidget.py tests/test_tab_row_selector.py
# 1 finding: F821 in new_ols_dockwidget.py, confirmed pre-existing on
# main before any of this session's changes, unrelated to this fix;
# tests/test_tab_row_selector.py fully clean
```

Row/column gap-and-duplicate check re-run on all 5 `QFormLayout`s
inside the (unmoved) subtab pages — unaffected, as expected, since
only the outer tab-bar wrapper changed, not any field layout.

Manual QGIS check (pending, no QGIS runtime available here): OES tab
shows 2 rows of 2 subtabs, no horizontal scroll arrow, clicking either
row's tabs switches pages and deselects the other row, Calculate reads
the correct subtab's `specific_params`.

## Risk / notes

- Branch `feature/137-straight-in-approach-oes` — continuing here
  rather than a new branch, since this directly follows #137's own UI
  work in the same files (`new_ols_panel.ui`, `new_ols_dockwidget.py`)
  earlier in this session.
- Zero changes to `TwoRowTabSelector` itself or its original 20 tests
  — purely a second call site reusing an already-verified widget.
- If a 5th OES surface is ever added, `stack_indices_per_bar` would
  need a 3rd row or a rebalanced 2-row split; the code comment in
  `__init__` (mirroring #123's own) flags this for a future editor.
