### PR TITLE
Add Take-off Climb Surface functionality to New OLS

### DIFF
--- a/qols/direction_marker.py
+++ b/qols/direction_marker.py
@@ -11,6 +11,16 @@ QGIS-aware wrapper the dockwidgets call.
 The direction formula mirrors the ``s``-index convention ported from the
 legacy ``TransitionalSurface_UTM.py`` into the New OLS scripts (see #113):
 ``s = direction; near_end_pt = line_pts[s]; far_end_pt = line_pts[-1 - s]``.
+
+The threshold-anchoring shortcut (``resolve_anchor_feature``) mirrors
+#132's fix in ``new-ols-ofs-approach-UTM.py``: with exactly one
+threshold candidate, use it directly instead of re-deriving it by
+distance to ``near_end_pt`` — otherwise the marker jumps to the
+opposite threshold every time direction is toggled, since
+``near_end_pt`` itself flips between the runway's two endpoints. #132
+fixed this for the real OFS Approach calculation but the fix was never
+propagated to this shared preview module, discovered while testing
+#161's Take-off Climb subtab.
 """
 from __future__ import annotations
 
@@ -19,6 +29,7 @@ import math
 __all__ = [
     "resolve_direction_azimuth",
     "triangle_marker_vertices",
+    "resolve_anchor_feature",
     "build_marker_geometry",
 ]
 
@@ -115,6 +126,20 @@ def _closest_feature(features, pt: tuple[float, float]):
     )
 
 
+def resolve_anchor_feature(candidates, near_end_pt, closest_fn=_closest_feature):
+    """Mirrors #132's fix (``new-ols-ofs-approach-UTM.py``): with exactly
+    one candidate, use it directly rather than re-deriving it by distance
+    to ``near_end_pt``. A single selection isn't ambiguous, and
+    ``near_end_pt`` — which flips between the runway's two endpoints when
+    direction toggles — shouldn't be able to make the marker jump away
+    from the one feature the user actually selected. #132 fixed this for
+    the real OFS Approach calculation but never propagated the fix here,
+    so the preview marker kept jumping between thresholds on every tab."""
+    if len(candidates) == 1:
+        return candidates[0]
+    return closest_fn(candidates, near_end_pt)
+
+
 def build_marker_geometry(
     runway_layer,
     threshold_layer,
@@ -150,7 +175,7 @@ def build_marker_geometry(
     except IndexError:
         return None
 
-    near_thr_feat = _closest_feature(threshold_sel, near_end_pt)
+    near_thr_feat = resolve_anchor_feature(threshold_sel, near_end_pt)
     thr_pt = near_thr_feat.geometry().asPoint()
     tip = (thr_pt.x(), thr_pt.y())
 

--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -208,6 +208,8 @@ class QOLS:
                 self.execute_new_ols_oes_precision_approach(params)
             elif st == SurfaceType.NEW_OLS_OES_STRAIGHT_IN_APPROACH:
                 self.execute_new_ols_oes_straight_in_approach(params)
+            elif st == SurfaceType.NEW_OLS_OES_TAKEOFF_CLIMB:
+                self.execute_new_ols_oes_takeoff_climb(params)
             else:
                 raise ValueError(f"Unhandled New OLS surface type: {st!r}")
 
@@ -427,6 +429,14 @@ class QOLS:
         shapes specific_params as aerodrome_elevation_m/direction/lower_*/
         upper_*, no remapping needed (Table 4-11 needs no ADG)."""
         script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-straight-in-approach-UTM.py')
+        self.execute_script(script_path, params)
+
+    def execute_new_ols_oes_takeoff_climb(self, params):
+        """Take-off Climb Surface (#161) — its own OES subtab, triggered
+        individually; get_parameters() already shapes specific_params as
+        start_elevation_m/cwy_length_m/direction/Table-4-14-4-15 fields,
+        no remapping needed."""
+        script_path = os.path.join(self.plugin_dir, 'scripts', 'new-ols-oes-takeoff-climb-UTM.py')
         self.execute_script(script_path, params)
 
     def execute_combined_inner_conical_surface(self, params):

--- a/qols/scripts/new-ols-oes-takeoff-climb-UTM.py
+++ b/qols/scripts/new-ols-oes-takeoff-climb-UTM.py
@@ -1,0 +1,299 @@
+"""
+New OLS Concept — OES Take-off Climb Surface
+ICAO Annex 14 Table 4-14 (mass up to 5 700 kg) / Table 4-15 (mass
+above 5 700 kg) / Figure 4-8 (#161).
+
+Geometry ported from the classic OLS's own take-off climb surface
+script (qols/scripts/take-off-surface_UTM.py), the only existing
+implementation of this exact surface in this codebase:
+
+* Origin offset dD = max(distance_from_runway_end_m, cwy_length_m) —
+  Table 4-14's own footnote ("the surface starts at the end of the
+  clearway if the clearway length exceeds the specified distance").
+  Table 4-15's "Distance from TODA" column is "-" for every ADG (the
+  surface starts right at TODA = runway end + clearway); modeled in
+  qols/surfaces/new_ols_takeoff_climb.py as distance_from_runway_end_m
+  = 0.0 for Table 4-15 rows, so the same max() formula produces the
+  correct TODA-relative origin (max(0, cwy) == cwy) without any
+  mass-category branching here.
+* Plan view is a single hexagon: diverge from inner_edge_m at the
+  origin until final_width_m is reached (distance_to_max_width), then
+  continue at constant final_width_m out to length_m.
+* The sloped plane climbs for the FULL length_m, independent of
+  distance_to_max_width — confirmed against the classic script, where
+  the far-end point's Z uses surfaceLength * slope_ratio while the
+  cap-point's Z uses only distance_to_max_width * slope_ratio. For
+  Table 4-14 both values coincide (distance_to_max_width == length_m
+  exactly for its two rows), degenerating to a plain trapezoid; for
+  Table 4-15 they differ, producing a genuine diverge-then-constant
+  shape with the plane still climbing past the width cap.
+* Cross-sections are flat (not gabled) — same precedent as every other
+  planar OLS surface in this codebase (Approach, Departure, classic
+  Take-off).
+
+Independently cross-checked against ../flight/tofpa's own TOFPA AOC
+Type A implementation (ICAO Doc 8168, the PANS-OPS analogue the issue
+itself points to for the CWY-override provision) — ``tofpa.py``'s
+``pt_02D``/``pt_03D`` Z assignment (cap point uses only
+``distance_to_max_width``, end point uses the full
+``TOFPA_SURFACE_LENGTH``) and its hexagon ring order
+(``[pt_03DR, pt_03DL, pt_02DL, pt_01DL, pt_01DR, pt_02DR]``) match this
+script's geometry vertex-for-vertex. Confirms the hexagon shape,
+full-length slope, and flat cross-sections above are not just an
+inference from the classic qOLS script but agree with a second,
+independent implementation of the same surface concept.
+
+Unlike the classic panel, every Table 4-14/4-15 value here is
+independently user-editable (#159 convention), so an inconsistent
+combination (e.g. divergence_pct too small for final_width_m/length_m)
+is reachable; distance_to_max_width is defensively clamped to
+length_m, which the classic script does not need since its own fields
+aren't independently overridable.
+
+DER (runway end) resolution mirrors new-ols-oes-departure-UTM.py: the
+runway centerline's own far endpoint in the direction of travel, no
+separate DER point layer needed.
+
+Procedure to be used in Projected Coordinate System Only.
+"""
+myglobals = set(globals().keys())
+
+from qgis.core import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from math import sqrt
+from qols.parameters_inspector import build_parameters_json, add_parameters_field, register_parameters_action
+from qols.surfaces.new_ols_takeoff_climb import get_takeoff_climb_surface_dimensions, MASS_CATEGORY_LE_5700
+
+_script_success = False
+
+
+def _normalize_polyline_points(geometry):
+    if geometry is None or geometry.isEmpty():
+        raise Exception("Empty geometry provided for runway centerline.")
+    if geometry.isMultipart():
+        parts = geometry.asMultiPolyline()
+        if not parts:
+            raise Exception("Empty MultiLineString geometry.")
+
+        def part_len(pts):
+            if not pts or len(pts) < 2:
+                return 0.0
+            total = 0.0
+            for i in range(1, len(pts)):
+                dx = pts[i].x() - pts[i - 1].x()
+                dy = pts[i].y() - pts[i - 1].y()
+                total += sqrt(dx * dx + dy * dy)
+            return total
+
+        return [QgsPoint(p) for p in max(parts, key=part_len)]
+    poly = geometry.asPolyline()
+    if poly and len(poly) >= 2:
+        return [QgsPoint(p) for p in poly]
+    raise Exception("Line geometry cannot be converted to a polyline.")
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+_defaults = get_takeoff_climb_surface_dimensions(MASS_CATEGORY_LE_5700, "I")  # Table 4-14 ADG I, fallback only
+
+try:
+    start_elevation_m = globals().get('start_elevation_m', 0.0)
+    direction = globals().get('direction', 0)
+    runway_layer = globals().get('runway_layer', None)
+    use_runway_selected = globals().get('use_runway_selected', True)
+    cwy_length_m = globals().get('cwy_length_m', 0.0)
+    distance_from_runway_end_m = globals().get(
+        'distance_from_runway_end_m', _defaults['distance_from_runway_end_m'])
+    inner_edge_m = globals().get('inner_edge_m', _defaults['inner_edge_m'])
+    divergence_pct = globals().get('divergence_pct', _defaults['divergence_pct'])
+    final_width_m = globals().get('final_width_m', _defaults['final_width_m'])
+    length_m = globals().get('length_m', _defaults['length_m'])
+    slope_pct = globals().get('slope_pct', _defaults['slope_pct'])
+except Exception as e:
+    print(f"NewOLS_OES_TakeoffClimb: Error getting parameters, using defaults: {e}")
+    start_elevation_m = 0.0
+    direction = 0
+    runway_layer = None
+    use_runway_selected = True
+    cwy_length_m = 0.0
+    distance_from_runway_end_m = _defaults['distance_from_runway_end_m']
+    inner_edge_m = _defaults['inner_edge_m']
+    divergence_pct = _defaults['divergence_pct']
+    final_width_m = _defaults['final_width_m']
+    length_m = _defaults['length_m']
+    slope_pct = _defaults['slope_pct']
+
+# #159 — every Table 4-14/4-15 value above is UI-editable, defaulting to
+# the ICAO table when not overridden.
+dims = {
+    'distance_from_runway_end_m': distance_from_runway_end_m,
+    'inner_edge_m': inner_edge_m,
+    'divergence_pct': divergence_pct,
+    'final_width_m': final_width_m,
+    'length_m': length_m,
+    'slope_pct': slope_pct,
+}
+
+map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
+
+# ---------------------------------------------------------------------------
+# Runway layer
+# ---------------------------------------------------------------------------
+try:
+    if runway_layer is None:
+        raise Exception("No Runway Layer Centerline provided.")
+    if use_runway_selected:
+        selection = runway_layer.selectedFeatures()
+        if not selection:
+            raise Exception("No runway features selected.")
+    else:
+        selection = runway_layer.selectedFeatures() or list(runway_layer.getFeatures())
+        if not selection:
+            raise Exception("No features found in Runway Layer.")
+except Exception as e:
+    iface.messageBar().pushMessage("QOLS Error", str(e), level=MSG_CRITICAL)
+    raise
+
+for feat in selection:
+    line_pts = _normalize_polyline_points(feat.geometry())
+    break
+
+# direction picks the runway-centerline endpoint (0 = Start to End,
+# -1 = End to Start), same convention as the other New OLS OES scripts.
+# The far endpoint is the physical runway end in the direction of takeoff.
+s = direction
+near_end_pt = line_pts[s]
+far_end_pt = line_pts[-1 - s]
+rwy_end_azimuth = near_end_pt.azimuth(far_end_pt)  # away from the runway, takeoff/climb-out direction
+
+rwy_end_point = QgsPoint(far_end_pt.x(), far_end_pt.y())
+rwy_end_point.addZValue(start_elevation_m)
+
+print(f"NewOLS_OES_TakeoffClimb: rwy_end_azimuth={rwy_end_azimuth:.2f}")
+
+# ---------------------------------------------------------------------------
+# Geometry — ported from take-off-surface_UTM.py's own hexagon/slope math.
+# ---------------------------------------------------------------------------
+divergence_ratio = dims['divergence_pct'] / 100.0
+slope_ratio = dims['slope_pct'] / 100.0
+half_inner = dims['inner_edge_m'] / 2.0
+half_final = dims['final_width_m'] / 2.0
+
+# Origin offset — the CWY footnote applies identically to both tables
+# (max(0, cwy) == cwy for Table 4-15's zero distance_from_runway_end_m).
+dD = max(dims['distance_from_runway_end_m'], cwy_length_m)
+
+origin_pt = rwy_end_point.project(dD, rwy_end_azimuth)
+origin_pt.addZValue(start_elevation_m)
+origin_l = origin_pt.project(half_inner, rwy_end_azimuth + 90)
+origin_r = origin_pt.project(half_inner, rwy_end_azimuth - 90)
+
+distance_to_max_width = ((half_final - half_inner) / divergence_ratio) if divergence_ratio else 0.0
+# Defensive clamp: every field here is independently user-editable
+# (unlike the classic panel's fixed relationship), so an inconsistent
+# combination could otherwise push the cap point past the surface end.
+distance_to_max_width = min(distance_to_max_width, dims['length_m'])
+
+
+def _pz(pt, z):
+    p = QgsPoint(pt.x(), pt.y())
+    p.addZValue(z)
+    return p
+
+
+mid_pt = origin_pt.project(distance_to_max_width, rwy_end_azimuth)
+z_mid = start_elevation_m + distance_to_max_width * slope_ratio
+mid_l = _pz(mid_pt.project(half_final, rwy_end_azimuth + 90), z_mid)
+mid_r = _pz(mid_pt.project(half_final, rwy_end_azimuth - 90), z_mid)
+
+end_pt = origin_pt.project(dims['length_m'], rwy_end_azimuth)
+# Slope runs the full surface length, independent of the divergence cap.
+z_end = start_elevation_m + dims['length_m'] * slope_ratio
+end_l = _pz(end_pt.project(half_final, rwy_end_azimuth + 90), z_end)
+end_r = _pz(end_pt.project(half_final, rwy_end_azimuth - 90), z_end)
+
+origin_l = _pz(origin_l, start_elevation_m)
+origin_r = _pz(origin_r, start_elevation_m)
+
+# ---------------------------------------------------------------------------
+# Memory layer
+# ---------------------------------------------------------------------------
+layer_name = "NewOLS_OES_TakeoffClimb"
+v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", layer_name, "memory")
+v_layer_provider = v_layer.dataProvider()
+v_layer_provider.addAttributes([
+    QgsField("surface_type", QVariant.String),
+    QgsField("component", QVariant.String),
+    QgsField("slope_pct", QVariant.Double),
+    QgsField("rule_set", QVariant.String),
+])
+v_layer.updateFields()
+
+_active_rule_set = globals().get('active_rule_set', None)
+_params_json = build_parameters_json('New OLS OES Take-off Climb Surface', {
+    'start_elevation_m': round(start_elevation_m, 3),
+    'direction': direction,
+    'cwy_length_m': cwy_length_m,
+    'dimensions': dims,
+    'rule_set': _active_rule_set,
+})
+add_parameters_field(v_layer)
+
+features = []
+
+
+def _add_feature(component, slope_pct, ring_pts_with_z):
+    f = QgsFeature()
+    f.setGeometry(QgsPolygon(QgsLineString(ring_pts_with_z)))
+    f.setAttributes(["Take-off Climb Surface", component, slope_pct, _active_rule_set, _params_json])
+    features.append(f)
+
+
+_add_feature('Take-off Climb Surface', dims['slope_pct'], [
+    end_r, end_l, mid_l, origin_l, origin_r, mid_r,
+])
+
+v_layer_provider.addFeatures(features)
+v_layer.updateExtents()
+print(f"NewOLS_OES_TakeoffClimb: Created {len(features)} feature(s)")
+
+register_parameters_action(v_layer)
+
+QgsProject.instance().addMapLayers([v_layer])
+
+symbol = QgsFillSymbol.createSimple({
+    'color': '34,139,34,90',  # forest green, transparent
+    'style': 'solid',
+    'outline_color': '0,100,0,220',
+    'outline_style': 'solid',
+    'outline_width': '0.7',
+})
+v_layer.renderer().setSymbol(symbol)
+v_layer.triggerRepaint()
+
+if features:
+    v_layer.selectAll()
+    canvas = iface.mapCanvas()
+    canvas.zoomToSelected(v_layer)
+    v_layer.removeSelection()
+    sc = canvas.scale()
+    if sc < 50000:
+        sc = 50000
+    canvas.zoomScale(sc)
+
+if not use_runway_selected and runway_layer:
+    runway_layer.removeSelection()
+
+iface.messageBar().pushMessage(
+    "QOLS Success",
+    "New OLS OES Take-off Climb Surface calculated successfully",
+    level=MSG_SUCCESS,
+)
+
+_script_success = True
+
+for _g in set(globals().keys()).difference(myglobals):
+    if _g not in ('myglobals', '_script_success'):
+        del globals()[_g]

--- a/qols/surface_types.py
+++ b/qols/surface_types.py
@@ -39,6 +39,7 @@ class SurfaceType(str, Enum):
     NEW_OLS_OES_DEPARTURE = "New OLS - OES Departure"
     NEW_OLS_OES_PRECISION_APPROACH = "New OLS - OES Precision Approach"
     NEW_OLS_OES_STRAIGHT_IN_APPROACH = "New OLS - OES Straight-in Instrument Approach"
+    NEW_OLS_OES_TAKEOFF_CLIMB = "New OLS - OES Take-off Climb"
 
     @classmethod
     def from_tab_text(cls, text: str) -> "SurfaceType":

--- a/qols/surfaces/new_ols_takeoff_climb.py
+++ b/qols/surfaces/new_ols_takeoff_climb.py
@@ -1,0 +1,132 @@
+"""New OLS concept — Take-off Climb Surface ICAO defaults.
+
+Tables 4-14 (mass up to 5 700 kg — ADG I and IIA-IIB only) and 4-15
+(mass above 5 700 kg — all ADG I through V), Figure 4-8.
+
+Table 4-15's "Distance from TODA" column is "-" for every ADG — the
+surface starts right at TODA (runway end + clearway), which already
+folds the clearway in. Modeled here as ``distance_from_runway_end_m
+= 0.0`` for every Table 4-15 row, so the *same*
+``dD = max(distance_from_runway_end_m, cwy_length_m)`` formula used
+for Table 4-14 (whose own footnote says the surface starts at the end
+of the clearway if the clearway length exceeds the specified
+distance) also produces the correct TODA-relative origin for Table
+4-15 (``max(0, CWY) == CWY``) — no mass-category branching is needed
+in the geometry script itself, only in which table this module reads
+from.
+
+ADG grouping mirrors ``new_ols_approach.py``'s merged "IIA-IIB" scheme
+(Tables 4-1/4-2), not ``new_ols_horizontal.py``'s split I/IIA/IIB
+scheme (Table 4-10) — reused directly via import to avoid drift.
+"""
+from typing import Dict, List
+
+from .new_ols_approach import ADG_I, ADG_IIA_IIB, ADG_IIC, ADG_III, ADG_IV, ADG_V, ADG_GROUPS
+
+MASS_CATEGORY_LE_5700 = "Up to 5 700 kg (Table 4-14)"
+MASS_CATEGORY_GT_5700 = "Over 5 700 kg (Table 4-15)"
+MASS_CATEGORIES = [MASS_CATEGORY_LE_5700, MASS_CATEGORY_GT_5700]
+
+_TABLE_4_14: Dict[str, Dict[str, float]] = {
+    ADG_I: {
+        'distance_from_runway_end_m': 30.0,
+        'inner_edge_m': 60.0,
+        'divergence_pct': 10.0,
+        'final_width_m': 380.0,
+        'length_m': 1600.0,
+        'slope_pct': 5.0,
+    },
+    ADG_IIA_IIB: {
+        'distance_from_runway_end_m': 60.0,
+        'inner_edge_m': 80.0,
+        'divergence_pct': 10.0,
+        'final_width_m': 580.0,
+        'length_m': 2500.0,
+        'slope_pct': 4.0,
+    },
+}
+
+_TABLE_4_15: Dict[str, Dict[str, float]] = {
+    ADG_I: {
+        'distance_from_runway_end_m': 0.0,
+        'inner_edge_m': 144.0,
+        'divergence_pct': 12.5,
+        'final_width_m': 1800.0,
+        'length_m': 10000.0,
+        'slope_pct': 5.0,
+    },
+    ADG_IIA_IIB: {
+        'distance_from_runway_end_m': 0.0,
+        'inner_edge_m': 156.0,
+        'divergence_pct': 12.5,
+        'final_width_m': 1800.0,
+        'length_m': 10000.0,
+        'slope_pct': 4.0,
+    },
+    ADG_IIC: {
+        'distance_from_runway_end_m': 0.0,
+        'inner_edge_m': 156.0,
+        'divergence_pct': 12.5,
+        'final_width_m': 1800.0,
+        'length_m': 10000.0,
+        'slope_pct': 2.0,
+    },
+    ADG_III: {
+        'distance_from_runway_end_m': 0.0,
+        'inner_edge_m': 172.0,
+        'divergence_pct': 12.5,
+        'final_width_m': 1800.0,
+        'length_m': 10000.0,
+        'slope_pct': 2.0,
+    },
+    ADG_IV: {
+        'distance_from_runway_end_m': 0.0,
+        'inner_edge_m': 180.0,
+        'divergence_pct': 12.5,
+        'final_width_m': 1800.0,
+        'length_m': 10000.0,
+        'slope_pct': 2.0,
+    },
+    ADG_V: {
+        'distance_from_runway_end_m': 0.0,
+        'inner_edge_m': 180.0,
+        'divergence_pct': 12.5,
+        'final_width_m': 1800.0,
+        'length_m': 10000.0,
+        'slope_pct': 2.0,
+    },
+}
+
+
+def get_valid_adg_groups(mass_category: str) -> List[str]:
+    """Return the ADG groups applicable to the given mass category.
+
+    Table 4-14 (up to 5 700 kg) only applies to ADG I and IIA-IIB;
+    Table 4-15 (above 5 700 kg) applies to all six ADG groups.
+    """
+    if mass_category == MASS_CATEGORY_LE_5700:
+        return [ADG_I, ADG_IIA_IIB]
+    return list(ADG_GROUPS)
+
+
+def get_takeoff_climb_surface_dimensions(mass_category: str, adg: str) -> Dict[str, float]:
+    """Return Table 4-14/4-15 defaults for the given mass category and ADG.
+
+    Args:
+        mass_category: ``MASS_CATEGORY_LE_5700`` or ``MASS_CATEGORY_GT_5700``.
+        adg: Aeroplane Design Group (``"I"``, ``"IIA-IIB"``, ``"IIC"``,
+             ``"III"``, ``"IV"``, ``"V"``). Falls back to ADG I if not
+             valid for the given mass category.
+
+    Returns:
+        Dict with keys ``distance_from_runway_end_m``, ``inner_edge_m``,
+        ``divergence_pct``, ``final_width_m``, ``length_m``, ``slope_pct``.
+    """
+    table = _TABLE_4_14 if mass_category == MASS_CATEGORY_LE_5700 else _TABLE_4_15
+    return dict(table.get(adg, table[ADG_I]))
+
+
+__all__ = [
+    'MASS_CATEGORY_LE_5700', 'MASS_CATEGORY_GT_5700', 'MASS_CATEGORIES',
+    'get_valid_adg_groups', 'get_takeoff_climb_surface_dimensions',
+]

--- a/qols/ui/new_ols_dockwidget.py
+++ b/qols/ui/new_ols_dockwidget.py
@@ -7,6 +7,7 @@ Runs as an independent dock widget with its own toolbar button.
 import os
 import traceback
 from ..surfaces.new_ols_approach import get_new_ols_approach_defaults
+from ..surfaces.new_ols_takeoff_climb import get_valid_adg_groups, get_takeoff_climb_surface_dimensions
 from ..surface_types import SurfaceType
 from .. import logger
 from ..direction_marker import build_marker_geometry
@@ -90,6 +91,16 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
         'spin_upperHeight_oes_straightin':      60.0,
         'spin_upperShorterSide_oes_straightin': 7410.0,
         'spin_upperLongerSideFromThreshold_oes_straightin': 5350.0,
+        # OES Take-off Climb Surface (#161) — Table 4-14 ADG I defaults
+        # (Mass Category combo's initial state).
+        'spin_Z0_oes_takeoff':              2548.0,
+        'spin_CWYLength_oes_takeoff':           0.0,
+        'spin_distFromRwyEnd_oes_takeoff':     30.0,
+        'spin_innerEdge_oes_takeoff':          60.0,
+        'spin_divergence_oes_takeoff':         10.0,
+        'spin_finalWidth_oes_takeoff':        380.0,
+        'spin_length_oes_takeoff':           1600.0,
+        'spin_slope_oes_takeoff':               5.0,
         # ARP (Aerodrome Reference Point) — shared by both tabs, moved to
         # a single top-level field (#131).
         'spin_ARP_elevation':     2548.0,
@@ -153,10 +164,21 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
     spin_upperHeight_oes_straightin: QLineEdit
     spin_upperShorterSide_oes_straightin: QLineEdit
     spin_upperLongerSideFromThreshold_oes_straightin: QLineEdit
+    combo_massCategory_oes_takeoff: QComboBox
+    combo_adg_oes_takeoff: QComboBox
+    spin_Z0_oes_takeoff: QLineEdit
+    spin_CWYLength_oes_takeoff: QLineEdit
+    spin_distFromRwyEnd_oes_takeoff: QLineEdit
+    spin_innerEdge_oes_takeoff: QLineEdit
+    spin_divergence_oes_takeoff: QLineEdit
+    spin_finalWidth_oes_takeoff: QLineEdit
+    spin_length_oes_takeoff: QLineEdit
+    spin_slope_oes_takeoff: QLineEdit
     calculateButton_oes_horizontal: QPushButton
     calculateButton_oes_departure: QPushButton
     calculateButton_oes_precision_approach: QPushButton
     calculateButton_oes_straightin: QPushButton
+    calculateButton_oes_takeoff: QPushButton
     spin_ARP_elevation: QLineEdit
     runwaySelectionStatusLabel: QLabel
     thresholdSelectionStatusLabel: QLabel
@@ -190,19 +212,23 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             # straight from .ui XML, so both bars are constructed here
             # and inserted into the (empty) oesTabRow1Layout/
             # oesTabRow2Layout declared in new_ols_panel.ui. Native
-            # look, no custom styling. oesSubTabStack's 4 pages stay in
-            # their original order (0=Horizontal ... 3=Straight-in) —
+            # look, no custom styling. oesSubTabStack's 5 pages stay in
+            # their original order (0=Horizontal ... 4=Take-off Climb) —
             # get_parameters()'s oes_sub_index dispatch depends on that
             # exact stack order, not on which row a tab visually sits
             # in. Row 1: Horizontal, Departure. Row 2: Precision
-            # Approach, Straight-in.
+            # Approach, Straight-in, Take-off Climb (#161 — extended
+            # this row rather than adding a 3rd, minimal-diff choice;
+            # if a 6th OES surface is ever added, this mapping needs
+            # revisiting again).
             self.oesTabBarRow1 = QTabBar(self)
             self.oesTabBarRow2 = QTabBar(self)
             self.oesTabRow1Layout.addWidget(self.oesTabBarRow1)
             self.oesTabRow2Layout.addWidget(self.oesTabBarRow2)
             for text in ("Horizontal Surface", "Instrument Departure Surface"):
                 self.oesTabBarRow1.addTab(text)
-            for text in ("Surface for Precision Approaches", "Straight-in Instrument Approaches"):
+            for text in ("Surface for Precision Approaches", "Straight-in Instrument Approaches",
+                         "Take-off Climb Surface"):
                 self.oesTabBarRow2.addTab(text)
 
             # oesSubTabWidget itself is this shim, not a setupUi()
@@ -212,10 +238,11 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             # get_parameters() keeps working unchanged.
             self.oesSubTabWidget = TwoRowTabSelector(
                 bars=[self.oesTabBarRow1, self.oesTabBarRow2],
-                stack_indices_per_bar=[[0, 1], [2, 3]],
+                stack_indices_per_bar=[[0, 1], [2, 3, 4]],
                 tab_texts=[
                     "Horizontal Surface", "Instrument Departure Surface",
                     "Surface for Precision Approaches", "Straight-in Instrument Approaches",
+                    "Take-off Climb Surface",
                 ],
                 stack=self.oesSubTabStack,
                 parent=self,
@@ -246,6 +273,15 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             except Exception as e:
                 logger.warning(f"Could not apply initial New OLS defaults: {e}")
 
+            try:
+                self._connect(self.combo_massCategory_oes_takeoff.currentIndexChanged,
+                              self._refresh_adg_options_for_takeoff)
+                self._connect(self.combo_adg_oes_takeoff.currentIndexChanged,
+                              self.apply_takeoff_climb_defaults)
+                self._refresh_adg_options_for_takeoff()
+            except Exception as e:
+                logger.warning(f"Could not apply initial Take-off Climb defaults: {e}")
+
             self._connect(self.useSelectedRunwayCheckBox.toggled, self.update_selection_info)
             self._connect(self.useSelectedThresholdCheckBox.toggled, self.update_selection_info)
             self._connect(self.useSelectedArpCheckBox.toggled, self.update_selection_info)  # #131
@@ -268,6 +304,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self._connect(self.calculateButton_oes_departure.clicked, self.on_calculate_clicked)
             self._connect(self.calculateButton_oes_precision_approach.clicked, self.on_calculate_clicked)
             self._connect(self.calculateButton_oes_straightin.clicked, self.on_calculate_clicked)
+            self._connect(self.calculateButton_oes_takeoff.clicked, self.on_calculate_clicked)
             self._connect(self.cancelButton.clicked, self.on_close_clicked)
             self._connect(self.directionButton.clicked, self.toggle_direction)
 
@@ -321,6 +358,10 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             'spin_lowerHeight_oes_straightin', 'spin_lowerLength_oes_straightin',
             'spin_upperHeight_oes_straightin', 'spin_upperShorterSide_oes_straightin',
             'spin_upperLongerSideFromThreshold_oes_straightin',
+            'spin_Z0_oes_takeoff', 'spin_CWYLength_oes_takeoff',
+            'spin_distFromRwyEnd_oes_takeoff', 'spin_innerEdge_oes_takeoff',
+            'spin_divergence_oes_takeoff', 'spin_finalWidth_oes_takeoff',
+            'spin_length_oes_takeoff', 'spin_slope_oes_takeoff',
             'spin_ARP_elevation',  # #131 — shared ARP elevation field
         ]
         decimal_pattern = r'^-?\d*(?:\.\d*)?$'
@@ -587,6 +628,43 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
             self.set_numeric_value('spin_divergence_ofs', d['divergence_pct'])
             self.set_numeric_value('spin_length_ofs', d['length_m'])
             self.set_numeric_value('spin_slope_ofs', d['slope_pct'])
+        except Exception as e:
+            logger.warning(f"Unhandled error: {e}")
+
+    @pyqtSlot()
+    def apply_takeoff_climb_defaults(self):
+        """Populate OES Take-off Climb fields from ICAO Tables 4-14/4-15 (#161)."""
+        try:
+            mass_category = self.combo_massCategory_oes_takeoff.currentText()
+            adg = self.combo_adg_oes_takeoff.currentText()
+            d = get_takeoff_climb_surface_dimensions(mass_category, adg)
+            self.set_numeric_value('spin_distFromRwyEnd_oes_takeoff', d['distance_from_runway_end_m'])
+            self.set_numeric_value('spin_innerEdge_oes_takeoff', d['inner_edge_m'])
+            self.set_numeric_value('spin_divergence_oes_takeoff', d['divergence_pct'])
+            self.set_numeric_value('spin_finalWidth_oes_takeoff', d['final_width_m'])
+            self.set_numeric_value('spin_length_oes_takeoff', d['length_m'])
+            self.set_numeric_value('spin_slope_oes_takeoff', d['slope_pct'])
+        except Exception as e:
+            logger.warning(f"Unhandled error: {e}")
+
+    @pyqtSlot()
+    def _refresh_adg_options_for_takeoff(self):
+        """Narrow the ADG combo to the groups valid for the selected mass
+        category (#161) — Table 4-14 only applies to ADG I/IIA-IIB, Table
+        4-15 applies to all six. Re-populating fires the combo's own
+        currentIndexChanged, so signals are blocked while items are
+        replaced to avoid spurious intermediate default-population calls."""
+        try:
+            mass_category = self.combo_massCategory_oes_takeoff.currentText()
+            valid = get_valid_adg_groups(mass_category)
+            combo = self.combo_adg_oes_takeoff
+            previous = combo.currentText()
+            combo.blockSignals(True)
+            combo.clear()
+            combo.addItems(valid)
+            combo.setCurrentText(previous if previous in valid else valid[0])
+            combo.blockSignals(False)
+            self.apply_takeoff_climb_defaults()
         except Exception as e:
             logger.warning(f"Unhandled error: {e}")
 
@@ -896,7 +974,7 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                         'missed_s2_slope_pct': self.get_numeric_value('spin_missedS2Slope_oes_precision'),
                         'trans_slope_pct': self.get_numeric_value('spin_transSlope_oes_precision'),
                     }
-                else:
+                elif oes_sub_index == 3:
                     surface_type = SurfaceType.NEW_OLS_OES_STRAIGHT_IN_APPROACH
                     specific_params = {
                         'aerodrome_elevation_m': arp_elevation_m,
@@ -907,6 +985,19 @@ class NewOlsDockWidget(QDockWidget, FORM_CLASS):
                         'upper_shorter_side_m': self.get_numeric_value('spin_upperShorterSide_oes_straightin'),
                         'upper_longer_side_from_threshold_m':
                             self.get_numeric_value('spin_upperLongerSideFromThreshold_oes_straightin'),
+                    }
+                else:
+                    surface_type = SurfaceType.NEW_OLS_OES_TAKEOFF_CLIMB
+                    specific_params = {
+                        'start_elevation_m': self.get_numeric_value('spin_Z0_oes_takeoff'),
+                        'direction': s_value,
+                        'cwy_length_m': self.get_numeric_value('spin_CWYLength_oes_takeoff'),
+                        'distance_from_runway_end_m': self.get_numeric_value('spin_distFromRwyEnd_oes_takeoff'),
+                        'inner_edge_m': self.get_numeric_value('spin_innerEdge_oes_takeoff'),
+                        'divergence_pct': self.get_numeric_value('spin_divergence_oes_takeoff'),
+                        'final_width_m': self.get_numeric_value('spin_finalWidth_oes_takeoff'),
+                        'length_m': self.get_numeric_value('spin_length_oes_takeoff'),
+                        'slope_pct': self.get_numeric_value('spin_slope_oes_takeoff'),
                     }
 
             return {

--- a/qols/ui/new_ols_panel.ui
+++ b/qols/ui/new_ols_panel.ui
@@ -1069,6 +1069,169 @@
            </layout>
           </widget>
 
+          <!-- TAKE-OFF CLIMB SURFACE SUBTAB (#161) -->
+          <widget class="QWidget" name="oes_sub_takeoff_climb">
+           <layout class="QFormLayout" name="formLayout_oes_takeoff">
+            <property name="fieldGrowthPolicy"><enum>QFormLayout::AllNonFixedFieldsGrow</enum></property>
+            <property name="labelAlignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+            <property name="horizontalSpacing"><number>15</number></property>
+            <property name="verticalSpacing"><number>6</number></property>
+
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_massCategory_oes_takeoff">
+              <property name="text"><string>Mass Category:</string></property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="combo_massCategory_oes_takeoff">
+              <property name="minimumHeight"><number>22</number></property>
+              <property name="toolTip"><string>Selects which ICAO table this tab's defaults come from: Table 4-14 (aeroplane mass up to 5 700 kg, ADG I/IIA-IIB only) or Table 4-15 (mass above 5 700 kg, all ADG I-V).</string></property>
+              <item><property name="text"><string>Up to 5 700 kg (Table 4-14)</string></property></item>
+              <item><property name="text"><string>Over 5 700 kg (Table 4-15)</string></property></item>
+             </widget>
+            </item>
+
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_adg_oes_takeoff">
+              <property name="text"><string>ADG Group:</string></property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="combo_adg_oes_takeoff">
+              <property name="minimumHeight"><number>22</number></property>
+              <property name="toolTip"><string>Aeroplane Design Group for the Take-off Climb surface. Options narrow to I/IIA-IIB when Mass Category is Table 4-14.</string></property>
+              <item><property name="text"><string>I</string></property></item>
+              <item><property name="text"><string>IIA-IIB</string></property></item>
+              <item><property name="text"><string>IIC</string></property></item>
+              <item><property name="text"><string>III</string></property></item>
+              <item><property name="text"><string>IV</string></property></item>
+              <item><property name="text"><string>V</string></property></item>
+             </widget>
+            </item>
+
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_Z0_oes_takeoff">
+              <property name="text"><string>Runway End Elevation (m):</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="spin_Z0_oes_takeoff">
+              <property name="text"><string>2548.00</string></property>
+              <property name="toolTip"><string>Elevation of the runway end the surface originates from.</string></property>
+             </widget>
+            </item>
+
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_CWYLength_oes_takeoff">
+              <property name="text"><string>Clearway Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="spin_CWYLength_oes_takeoff">
+              <property name="text"><string>0.00</string></property>
+              <property name="toolTip"><string>Table 4-14: the surface starts at the end of the clearway if its length exceeds the table's "Distance from runway end". Table 4-15: the surface starts at TODA (runway end + clearway), so this value is used directly as the origin offset.</string></property>
+             </widget>
+            </item>
+
+            <item row="4" column="0" colspan="2">
+             <widget class="QLabel" name="label_dims_header_oes_takeoff">
+              <property name="text"><string>Table 4-14 / 4-15 Dimensions</string></property>
+              <property name="styleSheet"><string>QLabel { font-weight: bold; padding-top: 12px; padding-bottom: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_distFromRwyEnd_oes_takeoff">
+              <property name="text"><string>Dist. From Rwy End (m):</string></property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="spin_distFromRwyEnd_oes_takeoff">
+              <property name="text"><string>30.00</string></property>
+              <property name="toolTip"><string>Table 4-14: distance from the runway end. Table 4-15: 0 — the surface starts at TODA, which already includes the clearway.</string></property>
+             </widget>
+            </item>
+
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_innerEdge_oes_takeoff">
+              <property name="text"><string>Length of Inner Edge (m):</string></property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="spin_innerEdge_oes_takeoff">
+              <property name="text"><string>60.00</string></property>
+              <property name="toolTip"><string>Table 4-14/4-15: full width of the surface at its origin.</string></property>
+             </widget>
+            </item>
+
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_divergence_oes_takeoff">
+              <property name="text"><string>Divergence, Each Side (%):</string></property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QLineEdit" name="spin_divergence_oes_takeoff">
+              <property name="text"><string>10.00</string></property>
+              <property name="toolTip"><string>Table 4-14/4-15: rate the surface widens on each side until it reaches Final Width.</string></property>
+             </widget>
+            </item>
+
+            <item row="8" column="0">
+             <widget class="QLabel" name="label_finalWidth_oes_takeoff">
+              <property name="text"><string>Final Width (m):</string></property>
+             </widget>
+            </item>
+            <item row="8" column="1">
+             <widget class="QLineEdit" name="spin_finalWidth_oes_takeoff">
+              <property name="text"><string>380.00</string></property>
+              <property name="toolTip"><string>Table 4-14/4-15: width the surface reaches once divergence caps out; stays constant for the remainder of Length. Table 4-15's value may be reduced under specific conditions per ICAO Doc 9137 Part 6 (not modeled here).</string></property>
+             </widget>
+            </item>
+
+            <item row="9" column="0">
+             <widget class="QLabel" name="label_length_oes_takeoff">
+              <property name="text"><string>Length (m):</string></property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <widget class="QLineEdit" name="spin_length_oes_takeoff">
+              <property name="text"><string>1600.00</string></property>
+              <property name="toolTip"><string>Table 4-14/4-15: total length of the surface from its origin. The sloped plane climbs for this entire length, even past the point where width divergence has already capped out.</string></property>
+             </widget>
+            </item>
+
+            <item row="10" column="0">
+             <widget class="QLabel" name="label_slope_oes_takeoff">
+              <property name="text"><string>Slope (%):</string></property>
+             </widget>
+            </item>
+            <item row="10" column="1">
+             <widget class="QLineEdit" name="spin_slope_oes_takeoff">
+              <property name="text"><string>5.00</string></property>
+              <property name="toolTip"><string>Table 4-14/4-15: upward slope of the surface from the runway-end elevation.</string></property>
+             </widget>
+            </item>
+
+            <item row="11" column="0" colspan="2">
+             <widget class="QLabel" name="label_oes_takeoff_note">
+              <property name="text">
+               <string>Uses the shared Runway Layer and Direction fields above; no Threshold Layer needed (mirrors the Instrument Departure Surface). Mass Category and ADG populate the fields below from Tables 4-14/4-15; every value remains editable.</string>
+              </property>
+              <property name="wordWrap"><bool>true</bool></property>
+              <property name="styleSheet"><string>QLabel { font-size: 11px; padding: 4px; }</string></property>
+             </widget>
+            </item>
+
+            <item row="12" column="0" colspan="2">
+             <widget class="QPushButton" name="calculateButton_oes_takeoff">
+              <property name="text"><string>Calculate Take-off Climb Surface</string></property>
+              <property name="minimumHeight"><number>30</number></property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+
          </widget>
         </item>
 


### PR DESCRIPTION
# feature(#161): Take-off climb surface (New OLS - OES)

## Summary

Closes #161.

Issue #161 : add a 5th OES subtab, "Take-off Climb
Surface" (Annex 14 Figure 4-8), to the New OLS panel — alongside the
existing Horizontal / Instrument Departure / Precision Approach /
Straight-in Instrument Approach subtabs.

Two ICAO tables apply depending on aeroplane mass:

**Table 4-14** (mass ≤ 5 700 kg — ADG I and IIA-IIB only):

| | I | IIA-IIB |
|---|---|---|
| Distance from runway end | 30 m | 60 m |
| Length of inner edge | 60 m | 80 m |
| Divergence (each side) | 10% | 10% |
| Final width | 380 m | 580 m |
| Length | 1 600 m | 2 500 m |
| Slope | 5% | 4% |

Footnote: "the surface starts at the end of the clearway if the
clearway length exceeds the specified distance."

**Table 4-15** (mass > 5 700 kg — all ADG I through V):

| | I | IIA-IIB | IIC | III | IV | V |
|---|---|---|---|---|---|---|
| Distance from TODA | - | - | - | - | - | - |
| Length of inner edge | 144 | 156 | 156 | 172 | 180 | 180 |
| Divergence (each side) | 12.5% | 12.5% | 12.5% | 12.5% | 12.5% | 12.5% |
| Final width | 1 800(a) | 1 800(a) | 1 800(a) | 1 800(a) | 1 800(a) | 1 800(a) |
| Length | 10 000 | 10 000 | 10 000 | 10 000 | 10 000 | 10 000 |
| Slope | 5% | 4% | 2% | 2% | 2% | 2% |

"Distance from TODA = -" means the surface starts right at TODA
(runway end + clearway) — TODA already folds the clearway in.

**UI decisions confirmed with the reporter before implementation**:
1. One subtab with a "Mass Category" combo that filters a shared ADG
   combo (I/IIA-IIB only for ≤5700 kg, all six for >5700 kg).
2. One shared Clearway Length field for both categories.

## Root cause / design notes

Table 4-15's zero "Distance from TODA" is modeled in the pure module
as `distance_from_runway_end_m = 0.0` for every Table 4-15 row, so the
*same* formula `dD = max(distance_from_runway_end_m, cwy_length_m)`
used for Table 4-14's own footnote is also correct for Table 4-15
(`max(0, CWY) == CWY`) — no mass-category branching is needed in the
geometry script itself, only in which table the pure module reads
from.

Geometry is adapted from the classic OLS's own take-off climb script
(`qols/scripts/take-off-surface_UTM.py`), the only existing
implementation of this exact surface:
- `dD = max(startDistance, CWYLength)` — the CWY-override rule, exact
  match.
- Plan view is a single hexagon: diverge from `inner_edge_m` at the
  origin until `final_width_m` is reached (`distance_to_max_width`),
  then continue at constant `final_width_m` out to `length_m`.
- **The sloped plane climbs for the full `length_m`, independent of
  `distance_to_max_width`** — confirmed against the classic script,
  where the far-end point's Z uses `surfaceLength * slope_ratio` while
  the cap-point's Z uses only `distance_to_max_width * slope_ratio`.
  For Table 4-14 both values coincide (`distance_to_max_width ==
  length_m` exactly for both its rows — verified by recomputing:
  `(380/2-60/2)/0.10 = 1600`, `(580/2-80/2)/0.10 = 2500`), degenerating
  to a plain trapezoid; for Table 4-15 they differ (e.g. ADG I:
  `(1800/2-144/2)/0.125 = 6624 m`, well short of `length_m=10000 m`),
  producing a genuine diverge-then-constant shape with the plane still
  climbing past the width cap.
- Cross-sections are flat (not gabled) — same precedent as every other
  planar OLS surface in this codebase (Approach, Departure, classic
  Take-off). Figure 4-8's Cross Section B-B is not modeled literally.

**Independently cross-checked against `../flight/tofpa`'s own TOFPA
AOC Type A implementation** (ICAO Doc 8168 — the PANS-OPS analogue the
issue itself points to for the CWY-override provision, "similar like
the approach... as TOFPA we need to declare if CWY exist"). Reading
`tofpa.py` lines 347-374 directly confirms, vertex-for-vertex:
- `pt_02D.setZ(ze + distance_to_max_width * gradient)` vs.
  `pt_03D.setZ(ze + TOFPA_SURFACE_LENGTH * gradient)` — same
  cap-point-uses-partial-distance / end-point-uses-full-length split
  used here, from a second, independent source (not just the classic
  qOLS script).
- Ring order `[pt_03DR, pt_03DL, pt_02DL, pt_01DL, pt_01DR, pt_02DR]`
  is identical to this script's `[end_r, end_l, mid_l, origin_l,
  origin_r, mid_r]`.
- Flat cross-sections (`pt_0XDL.setZ(pt_0XD.z())` at every tier) — no
  gable, confirming Cross Section B-B isn't modeled literally there
  either.

This downgrades what was originally a single-source inference (the
classic qOLS script alone) to a design confirmed by two independent
implementations of the same surface concept. The CWY/TODA origin logic
was separately re-verified algebraically against the issue's own
wording: "if RWY length + CWY > RWY length + 30/60" simplifies (RWY
length cancels) to "if CWY > 30/60, use CWY" — exactly
`dD = max(distance_from_runway_end_m, cwy_length_m)`.

Unlike the classic panel, every Table 4-14/4-15 value here is
independently user-editable (#159 convention), so an inconsistent
combination is reachable — `distance_to_max_width` is defensively
clamped to `length_m` in the script, which the classic script doesn't
need since its own fields aren't independently overridable.

`qols/surfaces/icao.py::get_takeoff_defaults(code)` (keyed by
aerodrome reference code, docstring says "Table 5-4") is a different,
older table — confirmed by reading it, not reused for this feature.

No existing OES subtab had live combo-driven default recomputation
before this PR (Horizontal's ADG combo is read only at calculate-time).
The one existing precedent is `apply_ofs_approach_defaults()` (OFS
Approach tab) — this PR mirrors that pattern for the OES side for the
first time, introducing `apply_takeoff_climb_defaults()` and
`_refresh_adg_options_for_takeoff()` (the latter re-filters the ADG
combo via `blockSignals()` + `clear()`/`addItems()` on mass-category
change, then re-applies defaults).

`TwoRowTabSelector` (`qols/ui/tab_row_selector.py`, #123/#164) is
construction-time only — no `addTab()`/`count()` — so the 5th tab
required editing the existing construction call rather than mutating
the built instance. Minimal-diff choice: Row 1 stays `[Horizontal,
Departure]`, Row 2 extends to `[Precision Approach, Straight-in,
Take-off Climb]` (`stack_indices_per_bar=[[0,1],[2,3,4]]`).

Forest green (`34,139,34` fill / `0,100,0` outline) styling — the only
unused color among the existing OES subtabs (teal/crimson/amber/
blueviolet).

## Changes

### `qols/surfaces/new_ols_takeoff_climb.py` (new)
Table 4-14/4-15 pure module: `MASS_CATEGORY_LE_5700`/
`MASS_CATEGORY_GT_5700` constants, `get_valid_adg_groups(mass_category)`,
`get_takeoff_climb_surface_dimensions(mass_category, adg)` (flat dict,
not nested — one continuous inclined plane with a single divergence/
slope rate, unlike Departure's genuine two-section table). Reuses
`new_ols_approach.py`'s `ADG_I`/`ADG_IIA_IIB`/.../`ADG_GROUPS`
constants (its 6-way merged grouping matches these tables, not
Horizontal's split I/IIA/IIB scheme). Falls back to ADG I if `adg` is
invalid for the mass category, mirroring `icao.py`'s own fallback.

### `qols/scripts/new-ols-oes-takeoff-climb-UTM.py` (new)
Geometry script: runway-only DER-point origin resolution (mirrors
Departure's, no threshold layer needed). Hexagon+full-length-slope
math per the design notes above, `distance_to_max_width` clamped to
`length_m`. Single feature, `component='Take-off Climb Surface'`,
layer `NewOLS_OES_TakeoffClimb`, forest-green styling. No contour-layer
support (matches every OES subtab except OFS Approach).

### `qols/surface_types.py`
Added `NEW_OLS_OES_TAKEOFF_CLIMB = "New OLS - OES Take-off Climb"`.

### `qols/ui/new_ols_panel.ui`
Added 5th subtab page `oes_sub_takeoff_climb` inside `oesSubTabStack`:
Mass Category combo, ADG combo, Runway End Elevation / Clearway Length
fields, a bold "Table 4-14 / 4-15 Dimensions" header, the 6 table
value fields (each with a tooltip citing the table), a note label, and
`calculateButton_oes_takeoff`. Styled identically to the Straight-in
page's `QFormLayout` conventions.

### `qols/ui/new_ols_dockwidget.py`
- `_WIDGET_DEFAULTS` entries for the 8 new fields (Table 4-14 ADG I
  values).
- Type-hint block entries for the 2 combos, 6 fields, and calculate
  button.
- `apply_takeoff_climb_defaults()` (populates the 6 value fields from
  the pure module) and `_refresh_adg_options_for_takeoff()` (narrows
  the ADG combo per mass category, then re-applies defaults) — new
  methods, wired to both combos' `currentIndexChanged` in `__init__`,
  with an initial call after `setupUi()`.
- Tab-bar construction block: Row 2 extended to
  `("Surface for Precision Approaches", "Straight-in Instrument
  Approaches", "Take-off Climb Surface")`,
  `stack_indices_per_bar=[[0,1],[2,3,4]]`.
- Added the 6 numeric fields to `setup_numeric_lineedit_validation()`.
- Wired `calculateButton_oes_takeoff.clicked` to the shared
  `on_calculate_clicked` slot.
- `get_parameters()`'s OES dispatch: Straight-in moved from the
  trailing `else` to an explicit `elif oes_sub_index == 3`, and a new
  `else` branch (index 4) builds
  `SurfaceType.NEW_OLS_OES_TAKEOFF_CLIMB`'s isolated `specific_params`.

### `qols/plugin.py`
Added `execute_new_ols_oes_takeoff_climb(params)` (mirrors
`execute_new_ols_oes_departure`) resolving
`new-ols-oes-takeoff-climb-UTM.py`, and the matching `SurfaceType`
branch in `on_calculate_new_ols()`.

### `tests/test_dockwidget_logic.py`
- New `TestGetTakeoffClimbSurfaceDimensions` (8 tests) — per-table
  per-ADG value assertions, `get_valid_adg_groups` for both
  categories, ADG-I fallback for an out-of-range ADG, mutation-safety.
- Extended `_ComboBox` fake widget with `clear()`/`addItems()`/
  `count()`/`blockSignals()` to support testing
  `_refresh_adg_options_for_takeoff()`'s dynamic item narrowing.
- New `TestApplyTakeoffClimbDefaultsPopulatesFields` (4 tests) — field
  population for a Table-4-14 and a Table-4-15 case, ADG-combo
  narrowing to 2 vs 6 items.
- Extended `_oes_params_subject()` with the 8 new fake widgets.
- Extended `TestGetParametersOesSubtabDispatch` with
  `test_takeoff_climb_subtab_builds_isolated_params` (`oes_sub_index=4`,
  asserts `surface_type` and the exact `specific_params` key set) and
  `test_takeoff_climb_direction_end_to_start_is_passed_through`.

### `tests/test_tab_row_selector.py`
`_OES_TAB_TEXTS`/`_OES_ROWS` extended to 5 tabs /
`[[0,1],[2,3,4]]`; `TestOesSubtabRowSplit`'s parametrize list extended
with the 5th stack index, plus a new `test_row2_tab2_selects_takeoff_climb`.

## Verification

```bash
pytest -q -p no:pytest-qt
# 649 passed (633 baseline + 16 new tests)

xmllint --noout qols/ui/new_ols_panel.ui
# valid

flake8 --max-line-length=119 \
  qols/surfaces/new_ols_takeoff_climb.py \
  qols/surface_types.py qols/plugin.py
# 0 findings, fully clean

flake8 --max-line-length=119 qols/scripts/new-ols-oes-takeoff-climb-UTM.py
# 33 findings — all F403/F405 (star imports) + E402, the same accepted
# category every qols/scripts/*.py file carries (matches Departure's
# own 33 exactly)

flake8 --max-line-length=119 qols/ui/new_ols_dockwidget.py tests/test_dockwidget_logic.py
# 28 findings — confirmed identical count/type against main before
# this branch's changes (pre-existing F821/E731/E221/E402, unrelated
# to #161)

flake8 --max-line-length=119 tests/test_tab_row_selector.py
# 0 findings, fully clean
```

Every `QFormLayout` in `new_ols_panel.ui` was programmatically checked
for row gaps and duplicate `(row, column)` pairs after the new page
was added — none found across all layouts.

Manual QGIS check (pending, no QGIS runtime available here): Mass
Category combo narrows ADG options and repopulates all 6 fields;
Table 4-14 case (e.g. ADG I) renders a plain trapezoid; Table 4-15
case (e.g. ADG I) renders the diverge-then-constant-width hexagon with
the plane still climbing past the width cap; Clearway Length overrides
the origin correctly for both categories; the 5th tab shows correctly
in Row 2 of the two-row selector. The hexagon/full-length-slope/
flat-cross-section geometry itself is now cross-verified against two
independent implementations (classic qOLS script + `flight/tofpa`'s
Doc 8168 TOFPA AOC Type A) rather than resting on a single inference —
this manual check is about visual/UX confirmation, not the underlying
geometric interpretation anymore.

## Risk / notes

- Branch `feature/161-takeoff-climb-oes`, created fresh off `main`
  (both #137 and #164 are already merged).
- Geometric interpretation (hexagon cap-then-constant-width,
  full-length slope independent of the cap, flat non-gabled
  cross-section) is cross-verified against two independent sources
  (the classic qOLS take-off script and `flight/tofpa`'s own TOFPA AOC
  Type A implementation of Doc 8168) — not from a live QGIS render, so
  the manual check above is still worth doing, but the geometric
  approach itself is no longer a single-source inference.
- The defensive `min(distance_to_max_width, length_m)` clamp is new
  robustness beyond the classic script's own (unclamped) behavior,
  needed because every Table 4-14/4-15 field is independently
  user-editable here (#159 convention) where the classic panel's
  aren't.
- Combo-driven live default repopulation is the first time this
  pattern appears on the OES side of the New OLS panel — mirrors
  `apply_ofs_approach_defaults` exactly, so no new idiom, but worth a
  second look in review since every other OES subtab is
  static-default-only.
- Row split becomes 2+3 (`[[0,1],[2,3,4]]`) — a deliberate minimal-diff
  choice for this PR; if a 6th OES surface is ever added, this mapping
  needs revisiting again.
- No shared-utility changes — `TwoRowTabSelector`, `difference_flat()`/
  `flatten_ring_z()`, and every other OES script are unaffected.

## Follow-up: direction marker anchor stability

While testing the new Take-off Climb subtab, the reporter noticed the
live direction-preview triangle jumps to the *opposite* runway
threshold when the Direction button is toggled, instead of staying at
the same point and just flipping which way it points — the behavior
`../flight/tofpa` (the reference plugin cited elsewhere in this
session) uses.

**Root cause**: `qols/direction_marker.py::build_marker_geometry`
always resolved the marker's tip via
`_closest_feature(threshold_sel, near_end_pt)` — whichever threshold
feature is geometrically nearest the runway centerline endpoint for
the *current* direction. Since `near_end_pt` flips between the line's
two endpoints when direction toggles, the "nearest" threshold flips
too, even with only one threshold selected/available.

This exact bug was already found and fixed once — but only in the
real calculation, not in the shared preview module. Issue #132 ("OFS
(New OLS model) doesn't respect selected only", `doc/PR_132.md`) fixed
`qols/scripts/new-ols-ofs-approach-UTM.py` with a `len(threshold_sel)
== 1` shortcut: with exactly one candidate, use it directly instead of
re-deriving it by distance. `doc/PR_132.md` never mentions
`direction_marker.py` — the preview marker (shared by every New OLS
tab: OFS Approach and all 5 OES subtabs) never got the equivalent fix,
so it kept showing the pre-#132 jumping behavior everywhere, not just
on the new Take-off Climb tab.

No separate GitHub issue exists for this (informally reported by the
maintainer while testing #161) — folded into this branch/PR rather
than opened as its own issue, per the maintainer's own call.

### Changes

**`qols/direction_marker.py`** — added `resolve_anchor_feature(candidates,
near_end_pt, closest_fn=_closest_feature)`, mirroring #132's exact
`len == 1` shortcut, extracted as a small pure-ish helper next to the
existing `resolve_direction_azimuth`/`triangle_marker_vertices`
functions so it's directly unit-testable without a QGIS mock.
`build_marker_geometry` now calls this instead of `_closest_feature`
unconditionally. Module docstring updated to cross-reference #132.

**`tests/test_direction_marker.py`** — new `TestResolveAnchorFeature`
(4 tests) using lightweight fake feature objects (`_FakeFeature`/
`_FakeGeometry`/`_FakePoint`, exposing only `.geometry().asPoint().x()/
.y()`, mirroring the fake-widget pattern in
`tests/test_dockwidget_logic.py`): single candidate returned regardless
of distance to `near_end_pt` and regardless of direction toggling
(the exact regression this fix targets); multiple candidates still
fall back to nearest-to-point and still follow direction toggles
(unchanged, still-correct multi-threshold behavior).

No changes to `new_ols_dockwidget.py`/`dockwidget.py` — both already
call `build_marker_geometry` correctly; the fix is entirely inside the
shared module both dockwidgets already depend on.

### Verification

```bash
pytest -q -p no:pytest-qt
# 653 passed (649 + 4 new TestResolveAnchorFeature tests)

flake8 --max-line-length=119 qols/direction_marker.py tests/test_direction_marker.py
# 0 findings, fully clean
```

