### PR TITLE
Enhance KML export error handling and update version to 0.2.1 in meta…

### DIFF
--- a/qols/kml_export/exporter.py
+++ b/qols/kml_export/exporter.py
@@ -36,6 +36,7 @@ from .. import logger
 from ..compat import (
     DISTANCE_UNIT_DEGREES,
     FILE_ACTION_CREATE_OR_OVERWRITE,
+    MSG_CRITICAL,
     MSG_SUCCESS,
     MSG_WARNING,
     SYMBOLOGY_NO_SYMBOLOGY,
@@ -308,10 +309,14 @@ def export_layer(iface, layer, options: KmlExportOptions) -> Optional[Tuple[str,
     features = list(export_source.getFeatures())
     metadata = build_feature_metadata(export_source.fields(), features, target_name_field, color_info, mode)
 
-    kml_ns = postprocess_kml_tree(
-        tree, metadata, group_by_label=options.group_by_label, theme=options.theme)
-    ET.register_namespace('', kml_ns)
-    tree.write(kml_path, encoding="utf-8", xml_declaration=True)
+    try:
+        kml_ns = postprocess_kml_tree(
+            tree, metadata, group_by_label=options.group_by_label, theme=options.theme)
+        ET.register_namespace('', kml_ns)
+        tree.write(kml_path, encoding="utf-8", xml_declaration=True)
+    except Exception as e:
+        logger.error(f"KML post-processing failed for '{layer.name()}': {e}")
+        return None
 
     return layer.name(), kml_path
 
@@ -344,16 +349,31 @@ def run_kml_export(iface) -> None:
     os.makedirs(options.output_dir, exist_ok=True)
 
     exported = []
+    failed = []
     for layer in layers:
-        result = export_layer(iface, layer, options)
+        try:
+            result = export_layer(iface, layer, options)
+        except Exception as e:
+            logger.error(f"Unexpected error exporting '{layer.name()}': {e}")
+            result = None
         if result is not None:
             exported.append(result)
+        else:
+            failed.append(layer.name())
 
     if exported:
         links = [
             f'<a href="{QUrl.fromLocalFile(os.path.dirname(path)).toString()}">{name}</a>'
             for name, path in exported
         ]
+        message = "Exported layers: " + ", ".join(links)
+        if failed:
+            message += " — failed: " + ", ".join(failed) + " (see Log Messages panel for details)"
         iface.messageBar().pushMessage(
-            "Export Complete", "Exported layers: " + ", ".join(links),
-            level=MSG_SUCCESS, duration=10)
+            "Export Complete" if not failed else "Export Partially Complete", message,
+            level=MSG_SUCCESS if not failed else MSG_WARNING, duration=10)
+    else:
+        iface.messageBar().pushMessage(
+            "QOLS",
+            "KML export failed for: " + ", ".join(failed) + " (see View → Panels → Log Messages for details)",
+            level=MSG_CRITICAL, duration=10)

--- a/qols/metadata.txt
+++ b/qols/metadata.txt
@@ -3,7 +3,7 @@ name=qOLS
 qgisMinimumVersion=3.0
 qgisMaximumVersion=4.99
 description=Obstacle Limitation Surfaces plugin for QGIS
-version=0.2.0
+version=0.2.1
 author=FLYGHT7
 email=info@flyght7.com
 
@@ -22,6 +22,11 @@ experimental=True
 deprecated=False
 
 changelog=
+     Version 0.2.1:
+	 - fixed remaining Qt6 enum compatibility issues (compat.py extended, all raw enum access removed from qols_dockwidget.py, both dockwidgets, KML export, and New OLS scripts)
+	 - resolved Bandit security findings (self-generated KML XML parsing justified, silent except/pass blocks now log, bare except narrowed)
+	 - suppressed known Flake8 star-import findings in New OLS scripts with documented justification, fixed 2 real missing-import bugs in default-population code
+	 - fixed KML export failing with no success/failure message and no output file (#153 follow-up)
      Version 0.2.0:
 	 - bug squashing effort including selected features not working properly - gets stuck
 	 - optimization of script for qt6

--- a/qols/plugin.py
+++ b/qols/plugin.py
@@ -303,6 +303,8 @@ class QOLS:
             run_kml_export(self.iface)
         except Exception as e:
             logger.error(f"Error exporting to KML: {e}\n{traceback.format_exc()}")
+            self.iface.messageBar().pushMessage(
+                "QOLS", f"KML export failed: {e}", level=MSG_CRITICAL, duration=8)
 
     def on_calculate(self):
         """Execute the selected surface calculation script with parameters."""


### PR DESCRIPTION
# fix(#153): KML export failing silently

## Summary

Follow-up to #153 (closed by #167 

> Not working, there is no message saying if correct or wrong or showing
> the output. There is no output in the selected folder.

No repro steps or QGIS Log Messages panel contents were provided, and this
environment has no QGIS runtime to reproduce against — but reading the
export flow end-to-end (`qols/plugin.py:on_export_kml` →
`qols/kml_export/exporter.py:run_kml_export`/`export_layer` →
`qols/kml_export/xml_mutate.py:postprocess_kml_tree`) turned up several
confirmed silent-failure gaps that produce exactly this symptom regardless
of what the underlying per-environment failure actually is:

1. `on_export_kml()`'s top-level `except Exception:` only called
   `logger.error(...)` — which writes to `QgsMessageLog` (the Log Messages
   panel, collapsed/hidden by default). Any exception anywhere in the whole
   call chain — dialog construction, `dlg.exec()`, `collect_selected_layers`,
   `postprocess_kml_tree`, etc. — was completely invisible to the user.
2. `run_kml_export()`'s final block only had an `if exported:` branch
   pushing a success message. There was no `else` — if every layer's
   `export_layer()` call returned `None` (write failure, XML parse
   failure, or "Skip Layer" chosen for every conflict), the function
   returned with zero feedback: no popup, no output file, nothing.
3. The per-layer loop had no `try/except` around `export_layer(...)`, and
   `export_layer()` itself had none around its call into
   `postprocess_kml_tree`. One bad layer — or any KML post-processing
   error — silently aborted the *entire* batch, including layers that had
   already succeeded, and fell straight into gap #1's log-only handler.

Net effect: there was no code path that ever reached the user when
anything went wrong, at any stage. This PR closes that gap comprehensively
rather than guessing at one specific cause.

## Changes

### `qols/kml_export/exporter.py`

- `export_layer()`: wrapped the `postprocess_kml_tree(...)`/`tree.write(...)`
  call in `try/except`, returning `None` (same failure contract as every
  other branch in this function) instead of letting the exception escape.
- `run_kml_export()`: each `export_layer(...)` call in the loop is now
  wrapped in `try/except` — an unexpected exception is logged and treated
  as a failed layer (added to a new `failed` list) instead of aborting the
  whole batch.
- Replaced the `if exported:`-only block with one that always pushes a
  `messageBar` message:
  - all succeeded → unchanged success message.
  - some succeeded, some failed → `MSG_WARNING`, naming both groups.
  - all failed → `MSG_CRITICAL`, naming every failed layer and pointing at
    View → Panels → Log Messages for detail.
- Added `MSG_CRITICAL` to the existing `from ..compat import (...)` block
  (already used elsewhere in the file's error paths, just not imported
  here yet).

### `qols/plugin.py`

- `on_export_kml()`'s `except Exception as e:` now also pushes a
  `messageBar` critical message (`MSG_CRITICAL`, already imported in this
  file) alongside the existing `logger.error(...)` call, covering failures
  that happen before/outside the per-layer loop entirely.

No changes to `dialog.py` or the KML-building logic in `xml_mutate.py` —
this is purely about making existing failure paths visible, not about the
KML content itself.

### New tests: `tests/test_kml_export_exporter.py`

`exporter.py` had no direct unit tests before this (only `colors.py`/
`html_table.py`/`xml_mutate.py` were covered by PR #167). Added 4, using
`unittest.mock.MagicMock` for `iface`/layers:

- All layers fail → asserts a critical `messageBar` message naming the
  failed layer.
- Mixed success/failure → asserts a warning message naming both.
- One layer's `export_layer` raising → asserts the rest of the batch still
  completes and gets reported.
- `export_layer()` with `postprocess_kml_tree` raising → asserts `None` is
  returned, not an uncaught exception.

## Verification

```
pytest                                                          # 695 passed (691 + 4 new)
flake8 qols/kml_export/exporter.py qols/plugin.py tests/test_kml_export_exporter.py  # 0
flake8 qols --count                                             # 0
bandit -r qols/kml_export/ qols/plugin.py                       # 0
```
